### PR TITLE
feat(Announcer): support functions as speech producers

### DIFF
--- a/components/Announcer/Announcer.mdx
+++ b/components/Announcer/Announcer.mdx
@@ -44,14 +44,23 @@ Set `announcerEnabled` to true in your app and optionally `debug` to true to see
 
 The `Announcer` will travel through the `_focusPath` looking for `component.announce` then `component.title` then `component.label` properties. After collecting those properties it reverses the `_focusPath` looking for `component.announceContext` properties.
 
-All of the properties may return a string or recursively nestable array containing strings. Promises for strings and arrays may be used as well for async data.
+
+### SpeechType
+All of the properties may return values compatible with the following recursive type definition:
+```
+SpeechType = string | Array<SpeechType> | Promise<SpeechType> | () => SpeechType
+```
+At its simplest, you may return a string or an array of strings. Promises and functions that return SpeechType values may be used as necessary for advanced/asyncronous use cases.
+
+#### Examples
 ```js
   get announce() {
     return [
       'Despicable Me',
       Promise.resolve([
         ['2020', 'Rated PG'],
-        Promise.resolve('Steve Carell, Miranda Cosgrove, Kristen Wiig, Pierre Coffin')
+        Promise.resolve('Steve Carell, Miranda Cosgrove, Kristen Wiig, Pierre Coffin'),
+        () => 'A description of the movie'
       ])
     ];
   }
@@ -60,6 +69,8 @@ All of the properties may return a string or recursively nestable array containi
     return 'Press LEFT or RIGHT to review items';
   }
 ```
+
+## Inserting a pause
 
 You may also use `PAUSE-#` to pause speech for # seconds before saying the next string.
 ```js
@@ -83,7 +94,7 @@ announcerTimeout|number|false|By default the announcer only gets information abo
 name|args|description
 --|--|--|--
 $announce||Performs a manual announce
-&nbsp;|`announcement`|String or recursively nestable array containing strings. Promises for strings and arrays may be used as well for async data.
+&nbsp;|`announcement`|See *SpeechType* above
 &nbsp;|`options`|Object containing one or more boolean flags: <br/><ul><li>append - Appends announcement to the currently announcing series.</li></ul>
 $announcerRefresh|depth|Performs an announce using the focusPath - depth can trim known focusPath
 $announcerCancel|none|Cancels current speaking

--- a/components/Announcer/Speech.js
+++ b/components/Announcer/Speech.js
@@ -59,7 +59,9 @@ function speak(phrase, utterances) {
 
 function speakSeries(series, root = true) {
   const synth = window.speechSynthesis;
-  const remainingPhrases = flattenStrings(series);
+  const remainingPhrases = flattenStrings(
+    Array.isArray(series) ? series : [series]
+  );
   const nestedSeriesResults = [];
   /*
     We hold this array of SpeechSynthesisUtterances in order to prevent them from being
@@ -114,6 +116,10 @@ function speakSeries(series, root = true) {
               }
             }
           }
+        } else if (typeof phrase === 'function') {
+          const seriesResult = speakSeries(phrase(), false);
+          nestedSeriesResults.push(seriesResult);
+          await seriesResult.series;
         } else if (Array.isArray(phrase)) {
           // Speak it (recursively)
           const seriesResult = speakSeries(phrase, false);
@@ -150,7 +156,6 @@ function speakSeries(series, root = true) {
 
 let currentSeries;
 export default function(toSpeak) {
-  toSpeak = Array.isArray(toSpeak) ? toSpeak : [toSpeak];
   currentSeries && currentSeries.cancel();
   currentSeries = speakSeries(toSpeak);
   return currentSeries;

--- a/components/Announcer/Speech.test.js
+++ b/components/Announcer/Speech.test.js
@@ -74,6 +74,25 @@ describe('Speech', () => {
     });
   });
 
+  it('should handle a function that returns a string', () => {
+    return Speech([() => 'Hello There']).series.then(() => {
+      expect(utter).toHaveBeenCalledWith('Hello There');
+    });
+  });
+
+  it('should handle a function that returns an array', () => {
+    return Speech([() => ['Well', () => 'Hello There']]).series.then(() => {
+      expect(utter).toHaveBeenNthCalledWith(1, 'Well');
+      expect(utter).toHaveBeenNthCalledWith(2, 'Hello There');
+    });
+  });
+
+  it('should handle a function that returns a promise', () => {
+    return Speech([() => Promise.resolve('Hello There')]).series.then(() => {
+      expect(utter).toHaveBeenCalledWith('Hello There');
+    });
+  });
+
   it('should handle promise of string', () => {
     return Speech([Promise.resolve('Hello There')]).series.then(() => {
       expect(utter).toHaveBeenCalledWith('Hello There');
@@ -94,6 +113,12 @@ describe('Speech', () => {
         expect(utter).toHaveBeenCalledWith('Hello, There');
       }
     );
+  });
+
+  it('should handle promise of a function', () => {
+    return Speech([Promise.resolve(() => 'Hello There')]).series.then(() => {
+      expect(utter).toHaveBeenCalledWith('Hello There');
+    });
   });
 
   it('should ignore invalid values', async () => {


### PR DESCRIPTION
This allows functions that return speech to be passed to the Announcer, which are called when they are ready to be spoken. This allows for some advance use cases such as loading loops, and inserting a placeholder for speech that is true to the moment that it is spoken (vs pre-computed speech, or needing to rely on promises which can't change once resolved).

Also cleaned up the documentation a bit to be clearer about the speech types that are supported.