### PR TITLE
fix: update import paths in withSelections and withTransitions

### DIFF
--- a/mixins/withSelections/withSelections.test.js
+++ b/mixins/withSelections/withSelections.test.js
@@ -1,6 +1,6 @@
 import lng from '@lightningjs/core';
-import TestUtils from '../test/lightning-test-utils';
-import withSelections from './withSelections';
+import TestUtils from '../../test/lightning-test-utils';
+import withSelections from '.';
 
 const duplicate = (object, quantity) => Array.apply(null, { length: quantity }).map(() => Object.assign({}, object));
 

--- a/mixins/withTransitions/withTransitions.test.js
+++ b/mixins/withTransitions/withTransitions.test.js
@@ -18,7 +18,7 @@
 
 import lng from '@lightningjs/core';
 import TestRenderer from '../../test/lightning-test-renderer';
-import { withTransitions } from '.';
+import withTransitions from '.';
 
 describe('withTransitions', () => {
   class Example extends lng.Component {};


### PR DESCRIPTION
This PR fixes a pair of broken test suites due to incorrect import paths 