### PR TITLE
chore: update exports

### DIFF
--- a/elements/index.js
+++ b/elements/index.js
@@ -2,5 +2,5 @@ export { default as Announcer } from './Announcer';
 export { default as Base } from './Base';
 export { default as Button } from './Button';
 export { default as Icon } from './Icon';
-export { default as Keyboard } from './Keyboard';
+export { default as Keyboard, KEYBOARD_FORMATS } from './Keyboard';
 export { default as MarqueeText } from './MarqueeText';

--- a/index.js
+++ b/index.js
@@ -15,13 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-export * from './components/Styles/index.js';
-export { default as Announcer } from './components/Announcer/index.js';
-export { default as Button } from './components/Button/index.js';
-export { default as Column } from './components/Column/index.js';
-export { default as FocusManager } from './components/FocusManager/index.js';
-export { default as Icon } from './components/Icon/index.js';
-export { default as MarqueeText } from './components/MarqueeText/index.js';
-export { default as Row } from './components/Row/index.js';
-export { default as Base } from './components/Base';
-export { default as withHandleKey } from './mixins/withHandleKey';
+export * from './elements';
+export * from './layouts';
+export * from './mixins';
+export * from './Styles';

--- a/mixins/index.js
+++ b/mixins/index.js
@@ -16,8 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export { default as withHandleKey } from './withHandleKey';
 export { default as withSelections } from '/withSelections';
 export { default as withStyles } from './withStyles';
+export { default as withTags } from './withTags';
 export { default as withTheme } from './withTheme';
 export { default as withTransitions } from './withTransitions';
 export { default as withUpdates } from './withUpdates';


### PR DESCRIPTION
This PR adds the following exports:
- `KEYBOARD_FORMATS` 
- `withHandleKey`
- `withTags`

It also simplifies the root export by exporting everything from the relevant component directories(elements, layout, mixins, styles)