### PR TITLE
fix: update publish Action

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,41 +13,31 @@ on:
       - next
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{secrets.GIT_PUBLISH_TOKEN}}
       - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14.17
       - run: npm ci
+      - run: npm run test
 
   publish-npm:
-    needs: build
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{secrets.GIT_PUBLISH_TOKEN}}
       - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14.17
           registry-url: https://registry.npmjs.org/
       - run: npm ci
-      - run: NPM_TOKEN=${{secrets.NPM_TOKEN}} GH_TOKEN=${{secrets.GIT_PUBLISH_TOKEN}} npx semantic-release --no-ci --repository-url git@github.com:rdkcentral/Lightning-UI-Components.git
+      - run: npx semantic-release --no-ci --repository-url git@github.com:rdkcentral/Lightning-UI-Components.git
         env:
-          GITHUB_TOKEN: ${{secrets.GIT_PUBLISH_TOKEN}}
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-
-  publish-gpr:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 12
-          registry-url: https://npm.pkg.github.com/
-      - run: npm ci
-      - run: NPM_TOKEN=${{secrets.NPM_TOKEN}} GH_TOKEN=${{secrets.GIT_PUBLISH_TOKEN}} npx semantic-release --no-ci --repository-url git@github.com:rdkcentral/Lightning-UI-Components.git
-        env:
-          GITHUB_TOKEN: ${{secrets.GIT_PUBLISH_TOKEN}}
+          GH_TOKEN: ${{secrets.GIT_PUBLISH_TOKEN}}
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
This PR updates the publish Action config to properly work with semantic-release and automatically version and publish to NPM

Changes:
* elevate checkout permissions
* bump node version
* remove duplicate job