### PR TITLE
feat(Radio): add Radio element, tests, and docs

### DIFF
--- a/elements/Radio/Radio.mdx
+++ b/elements/Radio/Radio.mdx
@@ -1,3 +1,21 @@
+<!--
+  Copyright 2020 Comcast Cable Communications Management, LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 import { Canvas, Story } from '@storybook/addon-docs/blocks';
 import Radio from '.';
 

--- a/elements/Radio/Radio.mdx
+++ b/elements/Radio/Radio.mdx
@@ -1,0 +1,46 @@
+import { Canvas, Story } from '@storybook/addon-docs/blocks';
+import Radio from '.';
+
+# Radio
+
+A radio has 2 states: "on" or "off". When used in a group, it should let a user select only one of the choices at a time. This can be managed with the withSelections mixin
+
+## Usage
+
+Simple component that just needs a type.
+
+```js
+import { Radio } from '@lightning/ui';
+
+class Example extends lng.Component {
+  static _template() {
+    return {
+      Radio: {
+        type: Radio
+      }
+    };
+  }
+};
+```
+
+<Canvas>
+  <Story id="elements-radio--basic" />
+</Canvas>
+
+## API
+
+### Properties
+
+name|type|readonly|description
+--|--|--|--
+checked|boolean|true|toggle state
+
+### Methods
+
+#### toggle(): void
+
+Toggles `checked` state and updates UI accordingly
+
+### Styles
+
+Styled components can be adjusted by composing using [withStyles](?path=/docs/mixins-withstyles--basic). Below is the default `styles` object

--- a/elements/Radio/Radio.stories.js
+++ b/elements/Radio/Radio.stories.js
@@ -1,0 +1,38 @@
+import lng from '@lightningjs/core';
+import Radio from '.';
+import mdx from './Radio.mdx';
+
+export default {
+  title: 'Elements / Radio',
+  parameters: {
+    docs: {
+      page: mdx
+    }
+  }
+};
+
+export const Basic = () =>
+  class Basic extends lng.Component {
+    static _template() {
+      return {
+        Radio: {
+          type: Radio
+        }
+      };
+    }
+
+    _getFocused() {
+      return this.tag('Radio');
+    }
+  };
+Basic.args = { checked: false };
+Basic.argTypes = {
+  checked: { control: 'boolean' }
+};
+Basic.parameters = {
+  argActions: {
+    checked: (_, component) => {
+      component.tag('Radio').toggle();
+    }
+  }
+};

--- a/elements/Radio/Radio.stories.js
+++ b/elements/Radio/Radio.stories.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2021 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import lng from '@lightningjs/core';
 import Radio from '.';
 import mdx from './Radio.mdx';

--- a/elements/Radio/Radio.test.js
+++ b/elements/Radio/Radio.test.js
@@ -1,0 +1,30 @@
+import TestUtils from '../../test/lightning-test-utils';
+import Radio from '.';
+
+const createRadio = TestUtils.makeCreateComponent(Radio);
+
+describe('Radio', () => {
+  let radio, testRenderer;
+
+  beforeEach(() => {
+    [radio, testRenderer] = createRadio();
+  });
+  afterEach(() => {
+    radio = null;
+    testRenderer = null;
+  });
+
+  it('renders', () => {
+    const tree = testRenderer.toJSON(2);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('toggles checked state on enter', () => {
+    [radio, testRenderer] = createRadio({ checked: false });
+    expect(radio.checked).toEqual(false);
+    testRenderer.keyPress('Enter');
+    expect(radio.checked).toEqual(true);
+    testRenderer.keyPress('Enter');
+    expect(radio.checked).toEqual(false);
+  });
+});

--- a/elements/Radio/Radio.test.js
+++ b/elements/Radio/Radio.test.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2021 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import TestUtils from '../../test/lightning-test-utils';
 import Radio from '.';
 

--- a/elements/Radio/__snapshots__/Radio.test.js.snap
+++ b/elements/Radio/__snapshots__/Radio.test.js.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Radio renders 1`] = `
+Object {
+  "Component": Object {
+    "Knob": Object {
+      "active": false,
+      "alpha": 0,
+      "attached": true,
+      "boundsMargin": null,
+      "clipping": false,
+      "color": 4294967295,
+      "enabled": false,
+      "flex": false,
+      "flexItem": false,
+      "h": 16,
+      "isComponent": undefined,
+      "mount": 0.5,
+      "mountX": 0.5,
+      "mountY": 0.5,
+      "pivot": 0.5,
+      "pivotX": 0.5,
+      "pivotY": 0.5,
+      "ref": "Knob",
+      "renderOfScreen": undefined,
+      "renderToTexture": false,
+      "scale": 1,
+      "scaleX": 1,
+      "scaleY": 1,
+      "state": undefined,
+      "tag": [Function],
+      "tags": Array [
+        "Knob",
+      ],
+      "texture": Object {
+        "type": "StaticCanvasTexture",
+      },
+      "visible": true,
+      "w": 16,
+      "x": [Function],
+      "y": [Function],
+      "zIndex": 0,
+    },
+  },
+}
+`;

--- a/elements/Radio/index.js
+++ b/elements/Radio/index.js
@@ -1,0 +1,66 @@
+import lng from '@lightningjs/core';
+import Base from '../Base';
+import { withStyles } from '../../mixins';
+
+const styles = {
+  w: 32,
+  h: 32,
+  radius: 16,
+  background: { color: 0xff1f1f1f },
+  stroke: { color: 0xffffffff, width: 4 },
+  knob: { color: 0xffffffff, h: 16, w: 16 }
+};
+
+export default class Radio extends withStyles(Base, styles) {
+  static _template() {
+    return {
+      w: this.styles.w,
+      h: this.styles.h,
+      texture: lng.Tools.getRoundRect(
+        this.styles.w,
+        this.styles.h,
+        this.styles.radius,
+        this.styles.stroke.width,
+        this.styles.stroke.color,
+        true,
+        this.styles.background.color
+      ),
+      Knob: {
+        w: this.styles.knob.w,
+        h: this.styles.knob.h,
+        mount: 0.5,
+        x: w => w / 2,
+        y: h => h / 2,
+        alpha: 0,
+        texture: lng.Tools.getRoundRect(
+          this.styles.knob.w,
+          this.styles.knob.h,
+          this.styles.knob.w / 2,
+          false,
+          false,
+          true,
+          this.styles.knob.color
+        )
+      }
+    };
+  }
+
+  static get tags() {
+    return ['Knob'];
+  }
+
+  _handleEnter() {
+    this.toggle();
+  }
+
+  _update() {
+    const { checked } = this;
+    this._Knob.smooth = { alpha: checked ? 1 : 0 };
+  }
+
+  toggle() {
+    this.checked = !this.checked;
+    this._update();
+    return this;
+  }
+}

--- a/elements/Radio/index.js
+++ b/elements/Radio/index.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2021 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import lng from '@lightningjs/core';
 import Base from '../Base';
 import { withStyles } from '../../mixins';

--- a/elements/index.js
+++ b/elements/index.js
@@ -3,3 +3,4 @@ export { default as Button } from './Button';
 export { default as Icon } from './Icon';
 export { default as Keyboard, KEYBOARD_FORMATS } from './Keyboard';
 export { default as MarqueeText } from './MarqueeText';
+export { default as Radio } from './Radio';

--- a/elements/index.js
+++ b/elements/index.js
@@ -1,3 +1,22 @@
+/**
+ * Copyright 2021 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an
+ BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export { default as Base } from './Base';
 export { default as Button } from './Button';
 export { default as Icon } from './Icon';


### PR DESCRIPTION
This PR adds the Radio input as well as the related docs, stories, and tests. 

### Testing

- `git checkout feat/add-radio`
- `npm run test`
- `npm start`
- navigate to `elements > Radio`
- toggle the `checked` Control, the radio should toggle between a `checked` and `unchecked` state

 ### Checklist

- [x] code
- [x] tests
- [x] stories
- [x] docs
