### PR TITLE
fix(exports): correct layout export path

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 export * from './elements';
-export * from './layouts';
+export * from './layout';
 export * from './mixins';
 export * from './Styles';


### PR DESCRIPTION
Updates export path for `layout` dir to not be plural.