### PR TITLE
chore: fix publish-sb step

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -56,7 +56,7 @@ jobs:
       - run: npm run build
       - run: |
           git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/rdkcentral/Lightning-UI-Components.git
-          npm run deploy -- -u "github-actions-bot <support+actions@github.com>"
+          npm run gh-pages -- -u "github-actions-bot <support+actions@github.com>"
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -54,6 +54,9 @@ jobs:
           node-version: 14.17
       - run: npm i
       - run: npm run build
-      - run: npm run gh-pages
+      - run: |
+          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/rdkcentral/Lightning-UI-Components.git
+          npm run deploy -- -u "github-actions-bot <support+actions@github.com>"
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,25 +25,25 @@ jobs:
       - run: npm ci
       - run: npm run test
 
-  # publish-npm:
-  #   needs: test
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       with:
-  #         token: ${{secrets.GIT_PUBLISH_TOKEN}}
-  #     - uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 14.17
-  #         registry-url: https://registry.npmjs.org/
-  #     - run: npm ci
-  #     - run: npx semantic-release --no-ci --repository-url git@github.com:rdkcentral/Lightning-UI-Components.git
-  #       env:
-  #         GH_TOKEN: ${{secrets.GIT_PUBLISH_TOKEN}}
-  #         NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+  publish-npm:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{secrets.GIT_PUBLISH_TOKEN}}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.17
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npx semantic-release --no-ci --repository-url git@github.com:rdkcentral/Lightning-UI-Components.git
+        env:
+          GH_TOKEN: ${{secrets.GIT_PUBLISH_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
   publish-sb:
-    needs: test
+    needs: publish-npm
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,30 +25,30 @@ jobs:
       - run: npm ci
       - run: npm run test
 
-  publish-npm:
+  # publish-npm:
+  #   needs: test
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         token: ${{secrets.GIT_PUBLISH_TOKEN}}
+  #     - uses: actions/setup-node@v2
+  #       with:
+  #         node-version: 14.17
+  #         registry-url: https://registry.npmjs.org/
+  #     - run: npm ci
+  #     - run: npx semantic-release --no-ci --repository-url git@github.com:rdkcentral/Lightning-UI-Components.git
+  #       env:
+  #         GH_TOKEN: ${{secrets.GIT_PUBLISH_TOKEN}}
+  #         NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+  publish-sb:
     needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
-          token: ${{secrets.GIT_PUBLISH_TOKEN}}
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14.17
-          registry-url: https://registry.npmjs.org/
-      - run: npm ci
-      - run: npx semantic-release --no-ci --repository-url git@github.com:rdkcentral/Lightning-UI-Components.git
-        env:
-          GH_TOKEN: ${{secrets.GIT_PUBLISH_TOKEN}}
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-
-  publish-sb:
-    needs: publish-npm
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          token: ${{secrets.GIT_PUBLISH_TOKEN}}
+          token: ${{secrets.GITHUB_TOKEN}}
       - uses: actions/setup-node@v2
         with:
           node-version: 14.17
@@ -56,4 +56,4 @@ jobs:
       - run: npm run build
       - run: npm run gh-pages
         env:
-          GH_TOKEN: ${{secrets.GIT_PUBLISH_TOKEN}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -55,8 +55,6 @@ jobs:
       - run: npm i
       - run: npm run build
       - run: |
-          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/rdkcentral/Lightning-UI-Components.git
+          git remote set-url origin https://git:${{secrets.GITHUB_TOKEN}}@github.com/rdkcentral/Lightning-UI-Components.git
           npm run gh-pages -- -u "github-actions-bot <support+actions@github.com>"
-        env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 


### PR DESCRIPTION
This PR updates the `publish-sb` step in the publish Action so that we're properly(and successfully!) building and deploying the latest storybook build after a successful release