### PR TITLE
chore: prevent storybook deployments on prerelease builds

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -1,4 +1,4 @@
-# This workflow will run tests using node and then publish a package to both NPM and GitHub Packages when a release is created
+# This workflow will run tests using node and then publish a prerelease package to the appropriate channel based on the branch name
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
 # Copyright (c) 2019 GitHub
 # Licensed under the MIT license
@@ -8,7 +8,8 @@ name: Node.js Package
 on:
   push:
     branches:
-      - release
+      - beta
+      - next
 
 jobs:
   test:
@@ -39,20 +40,3 @@ jobs:
         env:
           GH_TOKEN: ${{secrets.GIT_PUBLISH_TOKEN}}
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-
-  publish-sb:
-    needs: publish-npm
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          token: ${{secrets.GITHUB_TOKEN}}
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14.17
-      - run: npm i
-      - run: npm run build
-      - run: |
-          git remote set-url origin https://git:${{secrets.GITHUB_TOKEN}}@github.com/rdkcentral/Lightning-UI-Components.git
-          npm run gh-pages -- -u "github-actions-bot <support+actions@github.com>"
-


### PR DESCRIPTION
This PR splits prerelease publish job out to its own script which doesnt include storybook deploy step so that we only publish new storybook builds on a stable release