### PR TITLE
fix(Row): lazy scrolling was scrolling too much on left press

### DIFF
--- a/layout/Row/index.js
+++ b/layout/Row/index.js
@@ -180,7 +180,7 @@ export default class Row extends FocusManager {
     let itemsContainerX;
     const prevIndex = this.Items.childList.getIndex(prev);
     if (prevIndex === this._lastFocusableIndex()) {
-      itemsContainerX = -this.Items.children[0].x;
+      itemsContainerX = -this.Items.children[prevIndex - 1].x;
     } else if (prevIndex > this.selectedIndex) {
       itemsContainerX = -this.selected.x;
     } else if (prevIndex < this.selectedIndex) {


### PR DESCRIPTION
Updates the lazy scrolling behavior for Row so that if you hit left after being scrolled from large, full row width items, the row scrolls back to the correct index.