### PR TITLE
chore: release scripts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
     node: true,
     jest: true
   },
+  ignorePatterns: ["dist"],
   plugins: ['jest', 'prettier'],
   extends: ['eslint:recommended', 'plugin:prettier/recommended', 'prettier'],
   rules: {

--- a/package.json
+++ b/package.json
@@ -10,16 +10,22 @@
   "scripts": {
     "start": "yarn workspace lightning-ui-docs start",
     "prepare": "husky install",
-    "release": "git fetch origin && git checkout develop && git pull origin develop && git pull origin release && git push origin develop && git checkout release && git pull origin release && git pull origin develop && git push origin release",
     "lint": "yarn workspaces foreach run lint",
     "lint:fix": "yarn workspaces foreach run lint:fix",
     "test": "yarn workspaces foreach -v run test",
     "test:updateSnapshot": "yarn workspaces foreach -v run test:updateSnapshot",
-    "build-packages": "yarn workspaces foreach --exclude lightning-ui-docs run build",
     "clean:dist": "yarn workspaces foreach exec rm -rf ./dist ./storybook-static ./tmp",
     "clean": "yarn clean:dist && yarn exec rm -rf node_modules && find ./packages -name 'node_modules' -type d -prune -exec rm -rf '{}' +",
     "postinstall": "node ./scripts/post-install.js",
-    "createComponent": "node bin/create.js"
+    "createComponent": "node bin/create.js",
+    "release": "git fetch origin && git checkout develop && git pull origin develop && git pull origin release && yarn release:quality && yarn release:build && yarn release:semantic-release && yarn release:build-storybook && yarn release:publish-storybook && git push origin develop && git checkout release && git pull origin release && git pull origin develop && git push origin release",
+    "release:dry-run": "yarn release:quality && yarn release:build && yarn release:semantic-release-dry-run && yarn release:build-storybook",
+    "release:quality": "yarn lint && yarn test",
+    "release:build": "yarn workspaces foreach --exclude lightning-ui-docs run build",
+    "release:semantic-release": "yarn workspaces foreach run semantic-release --no-ci -e semantic-release-monorepo",
+    "release:semantic-release-dry-run": "yarn workspaces foreach run semantic-release --no-ci --dry-run -e semantic-release-monorepo",
+    "release:build-storybook": "yarn workspace lightning-ui-docs build",
+    "release:publish-storybook:": "yarn gh-pages -d ./packages/apps/lightning-ui-docs/storybook-static"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",


### PR DESCRIPTION
Adds convenient release scripts to be ran locally

`release`

1. Pull latest develop and release branches
2. Checkout develop
3. Run eslint and tests
4. Run build on all workspaces that require it
5. Run semantic release
6. Build docs
7. Publish docs
8. Push changes to develop and release

`release:dry-run`

1. Run eslint and tests
2. Run build on all workspaces that require it
3. Run semantic release in dry run mode
4. Build docs

`release:quality`

1. Run eslint
2. Run unit tests

`release:build`

 Build the build command in all packages except lightning-ui-docs

`release:semantic-release`

Run semantic release monorepo and all plugins

`release:semantic-release-dry-run`

Run semantic release monorepo and all plugins - Dry run mode (no publishing)

`release:build-storybook`

Build storybook documentation

`release:publish-storybook`

Publish storybook directory to GitHub pages


