### PR TITLE
docs: update componentConfig info and fix formatting issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ Three packages are currently maintained and released from this project.
 - @lightningjs/ui-test-utils
 - @lightningjs/ui-base-theme
 
+## Local Development
+
+To run the repository locally, run:
+
+```
+yarn install
+yarn start
+```
+
+This will launch Storybook at [http://localhost:8000/](http://localhost:8000/).
+
 ## Peer dependencies
 
 `@lightningjs/ui-components` has a peer dependency on `@lightningjs/core^2.x`. If you are stuck using the _old Lightning_, i.e. `wpe-lightning^1.x`, you will need to alias `@lightningjs/core` in your build process. If you are bundling your app using [Webpack](https://webpack.js.org/), you should add this to your config:

--- a/packages/@lightningjs/ui-components/docs/Theming.stories.mdx
+++ b/packages/@lightningjs/ui-components/docs/Theming.stories.mdx
@@ -37,7 +37,7 @@ Each of the components references specific style properties that map back to a g
 
 3. Products can bring their own design systems. In the first two examples, there is an expectation of shared styles. But there’s no reason that Xfinity, Sky, and Peacock products can’t share the same core Tile component and replace their entire theme with their unique design systems.
 
-4. Another feature of theming, which you will see during the demo, is something we call Sub-Theming. This is a way for editorial teams to highlight specific sets of data within an application without ever changing the core look and feel of a product.
+4. Another feature of theming, which you will see during the demo, is something we call "subtheming." This is a way for editorial teams to highlight specific sets of data within an application without ever changing the core look and feel of a product.
 
 5. Additionally, themes can supply information to devices to change the style based on the capabilities of the hardware. For example, a device with less available memory can have certain features turned off, like fancy animations and effects.
 
@@ -182,7 +182,7 @@ MyComponent: {
 }
 ```
 
-**NOTE:** In order to change a specific component's style properties, you must use the `style` setter. This will trigger the update lifecycle for the component. Trying to diretly set the nested style property (eg. `MyComponent.style.progressColor = 0xf000000`) will **NOT** work unless you directly call the component's `_update()` method after. Nested style property updates may be part of a future enhancement.
+**NOTE:** In order to change a specific component's style properties, you must use the `style` setter. This will trigger the update lifecycle for the component. Trying to directly set the nested style property (eg. `MyComponent.style.progressColor = 0xf000000`) will **NOT** work unless you directly call the component's `_update()` method after. Nested style property updates may be part of a future enhancement.
 
  **As a WARNING, it is strongly discouraged to make changes to an instance of a component**. Doing so comes with risks given that this is an anti-pattern and no other components will be changed.
 

--- a/packages/@lightningjs/ui-components/docs/Theming.stories.mdx
+++ b/packages/@lightningjs/ui-components/docs/Theming.stories.mdx
@@ -25,20 +25,35 @@ import { Canvas, Story } from '@storybook/addon-docs';
 
 # Theming
 
-## What is theming?
-Theming allows for adjustments in color, type, animation, and other foundational patterns to improve the overall user experience.
+Theming is a way to easily reskin or style components via a set of style properties. It allows for easy adjustments in color, type, animation, and other foundational patterns to improve the overall user experience via one central style file.
+
+Each of the components references specific style properties that map back to a global style sheet, which we call a "theme." This is a similar concept as CSS for web components.
+
+## Capabilities of Theming
+
+1. It allows for reskinning of components and entire applications for product-specific needs. For example, within the Comcast umbrella of products, there are Core brand principles we share, like our signature purple, but there are differences across our products, like an animating Focus Ring on Flex versus a static highlight state on X1.
+
+2. Additionally, this re-skinning allows for more flexibility for syndication partners. Brands that utilize the same core production code can easily swap in their font styles and brand colors.
+
+3. Products can bring their own design systems. In the first two examples, there is an expectation of shared styles. But there’s no reason that Xfinity, Sky, and Peacock products can’t share the same core Tile component and replace their entire theme with their unique design systems.
+
+4. Another feature of theming, which you will see during the demo, is something we call Sub-Theming. This is a way for editorial teams to highlight specific sets of data within an application without ever changing the core look and feel of a product.
+
+5. Additionally, themes can supply information to devices to change the style based on the capabilities of the hardware. For example, a device with less available memory can have certain features turned off, like fancy animations and effects.
+
+6. Theming also allows us to more easily make changes to our products that fit the accessibility needs of every customer. For example, adjusting the type-scale and dynamically adjusting content around it, or providing preset color palette themes for those with color blindness.
+
+7. And lastly, theming can even allow for user initiated personalization, by giving our users the ability to choose their preferred color scheme or font styles.
 
 ## Context
 `Context` allows you to set and update your theme from anywhere in the application. `Context` holds settings and logic that can be used across all Lightning-UI components.
 
-### Context set up
+### Setting the Global Context
 
 To start applying themes to your components you need to import both `context` and the theme you want to use in your file, if different from the Base theme. If you do not import a theme, you will default to the open-source Base theme.
 
 ``` js
-
 import { context } from @lightningjs/ui;
-
 ```
 You can configure `context` in a single call by using the function `context.config()`. `Context` is used as the global store for all Lightning-UI components and contains multiple settings. Utilizing this method allows all configurations to easily be set at one time.
 
@@ -67,13 +82,12 @@ export default {
   spacer,
   stroke,
   typography,
-  componentStyle: {},
-  componentTone: {}
+  componentConfig
 };
 
 ```
 
-### Utilizing context
+### Utilizing Context
 
 The primary `context` methods to utilize when modifying your theme are `setTheme` and `updateTheme`. These methods will allow you to set up a global theme.
 
@@ -87,13 +101,13 @@ Then, the function `context.setTheme(customTheme)` takes in the imported theme o
 If you tried to change the bar color or the progress color in the `ProgressBar` component, the method `context.setTheme(customTheme)` will overwrite those changes with values from the 'customTheme' theme.
 Setting the theme completely wipes out the modifications on components made by the previously defined theme.
 
-#### Updating the theme
+#### Updating the Theme
 The `updateTheme` method merges the component styles you have updated with the currently selected theme. For example:
 
 ```js
 context.updateTheme(
   color: {
-    fillNeutralFocus: ['#c15a5a', 1],
+    fillNeutral: ['#c15a5a', 1],
     surface: ['#680f0f', 1]
   }
 );
@@ -105,7 +119,7 @@ The above line of code could create a `ProgressBar` that looks like this:
 Here `progressColor` and `barColor` are merged in with your selected theme, in this case, 'customTheme.' This means that some of the theme properties are consistent with your custom values and some of the properties are updated with the 'customTheme' theme.
 If you updated `barColor` and `progressColor` with the method `context.updateTheme()` but did not update the radius, this would yield a theme where the colors are what you defined, but the radius is that of the 'customTheme' theme.
 
-### Utilizing context logger
+### Context Logger
 
 Logger provides a way for internal errors and warnings to be gracefully handled in Lightning-UI, gives the ability to show/hide logs in the console, and offers a way to expose logs to a callback so that the application can send them to a third party front end logging endpoint. It is included under `context` so that you can access it anywhere in the application.
 Logger functions can be used as such:
@@ -123,29 +137,28 @@ context.error('Broken!');
 context.info('Emergency');
 ```
 
-## Theming at a global versus component level
+## Theming at a Global versus Component Level
 
 If you choose to apply a theme at a **global level**, the theme values you have selected will be mapped to a broader set of components.
-For example, `fillNeutralFocus` is used by `ProgressBar` and `FocusRing`. If you wanted to change the colors of both of these components you can update the `fillNeutralFocus` value. The two components' color would now be updated to the new `fillNeutralFocus` value. This would be considered a **global level** change.
-
+For example, `fillNeutral` is used by `ProgressBar` and `Checkbox`. If you wanted to change the colors of both of these components you can update the `fillNeutral` value. The two components' color would now be updated to the new `fillNeutral` value. This would be considered a **global level** change.
 
 ``` js
 context.updateTheme({
-  color: { fillNeutralFocus: [value, 1] }
+  color: { fillNeutral: [value, 1] }
 });
 
 ```
-Alternatively, you can apply theme changes at a **component level**. In this case, every instance of a particular component type will use the new values, but the changes will not affect other types of components referencing the same theme values.
-To make custom changes on a component level, use `componentStyle`.
+Alternatively, you can apply theme changes at a **component level** via the `componentConfig`. In this case, every instance of a particular component type will use the new values, but the changes will not affect other types of components referencing the same theme values.
 
-Again, `fillNeutralFocus` is used by both `ProgressBar` and `FocusRing`. If you wanted to just change the color of just `ProgressBar`, you would use `componentStyle` to impact only the value of `progressColor`:
+The `fillNeutral` is used by both `ProgressBar` and `Checkbox`. If you wanted to only change the color of `ProgressBar`, you would use `componentConfig` to impact only the value of `progressColor`:
 
 ``` js
 context.updateTheme({
-  componentStyle: {
+  componentConfig: {
     ProgressBar: {
-      progressColor: getHexColor(#32CD32)
-      //can also be written as progressColor: ['#32CD32', 1]
+      style: {
+        progressColor: getHexColor(#32CD32) // can also be written as progressColor: ['#32CD32', 1]
+      }
     }
   }
 });
@@ -155,14 +168,25 @@ context.updateTheme({
 Additionally, while not recommended (see below), to make changes on one singular instance of a component you would have to change the theme values under each component's style file. For example, you could change a component's `ProgressBar` color by coding:
 
 ```js
-
-MyComponent.style.progressColor = 0xf000000
-
+MyComponent.style = { progressColor: 0xf000000 }
 ```
+
+or
+
+```js
+MyComponent: {
+  type: ProgressBar,
+  style: {
+    progressColor: 0xf000000
+  }
+}
+```
+
+**NOTE:** In order to change a specific component's style properties, you must use the `style` setter. This will trigger the update lifecycle for the component. Trying to diretly set the nested style property (eg. `MyComponent.style.progressColor = 0xf000000`) will **NOT** work unless you directly call the component's `_update()` method after. Nested style property updates may be part of a future enhancement.
 
  **As a WARNING, it is strongly discouraged to make changes to an instance of a component**. Doing so comes with risks given that this is an anti-pattern and no other components will be changed.
 
- **We highly RECOMMEND** that if you want to make a global change to an existing theme, it is best to make a custom theme based off of one of the existing themes and then update relevant theme values. This is a great place to use componentStyle overrides and [extensions](../?path=/story/docs-theming-extensions--page).
+ **We highly RECOMMEND** that if you want to make a global change to an existing theme, it is best to make a custom theme based off of one of the existing themes and then update relevant theme values. This is a great place to use componentConfig overrides and [extensions](../?path=/story/docs-theming-extensions--page).
 
 Continuing with the `ProgressBar` example, let's summarize all the different ways you can change the `ProgressBar` color (`progressColor`) and how it will impact other components:
 

--- a/packages/@lightningjs/ui-components/docs/ThemingAttributes.stories.mdx
+++ b/packages/@lightningjs/ui-components/docs/ThemingAttributes.stories.mdx
@@ -23,9 +23,9 @@ import typographyTable from '../../../apps/lightning-ui-docs/scripts/themeProper
 
 <Meta title="Docs / Theming/ Theme Properties" />
 
-# Theming Properties
+# Theming Properties in Our Components
 
-<br /> 
+<br />
 
 ## Radius
 
@@ -44,10 +44,7 @@ Theme typography is set up to use semantically-named tokens. They are JavaScript
 When loading fonts from a theme you can specify an array containing paths to the font you would like to target. These values can be a url of a font from a CDN (Content Delivery Network), a locally hosted font, or a system font.
 When an array of font urls is provided, each url will be tested in order until one successfully loads. If none are able to be loaded, the Lightning default font will be used (Times New Roman).
 
-
 Below is an example of setting custom font families in a custom theme file.
-
-
 
 ```js
 export default {
@@ -59,20 +56,19 @@ export default {
         'https://myfontwebsite.com/myfont.woff2',
         './fonts/myfont.woff2',
       ]
-    }  
+    }
   ]
 };
 ```
 
-In this example, we provided an array of urls for the MyCustomFont font family. 
-Now any components that use MyCustomFont will try to request and display the first font url link. 
+In this example, we provided an array of urls for the MyCustomFont font family.
+Now any components that use MyCustomFont will try to request and display the first font url link.
 If that url doesn’t work then with the font fallback feature, it’s going to look into the second value in the array and request that url. If that also doesn’t work then it will move on again into the next font url provided in the array. It will continuously try to request and return a working url until it reaches the end of the array.
 If no working url is returned then Times New Roman is displayed as the font.
 
 #### Use Case: Smart TVs
 
 A product may wish to use custom brand fonts for their TV's UI. It is common to reference a CDN for assets like fonts in case the product updates its branding. However, while smart TVs are designed to be used with an internet connection, it is not a requirement for use. Just because a user doesn't connect their TV to the internet does not mean they should not still get the branded product experience in offline mode. This is where font fallbacks can be leveraged. The first font to try could be from the CDN in case any changes were made. Then if the user is offline, we can fall back to the font stored locally on the hardware.
-
 
 <br />
 

--- a/packages/@lightningjs/ui-components/docs/ThemingComponentConfig.stories.mdx
+++ b/packages/@lightningjs/ui-components/docs/ThemingComponentConfig.stories.mdx
@@ -1,0 +1,101 @@
+<!--
+  Copyright 2023 Comcast Cable Communications Management, LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+
+import { Meta, Description } from '@storybook/addon-docs';
+
+<Meta title="Docs / Theming / Component Config" />
+
+# Component Config
+
+The `componentConfig` object can take in key value pairs of component names to new objects. These objects contain theme values that can override both the standard component properties and the predetermined style properties of the given component type.
+
+## Style
+
+The `style` object can be used to override the predetermined style properties of the given component type.
+
+For example:
+```js
+componentConfig: {
+  ProgressBar: {
+    style: { radius: 20 }
+  }
+}
+```
+
+## Tones
+
+For a deeper dive on `tones`, see ["Tones"](../?path=/story/docs-theming-tones--page).
+
+The `tone` property expects a string which will determine the default color palette to apply to a component. It should match one of the following:
+- neutral (meant for use on dark backgrounds)
+- inverse (meant for use on light backgrounds)
+- brand (meant to call branded focus to an element)
+
+When specified, these strings will override the default tone used by the component in our library to quickly change the appearance of the component.
+
+For example:
+```js
+componentConfig: {
+  ProgressBar: {
+    tone: 'brand'
+  }
+}
+```
+
+## Modes
+
+For a deeper dive on `modes`, see ["Modes"](../?path=/story/docs-theming-modes--page).
+
+The `mode` property expects a string which will determine the default interaction state to apply to a component. By default, components are in the unfocused mode, but depending on the platform, can be switched into modes like:
+
+- unfocused (default)
+- focused (the active component being interacted with)
+- disabled (when a user should not be able to interact with a component)
+- selected (used to denote context on screen, like the currently selected tab when the content below is focused)
+- hover (potentially similar to focused, but can be styled differently)
+- pressed (can change the style when a Button is clicked down versus hovered on)
+
+For example:
+```js
+componentConfig: {
+  ProgressBar: {
+    mode: 'disabled'
+  }
+}
+```
+
+## Style Config
+
+The `styleConfig` object contains overrides for a component's `tone` and `mode` styles that will be applied when a component is switched into those tone or mode states.
+
+For example:
+```js
+componentConfig: {
+  ProgressBar: {
+    styleConfig: {
+      mode: {
+        disabled: { alpha: 0.25 }
+      },
+      tone: {
+        brand: { progressColor: '#00ff00' }
+      }
+    }
+  }
+}
+```

--- a/packages/@lightningjs/ui-components/docs/ThemingComponentConfig.stories.mdx
+++ b/packages/@lightningjs/ui-components/docs/ThemingComponentConfig.stories.mdx
@@ -42,7 +42,7 @@ componentConfig: {
 
 For a deeper dive on `tones`, see ["Tones"](../?path=/story/docs-theming-tones--page).
 
-The `tone` property expects a string which will determine the default color palette to apply to a component. It should match one of the following:
+The `tone` property expects a string which will determine the default color palette to apply to a component. Unless you have created a custom tone, this string should match one of the following:
 - neutral (meant for use on dark backgrounds)
 - inverse (meant for use on light backgrounds)
 - brand (meant to call branded focus to an element)

--- a/packages/@lightningjs/ui-components/docs/ThemingExtensions.stories.mdx
+++ b/packages/@lightningjs/ui-components/docs/ThemingExtensions.stories.mdx
@@ -30,25 +30,17 @@ import ExtensionProgressBar from '../src/assets/images/ExtensionProgressBar.png'
 
 # Extensions
 
-## What are Extensions?
+The component library cannot account for every design imaginable. That's where extensions come in. Extensions are exported functions that return a class. They allow users to add functionality to components without having to make the components from scratch themselves.
 
-The component library cannot account for every design imaginable. That's where extensions come in.
-Extensions are exported functions that return a class.
-They allow users to add functionality to components without having to make the components from scratch themselves.
-
-For example, let's say a `Tile` element needs to have a certain feature.
-An extension containing that feature can be created and added to the `Tile` element without the developer having to make an entirely new component.
+For example, let's say a `Tile` element needs to have a certain feature. An extension containing that feature can be created and added to the `Tile` element without the developer having to make an entirely new component.
 
 Overall, extensions make LUI as flexible with [theming](../?path=/story/docs-theming-overview--page) as possible.
 
 ### `withExtensions` Mixin
 
-Extensions follow a similar structure as mixins. Mixins return classes with added functionality without needing to create a new, standalone class that inherits from another.
-They make it so that functions that are often used can be quickly applied across components just by nesting the component in a mixin.
-In this way, mixins also simplify the amount of code in the component(s).
+Extensions follow a similar structure as mixins. Mixins return classes with added functionality without needing to create a new, standalone class that inherits from another. They make it so that functions that are often used can be quickly applied across components just by nesting the component in a mixin. In this way, mixins also simplify the amount of code in the component(s).
 
-The `withExtensions` mixin, specifically, contains functions that allow for the use of extensions in every component.
-In order to take advantage of the ability to use extensions, components must have the `withExtensions` mixin applied to it.
+The `withExtensions` mixin, specifically, contains functions that allow for the use of extensions in every component. In order to take advantage of the ability to use extensions, components must have the `withExtensions` mixin applied to it.
 
 > **Note:** All LUI components already have the `withExtensions` mixin applied.
 
@@ -89,11 +81,9 @@ This example code extension will add a text box displaying 'Extension Applied!' 
 
 ### 2. Determine which theme(s) and component(s) to apply the extension to
 
-Now that we have the extension defined, we can apply the extension to components in our desired theme(s).
-We'll have to generate an array of objects containing the component(s) we want to add the extension to as well as the extension itself.
+Now that we have the extension defined, we can apply the extension to components in our desired theme(s). We'll have to generate an array of objects containing the component(s) we want to add the extension to as well as the extension itself.
 
-Let's say we have a theme called 'customTheme' and we want to apply our newly created extension, `textAdditionExtension`, to the `ProgressBar` component.
-Our theme file where we define all our theme properties might look something like:
+Let's say we have a theme called 'customTheme' and we want to apply our newly created extension, `textAdditionExtension`, to the `ProgressBar` component. Our theme file where we define all our theme properties might look something like:
 
 ##### ./customTheme/index.js
 ```js
@@ -136,8 +126,7 @@ After doing all three steps, for our example, we should see a `ProgressBar` with
 
 ## Use Cases Outside of UI Enhancements
 
-There are many use cases for extensions since it's all about adding functionality to different components.
-This provides a fully customizable experience.
+There are many use cases for extensions since it's all about adding functionality to different components. This provides a fully customizable experience.
 
 Below are some specific examples that extensions can be used for:
 
@@ -145,19 +134,13 @@ Below are some specific examples that extensions can be used for:
 
 Extensions can be used to toggle metrics collection.
 
-For example, let's say we want to collect how often users focus on certain movie `Tiles` to understand the general genre of interest among the audience.
-We can write all the functionality of detecting how many times the `Tile` elements are being put into focus state and apply that to the `Tile` components.
-As easy as we can apply the extension, we can just as easily remove the extension when we're done with metrics collection.
+For example, let's say we want to collect how often users focus on certain movie `Tiles` to understand the general genre of interest among the audience. We can write all the functionality of detecting how many times the `Tile` elements are being put into focus state and apply that to the `Tile` components. As easy as we can apply the extension, we can just as easily remove the extension when we're done with metrics collection.
 
 ### A/B Testing
 
-Another potential use of extensions is for A/B testing. If you're unfamiliar with A/B testing, it is also known as 'split testing.'
-It's a randomized experiment that explores how users view two or more variations of a component at the same time (often a control - the original and the variation).
+Another potential use of extensions is for A/B testing. If you're unfamiliar with A/B testing, it is also known as "split testing." It's a randomized experiment that explores how users view two or more variations of a component at the same time (often a control - the original and the variation).
 
-For our case, extensions can help us do A/B testing on, say, a new feature of `Tile` or a potential new look to `Tile`.
-For example, let's say we want to gauge if making the `Tile` components more vibrant in color would increase engagement.
-We can patch an update to the `Tile`'s colors in our extension.
-During testing, we can then apply the extension at theme level to random users and test to see if there are more interactions with the vibrant colored `Tile` components.
+For our case, extensions can help us do A/B testing on, say, a new feature of `Tile` or a potential new look to `Tile`. For example, let's say we want to gauge if making the `Tile` components more vibrant in color would increase engagement. We can patch an update to the `Tile`'s colors in our extension. During testing, we can then apply the extension at theme level to random users and test to see if there are more interactions with the vibrant colored `Tile` components.
 
 If we find through A/B testing, the results are not in favor of the vibrant colored `Tile` components, we can easily discard our extension and move forward since we didn't have to touch the core code.
 
@@ -165,12 +148,9 @@ If we find through A/B testing, the results are not in favor of the vibrant colo
 
 ### `super._update()`
 
-If we consider extensions as the child of the existing component it builds off, the `super` keyword allows us to access the properties and methods in the existing/parent component.
-`_update` is an extremely important lifecycle event since it ensures everything is up to date.
-Together, `super._update()` grants us access to the entire `_update` lifecycle event of the parent component.
+If we consider extensions as the child of the existing component it builds off, the `super` keyword allows us to access the properties and methods in the existing/parent component. The `_update` method is an extremely important lifecycle event since it ensures everything is up to date. Together, `super._update()` grants us access to the entire `_update` lifecycle event of the parent component.
 
-For that reason, most often, we would want to include `super._update()` within our extension's `_update` lifecycle event.
-This way we ensure our extension functions are applying to the most up to date component.
+For that reason, most often, we would want to include `super._update()` within our extension's `_update` lifecycle event. This way we ensure our extension functions are applying to the most up to date component.
 
 On the other hand, if we want to update the existing functions within the `_update` lifecycle event in the parent component, then that's when we wouldn't call `super._update()`.
 

--- a/packages/@lightningjs/ui-components/docs/ThemingMode.stories.mdx
+++ b/packages/@lightningjs/ui-components/docs/ThemingMode.stories.mdx
@@ -19,11 +19,11 @@
 
 import { Meta, Description } from '@storybook/addon-docs';
 
-<Meta title="Docs / Theming/ Mode" />
+<Meta title="Docs / Theming / Modes" />
 
 # Mode
 
-LightningUI components utilize modes to update `this.style`. The component's appearance can be changed depending on it's mode. 
+LightningUI components utilize modes to update `this.style`. The component's appearance can be changed depending on it's mode.
 
 **Common modes include:**
 
@@ -32,35 +32,39 @@ LightningUI components utilize modes to update `this.style`. The component's app
 * disabled
 * selected
 
-By default each component will attempt to find a `focused` mode when thte component gains focus. 
+By default each component will attempt to find a `focused` mode when thte component gains focus.
 
-### Theme level
+### Theme Level
 
-You can set any component's default mode by specifying it in the componentMode property of your theme.
-
-```js
-componentMode: {
-  Tile: 'focused'
-}
-``` 
-
-You can also adjust the functionality of a mode by overriding it in your theme using the componentStyle property. To target a mode override select the component to target ex. `ProgressBar` add a mode property to the theme level component overrride.
+You can set any component's default mode by specifying it in the `componentConfig` property of your theme. For a deeper dive on `tones`, see ["Component Config"](../?path=/story/docs-theming-component-config--page).
 
 ```js
-componentStyle: {
+componentConfig: {
   Tile: {
-    mode: {
-      focused: {
-        radius: 100
+    mode: 'focused'
+  }
+}
+```
+
+You can also adjust the functionality of a mode by overriding it in your theme using the `styleConfig` property nested inside `componentConfig`.
+
+```js
+componentConfig: {
+  Tile: {
+    styleConfig: {
+      mode: {
+        focused: {
+          radius: 100
+        }
       }
     }
   }
 }
 ```
 
-### Component level overrides
+### Component Level
 
-Modes can be set on individual components as well. 
+Modes can be set on individual components as well.
 
 In the example below this instance of a Tile would be shown in it's focused state
 

--- a/packages/@lightningjs/ui-components/docs/ThemingStorybook.stories.mdx
+++ b/packages/@lightningjs/ui-components/docs/ThemingStorybook.stories.mdx
@@ -30,7 +30,7 @@ Storybook controls and addons are helpful in visualizing the impact of theming o
 Controls in the properties category are values that you can change **regardless of theme**. For example, if you were to modify the `ProgressBar` component by changing the width of the bar, this change would persist regardless of the selected theme. Theme values are the style properties that change based on the current theme. On the ProgressBar, theme properties would be things like progressColor or radius.
 
 ### Themes
-We have created a custom "Theme Dropdown" addon to the Storybook toolbar, which allows you to select which theme you would like to apply to the components. The default theme is `Base`, which bundled into the library. However, in Storybook, we also allow you to create and download a custom theme.
+We have created a custom "Theme Dropdown" addon to the Storybook toolbar, which allows you to select which theme you would like to apply to the components. The default theme is `Base`, which is bundled into the library. However, in Storybook, we also allow you to create and download a custom theme.
 
 ### Global versus Component
 Choosing a theme target at a **global level** means that the theme values you have selected will be mapped to a broader set of components.

--- a/packages/@lightningjs/ui-components/docs/ThemingStorybook.stories.mdx
+++ b/packages/@lightningjs/ui-components/docs/ThemingStorybook.stories.mdx
@@ -22,23 +22,25 @@ import { Meta, Description } from '@storybook/addon-docs';
 <Meta title="Docs / Theming/ Use in Storybook" />
 
 # Theming and Storybook
-## Controls table
+
+## Controls Table
 Storybook controls and addons are helpful in visualizing the impact of theming on Lightning-UI components. The controls are split into two categories, **properties**, and **theme values**.
 
-### Properties versus theme values
-Controls in the properties category are values that you can change **regardless of theme**. For example, if you were to modify the `ProgressBar` component by changing the width of the bar, this change would persist regardless of the selected theme.
-Theme values are things like `ProgressBar` color or radius which change based on the theme. You have the ability to override theme values.
+### Properties versus Theme Values
+Controls in the properties category are values that you can change **regardless of theme**. For example, if you were to modify the `ProgressBar` component by changing the width of the bar, this change would persist regardless of the selected theme. Theme values are the style properties that change based on the current theme. On the ProgressBar, theme properties would be things like progressColor or radius.
 
 ### Themes
-The Storybook toolbar has an option where you can select which theme you would like to apply to your components.
-The primary default theme is the Base open-source theme. However, in Storybook we also allow you the option to create a custom theme.
+We have created a custom "Theme Dropdown" addon to the Storybook toolbar, which allows you to select which theme you would like to apply to the components. The default theme is `Base`, which bundled into the library. However, in Storybook, we also allow you to create and download a custom theme.
 
-### Global versus component
+### Global versus Component
 Choosing a theme target at a **global level** means that the theme values you have selected will be mapped to a broader set of components.
+
 Choosing a theme target at a **component level** means that every instance of a particular component type will use the new values set by the controls, but the changes will not affect other types of components referencing the same theme values.
-To learn more, [click here](../?path=/story/docs-theming-overview--page) and navigate to the 'Theming at a global versus component level' section.
+
+To learn more, check out ["Theming at a Global versus Component Level"](../?path=/story/docs-theming-overview--page#theming-at-a-global-versus-component-level).
 
 ## Downloading JSON data
-You can download your custom theme, which will include any property overrides you made in Storybook, by hitting the export/download button on the Storybook toolbar. By hitting the export button you will see JSON values relating to your theme selections. 
-If you overrode any "global" properties via the "Global Theme Values" tab, you will see that reflected in the main property objects like colors and typography. If you overrode any "component" properties via the "Component Style Theme Values" tab, you will see them in the JSON file under the `componentStyle` object.
+You can also download your custom theme, which will include any property overrides you made in Storybook, by hitting the export/download button on the Storybook toolbar. By hitting the export button you will see JSON values relating to your theme selections.
+
+If you overrode any "global" properties via the "Global Theme Values" tab, you will see that reflected in the main property objects like colors and typography. If you overrode any "component" properties via the "Component Style Theme Values" tab, you will see them in the JSON file under the `componentConfig` object.
 

--- a/packages/@lightningjs/ui-components/docs/ThemingSubTheming.stories.mdx
+++ b/packages/@lightningjs/ui-components/docs/ThemingSubTheming.stories.mdx
@@ -28,34 +28,19 @@ import MultiSubThemeProgressBars from '../src/assets/images/MultiSubThemeProgres
   }
 `}</style>
 
-<Meta title="Docs / Theming/ Sub Theming" />
+<Meta title="Docs / Theming/ Subtheming" />
 
-# Sub Theming
+# Subtheming
 
-## What is Sub Theming?
+Subtheming allows users to set unique themes on a subset of components without affecting the overarching application. It allows us to create multiple variations of an existing theme to be used across different elements and components.
 
-Sub theming is an aspect of [theming](../?path=/story/docs-theming-overview--page).
-It allows for updates/changes to an existing theme without permanently changing that theme.
-Essentially, with sub theming, we can create multiple variations of an existing theme to be used across different elements/components.
+## Use Cases
 
-## Use Case
+There are certain cases where we may need all the children of a Lightning element or component to have slightly different theme values. For example, a special browse page of 4th of July movies or perhaps a Shark Week promotion section. Distinct color palettes can be used to reflect these special occasions, but it's not always the case that we want entirely new brand (new radius, spacing, etc) values to be applied across entire pages. This is where subtheming comes in.
 
-There are certain cases where we may need all the children of a Lightning element or component to have slightly different theme values.
-For example, a special browse page of 4th of July movies or perhaps a Shark Week promotion section.
-Distinct color palettes can be used to reflect these special occasions, but it's not
-always the case that we want entirely new brand (new radius, spacing, etc) values to be applied across entire pages.
-This is where sub theming comes in.
+Subtheming allows us to target certain properties of a theme to change while still keeping the values of the other theme properties. For example, we can create a subtheme of the main theme where we change the core colors to reflect that of Shark Week with its variations of blues and add that to an element like `ProgressBar`. In this example, the `ProgressBar`'s color would reflect the new blue values from the sub-theme. However, its radius values would still reflect those of the main theme. Additionally, `ProgressBar` components used outside the context of this sub-theme will continue to use the brand colors of the main theme.
 
-Sub theming allows us to target certain properties of a theme to change while still keeping the values of the other theme properties.
-For example, we can create a sub-theme of the main theme where we change the core colors to reflect that of Shark Week with its
-variations of blues and add that to an element like `ProgressBar`.
-In this example, the `ProgressBar`'s color would reflect the new blue values from the sub-theme.
-However, its radius values would still reflect those of the main theme.
-Additionally, `ProgressBar` components used outside the context of this sub-theme will continue to use the brand colors of the main theme.
-
-Likewise, if there are multiple elements to a page, we can set a certain element to have a sub-theme (a `TabBar` with the Shark Week sub-theme)
-while the other elements (a display of `Tiles`) have the main theme.
-This allows the user to have two unique experiences living in the same visual space.
+Likewise, if there are multiple elements to a page, we can set a certain element to have a sub-theme (a `TabBar` with the Shark Week sub-theme) while the other elements (a display of `Tiles`) have the main theme. This allows the user to have two unique experiences living in the same visual space.
 
 ## Steps to Utilizing a Sub-Theme
 
@@ -69,11 +54,9 @@ Refer to [theming](../?path=/story/docs-theming-overview--page) for how to set t
 
 ### 2. Set the sub-theme
 
-To create a sub-theme, we'll need to utilize `context` and its `setSubTheme` method.
-The method takes in the sub-theme name followed by the properties and values of the sub-theme as parameters.
+To create a sub-theme, we'll need to utilize `context` and its `setSubTheme` method. The method takes in the sub-theme name followed by the properties and values of the sub-theme as parameters.
 
-For example, let's imagine we'd like some components to reflect the 4th of July holiday.
-Our `setSubTheme` method might look something like:
+For example, let's imagine we'd like some components to reflect the 4th of July holiday. Our `setSubTheme` method might look something like:
 
 ```js
 context.setSubTheme('4thOfJuly', {
@@ -82,10 +65,12 @@ context.setSubTheme('4thOfJuly', {
     coreNeutralSecondary: ['#FAF2E6', 85], // white
     coreNeutralTertiary: ['#80A1C2', 85] // blue
   },
-  componentStyle: {
+  componentConfig: {
     MetadataTile: {
-      descriptionTextStyle: {
-        textColor: ['#FAF2E6', 85]
+      style: {
+        descriptionTextStyle: {
+          textColor: ['#FAF2E6', 85]
+        }
       }
     }
   }
@@ -95,15 +80,13 @@ Here we're changing the colors of the existing theme, specifically the `coreNeut
 
 ### 3. Apply the sub-theme to the components in need
 
-After creating our sub-theme, we need to specify which components will be utilizing the sub-theme.
-Once the components have been picked out, there are two methods to applying the sub-theme.
+After creating our sub-theme, we need to specify which components will be utilizing the sub-theme. Once the components have been picked out, there are two methods to applying the sub-theme.
 
 #### Method 1: Lightning Element
 
 The first method is by utilizing the `_template` function and returning a component with the specified sub-theme.
 
-For example, let's say we have a page of movie `Tiles` and it's getting closer to the 4th of July holiday so we want to have a section displaying 4th of July movies.
-In this case, we can create a `_template` function like this:
+For example, let's say we have a page of movie `Tiles` and it's getting closer to the 4th of July holiday so we want to have a section displaying 4th of July movies. In this case, we can create a `_template` function like this:
 
 ```js
 static _template() {
@@ -131,9 +114,7 @@ static _template() {
 }
 ```
 
-Here we have two `Row` components each containing a set amount of movie `Tiles`.
-The first `Row` features the 4th of July movies so the '4thOfJuly' `subTheme` with its red, white, and blue values has been applied to it.
-On the other hand, the second `Row` will only reflect the main theme. The following should be displayed:
+Here we have two `Row` components each containing a set amount of movie `Tiles`. The first `Row` features the 4th of July movies so the '4thOfJuly' `subTheme` with its red, white, and blue values has been applied to it. On the other hand, the second `Row` will only reflect the main theme. The following should be displayed:
 
 <img src={SubThemingExample} alt="Row of Tiles with '4thOfJuly' subTheme and a Row with main theme" width="700" />
 
@@ -154,12 +135,9 @@ Assuming we are generating a `ProgressBar` component, our resulting `ProgressBar
 
 <img src={July4thProgressBar} alt="Progress Bar with the 4th of July sub-theme" width="600" />
 
-The `ProgressBar` uses both `coreNeutral` and `coreNeutralTertiary` to define its `progressColor`
-and `barColor`, respectively. Since our '4thOfJuly' sub-theme updated those values, we see the `progressColor`
-and `barColor` of the `ProgressBar` reflecting the values set in the sub-theme.
+The `ProgressBar` uses both `coreNeutral` and `coreNeutralTertiary` to define its `progressColor` and `barColor`, respectively. Since our '4thOfJuly' sub-theme updated those values, we see the `progressColor` and `barColor` of the `ProgressBar` reflecting the values set in the sub-theme.
 
-This `ProgressBar` is built off the Base open-source theme. Because the radius was never set, the `ProgressBar`
-still continues to reflect the radius value of the Base theme which is set to 0.
+This `ProgressBar` is built off the Base open-source theme. Because the radius was never set, the `ProgressBar` still continues to reflect the radius value of the Base theme which is set to 0.
 
 > **Note:** Adding the `subTheme` getter method will apply the sub-theme globally to all the listed components inside the `_template` function
 > that do not have an assigned sub-theme.
@@ -168,12 +146,9 @@ still continues to reflect the radius value of the Base theme which is set to 0.
 
 ## How Does it Work?
 
-Now that we understand how to create and use a sub-theme, let's digest how the component is able to determine how to retrieve the sub-theme.
-This all lies in the `_getSubTheme` method.
+Now that we understand how to create and use a sub-theme, let's digest how the component is able to determine how to retrieve the sub-theme. This all lies in the `_getSubTheme` method.
 
-The `_getSubTheme` method is executed on the `_setup` lifecycle event.
-In this function (displayed below), we can see that each component continuously goes through its
-parents to check if a sub-theme is applied to that component until there are no more parent components left to check.
+The `_getSubTheme` method is executed on the `_setup` lifecycle event. In this function (displayed below), we can see that each component continuously goes through its parents to check if a sub-theme is applied to that component until there are no more parent components left to check.
 
 
 ```js
@@ -186,19 +161,18 @@ _getSubTheme() {
 }
 ```
 
-As soon as a parent component detects a sub-theme, `_getSubTheme` exits the loop and returns the sub-theme.
-If the highest parent component up the chain is reached without returning/discovering a sub-theme, then the component will use the global theme.
+As soon as a parent component detects a sub-theme, `_getSubTheme` exits the loop and returns the sub-theme. If the highest parent component up the chain is reached without returning/discovering a sub-theme, then the component will use the global theme.
 
 > **Important:** If the parent theme is updated, the system will clear the cache the sub-themes depend on, regenerating the sub-theme, and ultimately updating the child elements that rely on the sub-theme.
 
-## Other Useful Methods for Sub Theming
+## Other Useful Methods for Subtheming
 
-Close to the functionality of the global theme, `context` also has `updateSubTheme` and `removeSubTheme` methods available.
-In addition, it has a `setSubThemes` method which is used to generate multiple sub-themes at once.
+Close to the functionality of the global theme, `context` also has `updateSubTheme` and `removeSubTheme` methods available. In addition, it has a `setSubThemes` method which is used to generate multiple sub-themes at once.
 
 ### updateSubTheme
 
 Similar to the Lightning `patch` object, `updateSubTheme` will only overwrite the properties specified and will not affect any other values from the existing sub-theme.
+
 For example:
 
 ```js
@@ -209,8 +183,7 @@ context.updateSubTheme('4thOfJuly', {
 })
 ```
 
-Here, we updated the `coreNeutral` value to white, which will then update the `ProgressBar`'s `progressColor`.
-This will only affect the `ProgressBar` to which we have applied the sub-theme. All other colors, like `barColor` will remain unchanged.
+Here, we updated the `coreNeutral` value to white, which will then update the `ProgressBar`'s `progressColor`. This will only affect the `ProgressBar` to which we have applied the sub-theme. All other colors, like `barColor` will remain unchanged.
 
 <img src={UpdatedJuly4thProgressBar} alt="Progress Bar with the 4th of July sub-theme" width="600" />
 
@@ -227,8 +200,7 @@ context.removeSubTheme('4thOfJuly')
 
 The `setSubThemes` method can be used to create multiple sub-themes at once by taking in a `subThemes` object. The keys of the object reflect the name of the sub-theme.
 
-The example below will create both a sub-theme reflecting the 4th of July colors as well as a sub-theme reflecting colors
-for Shark Week.
+The example below will create both a sub-theme reflecting the 4th of July colors as well as a sub-theme reflecting colors for Shark Week.
 
 ```js
 context.setSubThemes({

--- a/packages/@lightningjs/ui-components/docs/ThemingTone.stories.mdx
+++ b/packages/@lightningjs/ui-components/docs/ThemingTone.stories.mdx
@@ -19,26 +19,29 @@
 
 import { Meta, Description } from '@storybook/addon-docs';
 
-<Meta title="Docs / Theming / Tone" />
+<Meta title="Docs / Theming / Tones" />
 
 # Tone
-Each Lightning-UI component can be displayed in one of three visual modes that are referred to as a tone.
-All components have three tone options by default: **neutral**, **brand**, and **inverse**.
-Some of our components also utilize status colors, like **positive**, **negative**, **caution**, and **info**.
-It is also possible to add other custom tones. Each component has a default tone.
-For example, Base theme `Buttons` and `ListItems` default to the neutral tone.
-A component's tone can be set at the theme or component level.
+Each Lightning-UI component can be displayed in one of three visual modes that are referred to as a tone. All components have three tone options by default: **neutral**, **brand**, and **inverse**.
+Some components can also utilize status colors, like **positive**, **negative**, **caution**, and **info**.
 
-### Theme level
-Each theme may contain a property `componentTone`. This property can hold one or more properties which correspond to each LUI component's `__componentName`.
-You may change the default tone across all LUI components by setting this value in your themes file.
-If you want to use a neutral tone on all `ProgressBar` components in the Base or your custom theme you would do this:
+Each component has a default tone. For example, Base theme `Buttons` and `ListItems` default to the neutral tone.
+
+A component's tone can be set at the theme or component level. It is also possible to add custom tones.
+
+### Theme Level
+You may change the default tone across all LUI components by setting this value in your theme file's `componentConfig`. For a deeper dive on `tones`, see ["Component Config"](../?path=/story/docs-theming-component-config--page).
+
+For example, if you want to use a brand tone on all `ProgressBar` components, add ProgressBar's tone to `componentConfig`:
 
 ```js
-componentTone: {
-  ProgressBar: 'neutral'
+componentConfig: {
+  ProgressBar: {
+    tone: 'brand'
+  }
 }
 ```
+
 The resulting theme object would look like this:
 
 ```js
@@ -50,16 +53,17 @@ export default {
   radius,
   typography,
   animation,
-  componentStyle: {},
-  componentTone: {
-    ProgressBar: 'neutral'
+  componentConfig: {
+    ProgressBar: {
+      tone: 'neutral'
+    }
   }
 };
 ```
 
 In this example, **all** `ProgressBar` components will be using the neutral tone.
 
-### Component level
+### Component Level
 
 You may also update this value on a per component basis by setting its tone property. For example:
 

--- a/packages/apps/lightning-ui-docs/.storybook/utils/constants.js
+++ b/packages/apps/lightning-ui-docs/.storybook/utils/constants.js
@@ -31,12 +31,13 @@ export const storySortOrder = [
     'Theming',
     [
       'Overview',
-      'Theme Properties',
-      'Use in Storybook',
-      'Mode',
-      'Tone',
+      'Component Config',
+      'Tones',
+      'Modes',
       'Extensions',
-      'Sub Theming',
+      'Subtheming',
+      'Use in Storybook',
+      'Theme Properties',
       '*'
     ]
   ],


### PR DESCRIPTION
Adds a page specifically for the componentConfig and cleans up any leftover cases of componentStyle and componentTone. Additionally, fixes some formatting issues and clarifies some out-dated content.