### PR TITLE
fix: add Metrological line to license info in NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,8 @@
 [Lightning-UI-Components]
 Copyright 2020 Comcast Cable Communications Management, LLC
 
+Copyright 2020 Metrological
+
 Licensed under the Apache License, Version 2.0 (the "License");you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
@@ -17,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 This product includes software developed at Comcast (http://www.comcast.com/)
 
 The component may include material which is licensed under other licenses / copyrights as
-listed below. Your use of this material within the component is also subject to the terms and 
+listed below. Your use of this material within the component is also subject to the terms and
 conditions of these licenses. The LICENSE file contains the text of all the licenses which apply
 within this component.
 


### PR DESCRIPTION
@mhughesacn I saw your comment [here](https://github.com/rdkcentral/Lightning-UI-Components/pull/113#issuecomment-1450618792)
> Also please append credit to NOTICE for the Metrological use:
>
> Copyright 2020 Metrological
> Licensed under the Apache License, Version 2.0

Is this all that's needed? Thank you!