### PR TITLE
fix(Row): prevent items scrolling off screen when quickly navigating

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Row/Row.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.js
@@ -18,6 +18,7 @@
 
 import NavigationManager from '../NavigationManager/index.js';
 import * as styles from './Row.styles.js';
+import { getX } from '../../utils';
 
 export default class Row extends NavigationManager {
   static get __componentName() {
@@ -53,8 +54,12 @@ export default class Row extends NavigationManager {
   // At a later time, we should investigate this further.
   _isOnScreenForScrolling(child) {
     if (!child) return false;
-    let itemX = child.core.renderContext.px;
+
+    const x = getX(child);
+    if (!Number.isFinite(x)) return false;
+    const itemsTransitionX = this.getTransitionXTargetValue();
     const rowX = this.core.renderContext.px;
+    let itemX = rowX + itemsTransitionX + x;
     let xModifier;
 
     // This section here takes the difference between a possible target value


### PR DESCRIPTION
## Description
**Bug:** This bug existed on all `Row` components (`Row`, `TitleRow`, `ControlRow`). If a user rapidly navigated to the end of the `Row` (ex. holding down the right arrow button) then the scrolling calculations would sometimes return an incorrect value and result in the focused item sometimes being displayed not aligned with the grid layout.

This PR changes that calculation to account for `x` transitions that could still be running when the row is calculating `x` positions. This approach has been in use in `FocusManager._isComponentHorizontallyVisible`, so those parts were brought over to `Row._isOnScreenForScrolling`.

## Testing
On any of the Row/TitleRow/ControlRow stories:
1. navigate to the last item in the Row one-by-one by pressing the right arrow key repeatedly. All tiles should be aligned in the grid system. Note where the last item is aligned; it should be at the same position after step 3.
2. Navigate back to the first item.
3. Hold down the right arrow button to rapidly navigate to the end of the Row. 
ER: All tiles should be aligned in the grid system, in the same positions as after step 1.
<!-- step by step instructions to review this PR's changes -->