### PR TITLE
chore: add PR template back

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Description
+
+<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
+
+## References
+
+<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->
+
+## Testing
+
+<!-- step by step instructions to review this PR's changes -->
+
+## Automation
+
+<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->
+
+## Checklist
+
+- [ ] all commented code has been removed
+- [ ] any new console issues have been resolved
+- [ ] code linter and formatter has been run
+- [ ] test coverage meets repo requirements
+- [ ] PR name matches the expected semantic-commit syntax


### PR DESCRIPTION
This PR template got dropped in the shuffle from internal LUI to Open Source, so adding it back in.

NOTE: It will not take affect until we change the repo's default branch to `develop` from `1.x`.