### PR TITLE
chore: update CODEOWNERS file to remove old team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-*  @Lightning/lightning-team @Lightning/automation
+*  @erautenberg @joshhowenstine @anthony9187 @ImCoolNowRight @THoj13 @arwehrman @jazzyw @soumyaloka


### PR DESCRIPTION
Since there is no longer a GitHub team for the group, adding us all individually as the code owners.