### PR TITLE
fix(NavigationManager): allow centering items off cross size of component

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Column/Column.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.stories.js
@@ -351,7 +351,11 @@ export const CenteredInParent = () =>
               autoResizeWidth: true,
               autoResizeHeight: true,
               centerInParent: true,
-              items: createItems(Button, 1)
+              items: createItems(Button, 2)
+            },
+            {
+              ...createItems(Button, 1)[0],
+              centerInParent: true
             }
           ]
         }

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.test.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.test.js
@@ -169,8 +169,8 @@ describe('NavigationManager', () => {
       });
     });
 
-    describe('centering items on the cross axis', () => {
-      it('should center items that have the centerInParent property set on them', () => {
+    describe('centering items on the cross axis with centerInParent property', () => {
+      it('should center items based off the Items cross dimension size', () => {
         [navigationManager] = createNavigationManager({
           items: [
             { ...baseItem, h: 400 },
@@ -181,6 +181,22 @@ describe('NavigationManager', () => {
         expect(navigationManager.Items.children[0].y).toBe(0);
         expect(navigationManager.Items.h).toBe(400);
         expect(navigationManager.Items.children[1].y).toBe((400 - 300) / 2);
+      });
+
+      it('should center items based off the NavigationManager cross dimension size', () => {
+        const h = 500;
+        [navigationManager] = createNavigationManager({
+          h,
+          items: [
+            { ...baseItem, h: 400 },
+            { ...baseItem, h: 300, centerInParent: true }
+          ]
+        });
+
+        expect(navigationManager.Items.children[0].y).toBe(0);
+        expect(navigationManager.h).toBe(500);
+        expect(navigationManager.Items.h).toBe(400);
+        expect(navigationManager.Items.children[1].y).toBe((h - 300) / 2);
       });
     });
 


### PR DESCRIPTION
**Bug: ** In a Column with multiple items that are not subclasses of NavigationManager and have centerInParent set to true, the items are not centered in the Column.

### Testing:
1. Navigate to "Column/Center In Parent" story
ER: All buttons are horizontally centered in the Column