### PR TITLE
fix(Tooltip): fixed args url issue by adding sharedargactions

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.stories.js
@@ -58,23 +58,40 @@ export default {
   }
 };
 
-export const Basic = () =>
+const sharedArgActions = {
+  argActions: {
+    delayVisible: (delayVisible, component) => {
+      component.tag('Tooltip').delayVisible = delayVisible;
+    },
+    timeVisible: (timeVisible, component) => {
+      component.tag('Tooltip').timeVisible = timeVisible;
+    }
+  }
+};
+
+export const Basic = args =>
   class Basic extends lng.Component {
     static _template() {
       return {
         Tooltip: {
           type: TooltipComponent,
-          x: 1280 / 2
+          x: 1280 / 2,
+          delayVisible: args.delayVisible,
+          timeVisible: args.timeVisible
         }
       };
     }
   };
+
+Basic.parameters = { ...sharedArgActions };
 
 export const LongTitle = Basic.bind({});
 LongTitle.args = {
   title:
     'This is a long message. Text will remain on a single line and does not have a maximum width'
 };
+
+LongTitle.parameters = { ...sharedArgActions };
 
 export const WithButton = args =>
   class WithButton extends lng.Component {


### PR DESCRIPTION
## Description

In this PR, I have updated add argActions to Basic tooltip and Long title story.

## Testing

1. Navigate to the 'Tooltip Basic' component
2. Go to unfocused mode and set the delayVisible in milliseconds like 2000
3. Open the story only in a new tab (hit the arrow button in the corner)
4. Change the mode to focused and update delayVisible then observe the component if the title visible is delayed for the specified seconds, repeat the same with timeVisible.