### PR TITLE
fix: update deployment order and add README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,10 @@ jobs:
       - name: Build Packages
         run: yarn workspaces foreach --exclude lightning-ui-docs run build
       - name: Semantic Release
-        run: yarn workspaces foreach run semantic-release --no-ci -e semantic-release-monorepo 
+        run: |
+          yarn workspace @lightningjs/ui-components-theme-base run semantic-release --no-ci -e semantic-release-monorepo 
+          yarn workspace @lightningjs/ui-components-test-utils run semantic-release --no-ci -e semantic-release-monorepo 
+          yarn workspace @lightningjs/ui-components run semantic-release --no-ci -e semantic-release-monorepo 
         env:
           GH_TOKEN: ${{secrets.GH_TOKEN}}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0 # make sure to get all history for semantic release
+          fetch-depth: 0 # Make sure to get all history for semantic release
       - name: Setup node
         uses: actions/setup-node@v3
         with:
@@ -30,11 +30,13 @@ jobs:
         run: yarn install
       - name: Build Packages
         run: yarn workspaces foreach --exclude lightning-ui-docs run build
+      - name: Copy README # Make sure to deploy README from the root directory along with @lightningjs/ui-components
+        run: cp ./README.md ./packages/@lightningjs/ui-components/README.md
       - name: Semantic Release
         run: |
           yarn workspace @lightningjs/ui-components-theme-base run semantic-release --no-ci -e semantic-release-monorepo 
-          yarn workspace @lightningjs/ui-components-test-utils run semantic-release --no-ci -e semantic-release-monorepo 
           yarn workspace @lightningjs/ui-components run semantic-release --no-ci -e semantic-release-monorepo 
+          yarn workspace @lightningjs/ui-components-test-utils run semantic-release --no-ci -e semantic-release-monorepo
         env:
           GH_TOKEN: ${{secrets.GH_TOKEN}}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ original/
 CHANGELOG.md
 
 /packages/apps/lightning-ui-docs/scripts/themePropertyTables
+
+# Copied into folder from root directory during release
+/packages/@lightningjs/ui-components/README.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ The following is a set of guidelines for contributing to `@lightningjs/ui-compon
 
 **Discuss on Slack**
 
-<a href="https://lightning-community.slack.com/archives/C04R2HNU5V3" target="_blank">#lightning-ui-componenents-support</a>
+<a href="https://lightning-community.slack.com/archives/C04R2HNU5V3" target="_blank">#lightning-ui-components-support</a>
 
 ## How Can I Contribute?
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Install from NPM:
 npm install --save @lightningjs/ui-components
 ```
 
-`@lightningjs/ui-componenents` has a peer dependency on the [Lightning package](https://www.npmjs.com/package/@lightningjs/core)
+`@lightningjs/ui-components` has a peer dependency on the [Lightning package](https://www.npmjs.com/package/@lightningjs/core)
 
 ```sh
 npm install -S @lightningjs/ui @lightningjs/core

--- a/packages/@lightningjs/ui-components-test-utils/README.md
+++ b/packages/@lightningjs/ui-components-test-utils/README.md
@@ -19,3 +19,17 @@
 # Lightning Component Test Utils
 
 This utility has been created to assist with writing Jest tests for applications utilizing [@lightningjs/ui-components](https://www.npmjs.com/package/@lightningjs/ui-components).
+
+## Installation
+
+Install from NPM:
+
+```bash
+npm install --save @lightningjs/ui-components-test-utils
+```
+
+`@lightningjs/ui-components-test-utils` has a peer dependency on the [Lightning package](https://www.npmjs.com/package/@lightningjs/core).
+
+```sh
+npm install -S @lightningjs/ui @lightningjs/core
+```

--- a/packages/@lightningjs/ui-components-test-utils/README.md
+++ b/packages/@lightningjs/ui-components-test-utils/README.md
@@ -1,0 +1,21 @@
+﻿<!--
+  Copyright 2023 Comcast Cable Communications Management, LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Lightning Component Test Utils
+
+This utility has been created to assist with writing Jest tests for applications utilizing [@lightningjs/ui-components](https://www.npmjs.com/package/@lightningjs/ui-components).

--- a/packages/@lightningjs/ui-components-theme-base/README.md
+++ b/packages/@lightningjs/ui-components-theme-base/README.md
@@ -19,3 +19,11 @@
 # Lightning Component Theme Base
 
 Base theme values consumed by Lightning UI Components [@lightningjs/ui-components](https://www.npmjs.com/package/@lightningjs/ui-components).
+
+## Installation
+
+Install from NPM:
+
+```bash
+npm install --save @lightningjs/ui-components-theme-base
+```

--- a/packages/@lightningjs/ui-components-theme-base/README.md
+++ b/packages/@lightningjs/ui-components-theme-base/README.md
@@ -1,0 +1,21 @@
+﻿<!--
+  Copyright 2023 Comcast Cable Communications Management, LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Lightning Component Theme Base
+
+Base theme values consumed by Lightning UI Components [@lightningjs/ui-components](https://www.npmjs.com/package/@lightningjs/ui-components).


### PR DESCRIPTION
## Description

**Issue 1:** 

During the release process semantic-release needs run in this order to make sure the correct dependency versions are used. This process will need to be audited at a later date in favor of [deferred versioning](https://yarnpkg.com/features/release-workflow#deferred-versioning) however, for now this should fix the issue. 

**Proposed solution:**

Update action to call semantic release in the correct order instead of the default order of `yarn workspace foreach`

1. @lightningjs/ui-components-theme-base
2. @lightningjs/ui-components
3. @lightningjs/ui-components-test-utils

**Issue 2:** 

Current package releases do not have a README when they are being viewed at NPM https://www.npmjs.com/package/@lightningjs/ui-components

**Proposed solution:**

Add README files

- @lightningjs/ui-components-test-utils
- @lightningjs/ui-components-theme-base
- @lightningjs/ui-components (copy from project directory during release ci steps)

During the release action the README will be copied to ./packages/@lightningjs/ui-components to avoid duplication.

## Testing

Run semantic release steps listed on line 36 of release.yml in dry run mode to ensure the proper versions are set for each package. As a more accurate test you may also update the patch for semantic-release-npm (locally only) and update line 43 with the pack command. This should allow you to inspect the contents of the final release from the tarball that is created for each package. 

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
