### PR TITLE
fix(Storybook): changes check for instance of Element

### DIFF
--- a/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
+++ b/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
@@ -59,11 +59,9 @@ export const withLightning = (
             ];
           }
           // TODO: Assess what config.optimization.minimize is doing different in production vs develop
-          // check string to see if it includes Element in the name string
           get componentTarget() {
-            return this.childList &&
-              this.childList.first &&
-              this.childList.first.constructor.name !== 'Element'
+            // using this check on type Element because production vs develop build issue
+            return this.childList.first instanceof lng.Component
               ? this.childList.first
               : this;
           }


### PR DESCRIPTION
## Description

This PR fixes loading errors happening on the following mixins stories: 
withMarqueeSync
withUpdates
withTags
 
- changed the conditional in `get componentTarget` method to look for instance of  Element instead of containing string "Element"  so that the conditional will work on production and development builds

## References

Jira-683

## Testing

- clone branch
- yarn start
- check the following mixin stories to see if they are loading properly: 
withMarqueeSync
withUpdates
withTags

## Automation

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
