### PR TITLE
fix(withLayout): adds check for positive numbers

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.test.js
@@ -299,7 +299,8 @@ describe('Tile', () => {
     tile.itemLayout = { circle: true };
     await tile.__updateBadgeSpyPromise;
     expect(tile._Badge).toBeUndefined();
-    tile.itemLayout = undefined;
+
+    tile.itemLayout = {};
     tile.badge = {
       title: 'changed'
     };
@@ -335,7 +336,7 @@ describe('Tile', () => {
     tile.itemLayout = { circle: true };
     await tile.__updateTagSpyPromise;
     expect(tile._Tag).toBeUndefined();
-    tile.itemLayout = undefined;
+    tile.itemLayout = {};
     tile.label = {
       title: 'changed'
     };
@@ -388,7 +389,7 @@ describe('Tile', () => {
     await tile.__updateCheckboxSpyPromise;
     expect(tile._Checkbox).toBeUndefined();
 
-    tile.itemLayout = undefined;
+    tile.itemLayout = {};
     tile.requestUpdate(true);
     await tile.__updateCheckboxSpyPromise;
     expect(tile._Checkbox).not.toBeUndefined();
@@ -420,7 +421,7 @@ describe('Tile', () => {
     fastForward([tile._ProgressBar]);
     testRenderer.update(); // Force redraw
     expect(tile._ProgressBar).toBeUndefined();
-    tile.itemLayout = undefined;
+    tile.itemLayout = {};
     tile.shouldSmooth = false;
     tile.progressBar = {
       progress: 0.4

--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.test.js
@@ -299,8 +299,7 @@ describe('Tile', () => {
     tile.itemLayout = { circle: true };
     await tile.__updateBadgeSpyPromise;
     expect(tile._Badge).toBeUndefined();
-
-    tile.itemLayout = {};
+    tile.itemLayout = undefined;
     tile.badge = {
       title: 'changed'
     };
@@ -336,7 +335,7 @@ describe('Tile', () => {
     tile.itemLayout = { circle: true };
     await tile.__updateTagSpyPromise;
     expect(tile._Tag).toBeUndefined();
-    tile.itemLayout = {};
+    tile.itemLayout = undefined;
     tile.label = {
       title: 'changed'
     };
@@ -389,7 +388,7 @@ describe('Tile', () => {
     await tile.__updateCheckboxSpyPromise;
     expect(tile._Checkbox).toBeUndefined();
 
-    tile.itemLayout = {};
+    tile.itemLayout = undefined;
     tile.requestUpdate(true);
     await tile.__updateCheckboxSpyPromise;
     expect(tile._Checkbox).not.toBeUndefined();
@@ -421,7 +420,7 @@ describe('Tile', () => {
     fastForward([tile._ProgressBar]);
     testRenderer.update(); // Force redraw
     expect(tile._ProgressBar).toBeUndefined();
-    tile.itemLayout = {};
+    tile.itemLayout = undefined;
     tile.shouldSmooth = false;
     tile.progressBar = {
       progress: 0.4

--- a/packages/@lightningjs/ui-components/src/mixins/withLayout/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withLayout/index.js
@@ -31,13 +31,13 @@ export default function withLayout(Base) {
     }
 
     set itemLayout(v) {
+      const componentName =
+        this.constructor._componentName || this.constructor.name;
       const itemLayout = JSON.parse(
         JSON.stringify(v, (k, v) => {
           if (k !== 'circle' && v < 0) {
             context.error(
-              `itemlayout for ${
-                this.constructor._componentName || this.constructor.name
-              } recieved an invaild value of ${v} for ${k}`
+              `itemlayout for ${componentName} recieved an invaild value of ${v} for ${k}`
             );
             return;
           } else if (k === 'circle') {

--- a/packages/@lightningjs/ui-components/src/mixins/withLayout/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withLayout/index.js
@@ -84,6 +84,7 @@ export default function withLayout(Base) {
     }
 
     _updateItemLayout() {
+      console.log('updatItemLayout');
       if (!this._allowUpdate()) return;
       const { w, h } = getDimensions(this.theme, this._itemLayout);
       if (h || w) {

--- a/packages/@lightningjs/ui-components/src/mixins/withLayout/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withLayout/index.js
@@ -84,7 +84,6 @@ export default function withLayout(Base) {
     }
 
     _updateItemLayout() {
-      console.log('updatItemLayout');
       if (!this._allowUpdate()) return;
       const { w, h } = getDimensions(this.theme, this._itemLayout);
       if (h || w) {

--- a/packages/@lightningjs/ui-components/src/mixins/withLayout/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withLayout/index.js
@@ -30,7 +30,22 @@ export default function withLayout(Base) {
       return this._itemLayout;
     }
 
-    set itemLayout(itemLayout) {
+    set itemLayout(v) {
+      const itemLayout = JSON.parse(
+        JSON.stringify(v, (k, v) => {
+          if (k !== 'circle' && v < 0) {
+            context.error(
+              `itemlayout for ${
+                this.constructor._componentName || this.constructor.name
+              } recieved an invaild value of ${v} for ${k}`
+            );
+            return;
+          } else if (k === 'circle') {
+            return Boolean(v);
+          }
+          return v;
+        })
+      );
       if (!stringifyCompare(this._itemLayout, itemLayout)) {
         if (itemLayout && !itemLayout.upCount) {
           this._originalW = this.w;

--- a/packages/@lightningjs/ui-components/src/mixins/withLayout/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withLayout/index.js
@@ -37,7 +37,7 @@ export default function withLayout(Base) {
         JSON.stringify(v, (k, v) => {
           if (k !== 'circle' && v < 0) {
             context.error(
-              `itemlayout for ${componentName} recieved an invaild value of ${v} for ${k}`
+              `itemLayout for ${componentName} received an invalid value of ${v} for ${k}`
             );
             return;
           } else if (k === 'circle') {

--- a/packages/@lightningjs/ui-components/src/mixins/withLayout/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withLayout/index.js
@@ -33,19 +33,23 @@ export default function withLayout(Base) {
     set itemLayout(v) {
       const componentName =
         this.constructor._componentName || this.constructor.name;
-      const itemLayout = JSON.parse(
-        JSON.stringify(v, (k, v) => {
-          if (k !== 'circle' && v < 0) {
-            context.error(
-              `itemLayout for ${componentName} received an invalid value of ${v} for ${k}`
-            );
-            return;
-          } else if (k === 'circle') {
-            return Boolean(v);
-          }
-          return v;
-        })
-      );
+      let itemLayout;
+      if (v) {
+        itemLayout = JSON.parse(
+          JSON.stringify(v, (k, v) => {
+            if (k !== 'circle' && v < 0) {
+              context.error(
+                `itemLayout for ${componentName} received an invalid value of ${v} for ${k}`
+              );
+              return;
+            } else if (k === 'circle') {
+              return Boolean(v);
+            }
+            return v;
+          })
+        );
+      }
+
       if (!stringifyCompare(this._itemLayout, itemLayout)) {
         if (itemLayout && !itemLayout.upCount) {
           this._originalW = this.w;

--- a/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.mdx
+++ b/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.mdx
@@ -120,10 +120,10 @@ If the mixin is unable to calculate height AND width from the passed parameters.
 
 ### itemLayout
 
-| name    | type   | required | default | description                                                                                                                               |
-| ------- | ------ | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| w       | number | false    | 0       | explicitly set the width of an item                                                                                                       |
-| h       | number | false    | 0       | explicitly set the height of an item                                                                                                      |
-| ratioX  | number | false    | 0       | units of x resolution relative to the screen height                                                                                       |
-| ratioY  | number | false    | 0       | units of y resolution relative to the screen width                                                                                        |
-| upCount | number | false    | 0       | the number of items that should be displayed within screen bounds. Additional items will run off-screen or outside of specified row width |
+| name    | type   | required | default | description                                                                                                                                                              |
+| ------- | ------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| w       | number | false    | 0       | explicitly set the width of an item                                                                                                                                      |
+| h       | number | false    | 0       | explicitly set the height of an item                                                                                                                                     |
+| ratioX  | number | false    | 0       | units of x resolution relative to the screen height, should be a posititve integer                                                                                       |
+| ratioY  | number | false    | 0       | units of y resolution relative to the screen width, should be a posititve integer                                                                                        |
+| upCount | number | false    | 0       | the number of items that should be displayed within screen bounds. Additional items will run off-screen or outside of specified row width, should be a posititve integer |

--- a/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.stories.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.stories.js
@@ -49,7 +49,7 @@ export const withLayout = () => {
 withLayout.storyName = 'withLayout';
 
 withLayout.args = {
-  ratioX: -16,
+  ratioX: 16,
   ratioY: 9,
   upCount: 3,
   circle: false

--- a/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.stories.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.stories.js
@@ -49,7 +49,7 @@ export const withLayout = () => {
 withLayout.storyName = 'withLayout';
 
 withLayout.args = {
-  ratioX: 16,
+  ratioX: -16,
   ratioY: 9,
   upCount: 3,
   circle: false

--- a/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.stories.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.stories.js
@@ -49,7 +49,7 @@ export const withLayout = () => {
 withLayout.storyName = 'withLayout';
 
 withLayout.args = {
-  ratioX: 16,
+  ratioX: -16,
   ratioY: 9,
   upCount: 3,
   circle: false
@@ -57,17 +57,17 @@ withLayout.args = {
 
 withLayout.argTypes = {
   ratioX: {
-    control: 'number',
+    control: { type: 'number', min: 0 },
     description: 'The units of x resolution relative to the screen height',
     table: { defaultValue: { summary: 0 } }
   },
   ratioY: {
-    control: 'number',
+    control: { type: 'number', min: 0 },
     description: 'The units of y resolution relative to the screen width',
     table: { defaultValue: { summary: 0 } }
   },
   upCount: {
-    control: 'number',
+    control: { type: 'number', min: 0 },
     description:
       'The number of items that should be displayed within screen bounds',
     table: { defaultValue: { summary: 0 } }

--- a/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.test.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.test.js
@@ -94,16 +94,17 @@ describe('withLayout', () => {
   });
 
   it('should throw an error if a negative value is used', () => {
-    const errorLog = jest.spyOn(global.console, 'error');
+    const errorLog = new Error('Error');
     tileWithLayout.itemLayout = { ratioX, ratioY, h, upCount };
     testRenderer.update();
     tileWithLayout.itemLayout.ratioX = -20;
-
-    expect(errorLog).toHaveBeenCalled();
+    const spy = jest.spyOn(context, 'error');
+    expect(spy).toHaveBeenCalled();
     // expect(logSpy).toHaveBeenCalledWith(
     //   'itemLayout for Tile recieved an invaild value of -16 for ratioX'
     // );
     expect(tileWithLayout.itemLayout.ratioX).toBe(16);
     //logSpy.console.error.mockRestore(); // restores original console log function
+    jest.clearAllMocks();
   });
 });

--- a/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.test.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.test.js
@@ -20,7 +20,7 @@ import { makeCreateComponent } from '@lightningjs/ui-components-test-utils';
 import withLayout from '.';
 import Tile from '../../components/Tile';
 import context from '../../globals/context';
-
+import { jest } from '@jest/globals';
 const createTileWithLayout = props =>
   makeCreateComponent(withLayout(Tile))(props);
 
@@ -84,12 +84,26 @@ describe('withLayout', () => {
     );
   });
 
-  it('should set width from height and default ratio', async () => {
+  it('should set width from height and default ratio', () => {
     tileWithLayout.itemLayout = { h };
     testRenderer.update();
     expect(tileWithLayout.w).toBeDefined();
     expect(tileWithLayout.w).toBe(
       (h * context.theme.layout.screenW) / context.theme.layout.screenH
     );
+  });
+
+  it('should throw an error if a negative value is used', () => {
+    const errorLog = jest.spyOn(global.console, 'error');
+    tileWithLayout.itemLayout = { ratioX, ratioY, h, upCount };
+    testRenderer.update();
+    tileWithLayout.itemLayout.ratioX = -20;
+
+    expect(errorLog).toHaveBeenCalled();
+    // expect(logSpy).toHaveBeenCalledWith(
+    //   'itemLayout for Tile recieved an invaild value of -16 for ratioX'
+    // );
+    expect(tileWithLayout.itemLayout.ratioX).toBe(16);
+    //logSpy.console.error.mockRestore(); // restores original console log function
   });
 });

--- a/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.test.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.test.js
@@ -21,8 +21,15 @@ import withLayout from '.';
 import Tile from '../../components/Tile';
 import context from '../../globals/context';
 import { jest } from '@jest/globals';
+
 const createTileWithLayout = props =>
-  makeCreateComponent(withLayout(Tile))(props);
+  makeCreateComponent(
+    class TileExtended extends withLayout(Tile) {
+      static get _componentName() {
+        return 'TileExtended';
+      }
+    }
+  )(props);
 
 describe('withLayout', () => {
   let tileWithLayout, testRenderer;
@@ -95,18 +102,33 @@ describe('withLayout', () => {
     );
   });
 
-  it('should throw an error if a negative value is used', () => {
+  it('should throw a context error if a invalid value is used for ratioX', () => {
     const errLog = jest.spyOn(context, 'error');
     tileWithLayout.itemLayout = { ratioX: -20, ratioY, h, upCount };
     testRenderer.update();
-    // console.log('tileWithLayout constructor: ', tileWithLayout.constructor);
-    // console.log.console.log(
-    //   'tileWithLayout constructor name:',
-    //   tileWithLayout.constructor.name
-    // );
     expect(errLog).toHaveBeenCalled();
     expect(errLog).toHaveBeenCalledWith(
-      'itemLayout for Tile recieved an invaild value of -20 for ratioX'
+      'itemLayout for TileExtended received an invalid value of -20 for ratioX'
+    );
+  });
+
+  it('should throw a context error if a invalid value is used for ratioY', () => {
+    const errLog = jest.spyOn(context, 'error');
+    tileWithLayout.itemLayout = { ratioX, ratioY: -8, h, upCount };
+    testRenderer.update();
+    expect(errLog).toHaveBeenCalled();
+    expect(errLog).toHaveBeenCalledWith(
+      'itemLayout for TileExtended received an invalid value of -8 for ratioY'
+    );
+  });
+
+  it('should throw a context error if an invalid value is used for upCount', () => {
+    const errLog = jest.spyOn(context, 'error');
+    tileWithLayout.itemLayout = { ratioX, ratioY, h, upCount: -2 };
+    testRenderer.update();
+    expect(errLog).toHaveBeenCalled();
+    expect(errLog).toHaveBeenCalledWith(
+      'itemLayout for TileExtended received an invalid value of -2 for upCount'
     );
   });
 });

--- a/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.test.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.test.js
@@ -94,17 +94,12 @@ describe('withLayout', () => {
   });
 
   it('should throw an error if a negative value is used', () => {
-    const errorLog = new Error('Error');
-    tileWithLayout.itemLayout = { ratioX, ratioY, h, upCount };
+    jest.spyOn(context, 'error');
+    tileWithLayout.itemLayout = { ratioX: -20, ratioY, h, upCount };
     testRenderer.update();
-    tileWithLayout.itemLayout.ratioX = -20;
-    const spy = jest.spyOn(context, 'error');
-    expect(spy).toHaveBeenCalled();
-    // expect(logSpy).toHaveBeenCalledWith(
-    //   'itemLayout for Tile recieved an invaild value of -16 for ratioX'
-    // );
-    expect(tileWithLayout.itemLayout.ratioX).toBe(16);
-    //logSpy.console.error.mockRestore(); // restores original console log function
-    jest.clearAllMocks();
+    expect(context.error).toHaveBeenCalled();
+    expect(context.error).toHaveBeenCalledWith(
+      'itemLayout for Tile recieved an invaild value of -20 for ratioX'
+    );
   });
 });

--- a/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.test.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.test.js
@@ -26,6 +26,7 @@ const createTileWithLayout = props =>
 
 describe('withLayout', () => {
   let tileWithLayout, testRenderer;
+
   const w = 320;
   const h = 180;
   const ratioY = 9;
@@ -39,6 +40,7 @@ describe('withLayout', () => {
   afterEach(() => {
     tileWithLayout = null;
     testRenderer = null;
+    jest.restoreAllMocks();
   });
 
   it('renders', () => {
@@ -94,11 +96,16 @@ describe('withLayout', () => {
   });
 
   it('should throw an error if a negative value is used', () => {
-    jest.spyOn(context, 'error');
+    const errLog = jest.spyOn(context, 'error');
     tileWithLayout.itemLayout = { ratioX: -20, ratioY, h, upCount };
     testRenderer.update();
-    expect(context.error).toHaveBeenCalled();
-    expect(context.error).toHaveBeenCalledWith(
+    // console.log('tileWithLayout constructor: ', tileWithLayout.constructor);
+    // console.log.console.log(
+    //   'tileWithLayout constructor name:',
+    //   tileWithLayout.constructor.name
+    // );
+    expect(errLog).toHaveBeenCalled();
+    expect(errLog).toHaveBeenCalledWith(
       'itemLayout for Tile recieved an invaild value of -20 for ratioX'
     );
   });


### PR DESCRIPTION
## Description

This PR updates withLayout mixin to only take positive integers for ratioX, ratioY and upCount.

- adds checks in `_alllowUpdate` to ensure that only positive numbers are used for ratioX, ratioY and upCount
- adds `min: 0` to `ratioX`, `ratioY` and `upCount` controls so that users can only input positive numbers

## References

LUI-684

## Testing

- clone branch
- yarn start
- go to withLayout story
-  try adjust the the ratioX, ratioY and upCount in controls, should only be able to adjust to a positive number
- to see context error, change one of the value in the story's args and look at the console


## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
