### PR TITLE
fix(ListItemPicker): fix selection reset when switching modes

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemPicker.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemPicker.js
@@ -62,6 +62,7 @@ export default class ListItemPicker extends ListItem {
     this._updateArrowsAlpha();
     this._updateAlignment();
     this._previousMode = this.mode;
+    this._previousTone = this.tone;
   }
 
   _updateAlignment() {
@@ -149,7 +150,11 @@ export default class ListItemPicker extends ListItem {
       h: this.style.descriptionTextStyle.lineHeight,
       w
     };
-    if (this._optionsChanged || this._previousMode !== this.mode) {
+    if (
+      this._optionsChanged ||
+      this._previousMode !== this.mode ||
+      this._previousTone !== this.tone
+    ) {
       patchObject.items = this.options.map(option => ({
         type: Marquee,
         h: this.style.descriptionTextStyle.lineHeight,

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemPicker.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemPicker.js
@@ -61,8 +61,6 @@ export default class ListItemPicker extends ListItem {
     this._updateArrows();
     this._updateArrowsAlpha();
     this._updateAlignment();
-    this._previousMode = this.mode;
-    this._previousTone = this.tone;
   }
 
   _updateAlignment() {
@@ -145,17 +143,11 @@ export default class ListItemPicker extends ListItem {
         }
       });
     }
-    const patchObject = {
+    this._Picker.patch({
       visible: !this._collapse,
       h: this.style.descriptionTextStyle.lineHeight,
-      w
-    };
-    if (
-      this._optionsChanged ||
-      this._previousMode !== this.mode ||
-      this._previousTone !== this.tone
-    ) {
-      patchObject.items = this.options.map(option => ({
+      w,
+      items: this.options.map(option => ({
         type: Marquee,
         h: this.style.descriptionTextStyle.lineHeight,
         w,
@@ -164,12 +156,10 @@ export default class ListItemPicker extends ListItem {
           ...this.style.descriptionTextStyle,
           text: option
         }
-      }));
+      })),
       // We need to reset the selected index to ensure it does not get reset to zero when patching items.
-      patchObject.selectedIndex = this.selectedIndex;
-      this._optionsChanged = false;
-    }
-    this._Picker.patch(patchObject);
+      selectedIndex: this.selectedIndex
+    });
     this._alignPicker();
   }
 
@@ -198,11 +188,6 @@ export default class ListItemPicker extends ListItem {
           : alpha;
     }
     this.fireAncestors('$announce', this.announce);
-  }
-
-  _setOptions(options) {
-    this._optionsChanged = options !== this._options;
-    return options;
   }
 
   get _fixedWordWrapWidth() {

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemPicker.test.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemPicker.test.js
@@ -116,7 +116,12 @@ describe('ListItemPicker', () => {
     );
   });
 
-  it('should update the value of alpha in focused mode', () => {
+  it('should update the value of alpha in each mode', () => {
+    listItemPicker.mode = 'unfocused';
+    testRenderer.forceAllUpdates();
+    expect(listItemPicker._LeftArrow.alpha).toEqual(0);
+    expect(listItemPicker._RightArrow.alpha).toEqual(0);
+
     listItemPicker.mode = 'focused';
     testRenderer.forceAllUpdates();
     expect(listItemPicker._LeftArrow.alpha).toEqual(
@@ -125,6 +130,11 @@ describe('ListItemPicker', () => {
     expect(listItemPicker._RightArrow.alpha).toEqual(
       listItemPicker.style.arrowAlphaValue
     );
+
+    listItemPicker.mode = 'disabled';
+    testRenderer.forceAllUpdates();
+    expect(listItemPicker._LeftArrow.alpha).toEqual(0);
+    expect(listItemPicker._RightArrow.alpha).toEqual(0);
   });
 
   it('should collapse description in unfocused mode when shouldCollapse flag is true', () => {


### PR DESCRIPTION
## Description

This PR resolves an issue where the selection in ListItemPicker would be reset if the mode was changed. It also fixes a separate issue where the arrows would show up if the tone was changed and then the mode was set to unfocused/disabled.

## References

LUI-692

## Testing

Reset issue:

1. Navigate to ListItemPicker story.
2. Press right to get to either the "Description2" or "Description3" option.
3. Change the mode to unfocused or disabled.
4. The description text should remain and not be reset to "Description1" anymore.

Arrow issue:

1. Navigate to ListItemPicker story.
2. Press right to get to either the "Description1" or "Description3" option.
3. Change the tone to inverse and the mode to unfocused or disabled.
4. There should not be any arrows on the ListItemPicker.

## Automation

No story arguments are affected by these changes.

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
