### PR TITLE
fix(withThemeStyles): add story documentation

### DIFF
--- a/packages/@lightningjs/ui-components/src/docs/ThemingHierarchy.stories.mdx
+++ b/packages/@lightningjs/ui-components/src/docs/ThemingHierarchy.stories.mdx
@@ -16,12 +16,29 @@
   SPDX-License-Identifier: Apache-2.0
 -->
 
-
 import { Meta, Description } from '@storybook/addon-docs';
 import Flowchart from '../assets/images/Flowchart.png';
 
 <Meta title="Docs / Theming/ Hierarchy" />
 
 # Theming Hierarchy
-
+<br />
 <img src={Flowchart} alt="" width="600" />
+
+The above flowchart serves to demonstrate how the different theming-related concepts covered in previous documentation come together to build the final styles for each component.
+
+## Component Style File
+
+A component's style file can consist of a base style object, a [tone style object](path=/docs/docs-theming-tone--page), and a [mode style object](path=/docs/docs-theming-mode--page). These three objects are deep merged, in that order, to create a single style object that serves as the foundation for the final component style object.
+
+## Theme's _componentConfig_
+
+Themes can have a `componentConfig` object that has nested component style objects, which serve to override any styles from component style files. The objects nested within `componentConfig` must have keys matching the `__componentName` of the target components. These are deep merged with the results from each of those files.
+
+## In-line Component Style Overrides
+
+When utilizing components within your application, you can use [withThemeStyles](path=/docs/utilities-withthemestyles--with-theme-styles) to override particular style values in just that use case. Those defined styles are merged with the result of the merge that happened above.
+
+## Extensions
+
+Any extensions that target your component are then merged with the result after in-line component style overrides to create the final component style object that will be referenced by your application's components.

--- a/packages/@lightningjs/ui-components/src/docs/ThemingHierarchy.stories.mdx
+++ b/packages/@lightningjs/ui-components/src/docs/ThemingHierarchy.stories.mdx
@@ -37,8 +37,8 @@ Themes can have a `componentConfig` object that has nested component style objec
 
 ## In-line Component Style Overrides
 
-When utilizing components within your application, you can use [withThemeStyles](path=/docs/utilities-withthemestyles--with-theme-styles) to override particular style values in just that use case. Those defined styles are merged with the result of the merge that happened above.
+When utilizing components within your application, you can use [withThemeStyles](path=/docs/utilities-withthemestyles--with-theme-styles) to override particular style values in just that use case. Those custom styles are deep-merged with the resulting object from the previous steps.
 
 ## Extensions
 
-Any extensions that target your component are then merged with the result after in-line component style overrides to create the final component style object that will be referenced by your application's components.
+Any extensions that target a component will be applied after the in-line component style overrides. This creates the final style object which will be referenced by the component via `this.style`.

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/withThemeStyles.mdx
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/withThemeStyles.mdx
@@ -1,0 +1,139 @@
+<!--
+  Copyright 2023 Comcast Cable Communications Management, LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+import { Canvas, Story } from '@storybook/addon-docs';
+# withThemeStyles
+
+Use `withThemeStyles` to create composable components that can be easily themed and decoupled from functionality.
+
+The `withThemeStyles` mixin provides flexibility with _composability_: the concept of combining the properties of multiple components to create a new component. This is not intended to be a replacement for building a component API, but rather a tool for augmentation.
+
+<Canvas>
+  <Story id="utilities-withthemestyles--with-theme-styles" />
+</Canvas>
+
+## Usage
+
+Let's use an example to see how we can use `withThemeStyles`. Let's say you have an unstyled `Box` component with a defined width and height:
+
+```js
+import lng from '@lightningjs/core';
+
+class Box extends lng.Component {
+  static _template() {
+    return {
+      w: 150,
+      h: 150,
+      rect: true
+    };
+  }
+}
+```
+
+If you want to re-use this `Box` to create a _new_ component called `BlueBox`, you can do that by extending the base class.
+
+```js
+class BlueBox extends Box {
+  static _template() {
+    return {
+      ...super._template(),
+      color: 0xff0000ff
+    };
+  }
+}
+```
+
+This is fine if you want a box that is always blue, but what if you want to change the color of your component without having to extend it and override that single value? Or if you want a box that changes based on certain factors, such as its [mode](?path=/docs/docs-theming-mode--page)? Or what if you want to have multiple color palettes (in LUI, these are called [tones](?path=/docs/docs-theming-tone--page)) that you can switch between depending on if your application is in light or dark mode?
+
+By utilizing `withThemeStyles`, you can tie the color of your box to the tokens used in your theme or a single style object. This can be done in the following ways.
+
+### Defining a Style Object
+
+The first (and suggested) way of handling styles is to wrap your component in the `withThemeStyles` mixin, and then define the `__themeStyle` getter.
+
+```js
+const style = {
+  color: 0xff0000ff
+};
+
+class Box extends withThemeStyles(lng.Component) {
+  static get __componentName() {
+    return 'Box';
+  }
+
+  static get __themeStyle() {
+    return style;
+  }
+
+  static _template() {
+    return {
+      w: 150,
+      h: 150,
+      rect: true
+    };
+  }
+
+  _update() {
+    this.color = this.style.color;
+  }
+}
+```
+
+With this setup, `Box` is able to have its color tied to a style value that exists outside of the `Box` class. This enables us to change the value of color externally, without the need to change any code in the `Box` class. Thus, the class can remain focused on the functional aspects of the component, and all style-related properties can be handled elsewhere.
+
+### Passing In a Style Object
+
+The second (and less preferred option) is to wrap your component in `withThemeStyles` and to pass in your style object as the second argument.
+
+```js
+const style = {
+  color: 0xff0000ff
+};
+
+class Box extends lng.Component {
+  static get __componentName() {
+    return 'Box';
+  }
+
+  static _template() {
+    return {
+      w: 150,
+      h: 150,
+      rect: true
+    };
+  }
+
+  _update() {
+    this.color = this.style.color;
+  }
+}
+
+class NewComponent extends lng.Component {
+  _template() {
+    Box: {
+      type: withThemeStyles(Box, style);
+    }
+  }
+}
+```
+
+This method is usually more appropriate for in-line styling, rather than defining the styles of a new component. This is because you rely on the component already being set up for use with theming, and this method will only apply the given styles to that particular instance of your component. (We advise changes to be made to all instances of a component when possible to ensure proper adherence to your design system.)
+
+In both cases, you'll notice that there is a `__componentName` getter in our `Box` class. This name is what is used to reference our component for any overrides and extension assignments that might exist in our theme's `componentConfig`.
+
+For more information on all of the ways you can set up your styles to fully utilize this mixin, read through the [Theming Documentation](?path=/docs/docs-theming-overview--page).

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/withThemeStyles.mdx
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/withThemeStyles.mdx
@@ -30,7 +30,7 @@ The `withThemeStyles` mixin provides flexibility with _composability_: the conce
 
 ## Usage
 
-Let's use an example to see how we can use `withThemeStyles`. Let's say you have an unstyled `Box` component with a defined width and height:
+Here is an example of applying `withThemeStyles`. Start with an un-styled `Box` component containing a defined width and height.
 
 ```js
 import lng from '@lightningjs/core';
@@ -46,7 +46,7 @@ class Box extends lng.Component {
 }
 ```
 
-If you want to re-use this `Box` to create a _new_ component called `BlueBox`, you can do that by extending the base class.
+In order to re-use this `Box` to create a new component called `BlueBox`, we can extend the base class.
 
 ```js
 class BlueBox extends Box {
@@ -61,11 +61,13 @@ class BlueBox extends Box {
 
 This is fine if you want a box that is always blue, but what if you want to change the color of your component without having to extend it and override that single value? Or if you want a box that changes based on certain factors, such as its [mode](?path=/docs/docs-theming-mode--page)? Or what if you want to have multiple color palettes (in LUI, these are called [tones](?path=/docs/docs-theming-tone--page)) that you can switch between depending on if your application is in light or dark mode?
 
-By utilizing `withThemeStyles`, you can tie the color of your box to the tokens used in your theme or a single style object. This can be done in the following ways.
+By utilizing `withThemeStyles`, you can tie the color of your box to the tokens used in your theme or a single style object. The preferred way of accomplishing this is by extending the `Base` component, which utilizes `withThemeStyles` and saves you from additional setup.
+
+If you are not extending the `Base` component, you can style your component in the following ways.
 
 ### Defining a Style Object
 
-The first (and suggested) way of handling styles is to wrap your component in the `withThemeStyles` mixin, and then define the `__themeStyle` getter.
+The first way of handling styles is to wrap your component in the `withThemeStyles` mixin, and then define the `__themeStyle` getter.
 
 ```js
 const style = {
@@ -95,11 +97,15 @@ class Box extends withThemeStyles(lng.Component) {
 }
 ```
 
-With this setup, `Box` is able to have its color tied to a style value that exists outside of the `Box` class. This enables us to change the value of color externally, without the need to change any code in the `Box` class. Thus, the class can remain focused on the functional aspects of the component, and all style-related properties can be handled elsewhere.
+With this setup, the `Box` component's `color` property is mapped to a style value external to the `Box` class. This enables us to change the value of color externally, without the need to change any code in the `Box` class. Thus, the class can remain focused on the functional aspects of the component, and all style-related properties can be handled elsewhere.
+
+It is worth noting that this method ensures all instances of your component are styled the same. If you need to style individual instances differently, another method is recommended.
 
 ### Passing In a Style Object
 
-The second (and less preferred option) is to wrap your component in `withThemeStyles` and to pass in your style object as the second argument.
+The second option is to wrap your component in `withThemeStyles` and to pass in your style object as the second argument.
+
+This method is usually more appropriate for in-line styling, rather than defining the styles of a new component. This is because you rely on the component already being set up for use with theming, and this method will only apply the given styles to that particular instance of your component. (We advise changes to be made to all instances of a component when possible to ensure proper adherence to your design system.)
 
 ```js
 const style = {
@@ -132,8 +138,6 @@ class NewComponent extends lng.Component {
   }
 }
 ```
-
-This method is usually more appropriate for in-line styling, rather than defining the styles of a new component. This is because you rely on the component already being set up for use with theming, and this method will only apply the given styles to that particular instance of your component. (We advise changes to be made to all instances of a component when possible to ensure proper adherence to your design system.)
 
 In both cases, you'll notice that there is a `__componentName` getter in our `Box` class. This name is what is used to reference our component for any overrides and extension assignments that might exist in our theme's `componentConfig`.
 

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/withThemeStyles.mdx
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/withThemeStyles.mdx
@@ -17,6 +17,7 @@
 -->
 
 import { Canvas, Story } from '@storybook/addon-docs';
+
 # withThemeStyles
 
 Use `withThemeStyles` to create composable components that can be easily themed and decoupled from functionality.

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/withThemeStyles.stories.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/withThemeStyles.stories.js
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import lng from '@lightningjs/core';
 import mdx from './withThemeStyles.mdx';
 import withThemeStylesMixin from './index.js';

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/withThemeStyles.stories.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/withThemeStyles.stories.js
@@ -1,0 +1,75 @@
+import lng from '@lightningjs/core';
+import mdx from './withThemeStyles.mdx';
+import withThemeStylesMixin from './index.js';
+import { CATEGORIES } from 'lightning-ui-docs';
+import { context } from '../../globals';
+
+export default {
+  title: `${CATEGORIES[512]}/withThemeStyles`,
+  parameters: {
+    docs: {
+      page: mdx
+    }
+  }
+};
+
+export const withThemeStyles = () => {
+  const style = {
+    color: context.theme.color.fillNeutral
+  };
+
+  class Box extends withThemeStylesMixin(lng.Component) {
+    static get __componentName() {
+      return 'Box';
+    }
+
+    static get __themeStyle() {
+      return style;
+    }
+
+    static _template() {
+      return {
+        Box: {
+          w: 150,
+          h: 150,
+          rect: true
+        }
+      };
+    }
+
+    toggleColor(theme) {
+      this.tag('Box').color = theme ? this.style.color : 0xff0000ff;
+    }
+  }
+
+  return class withThemeStyles extends lng.Component {
+    static _template() {
+      return {
+        Box: {
+          type: Box
+        }
+      };
+    }
+  };
+};
+
+withThemeStyles.storyName = 'withThemeStyles';
+withThemeStyles.args = {
+  themeColor: true
+};
+withThemeStyles.argTypes = {
+  themeColor: {
+    control: 'boolean',
+    description: 'Should the box use the color from the theme?',
+    table: {
+      defaultValue: { summary: withThemeStyles.args.themeColor }
+    }
+  }
+};
+withThemeStyles.parameters = {
+  argActions: {
+    themeColor: (themeColor, component) => {
+      component.tag('Box').toggleColor(themeColor);
+    }
+  }
+};


### PR DESCRIPTION
## Description

This PR updates the story for `withThemeStyles`, and adds documentation for it and the Theming Hierarchy page.

## References

LUI-648

## Testing

1. Go to the `withThemeStyles` story.
2. Ensure that the square is white when the `themeColor` toggle is true and blue when false.
3. Please read through the `withThemeStyles` docs and the `Theming Hierarchy` page to see if everything is covered and makes sense.

## Automation

There is a new story for the `withThemeStyles` mixin.

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
