### PR TITLE
docs: add repository field to display in npm docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@lightningjs/monorepo",
   "version": "0.0.0",
   "description": "The Lightning-UI-Components repo utilizes yarn workspaces to combine all packages like ui-components and ui-components-test-utils.",
+  "repository": "https://github.com/rdkcentral/Lightning-UI-Components",
   "packageManager": "yarn@3.2.3",
   "private": true,
   "workspaces": [

--- a/packages/@lightningjs/ui-components-test-utils/package.json
+++ b/packages/@lightningjs/ui-components-test-utils/package.json
@@ -2,6 +2,10 @@
   "name": "@lightningjs/ui-components-test-utils",
   "version": "1.0.1",
   "description": "Helpful Jest unit test utilities for LightningJS applications utilizing the Lightning-UI-Components package.",
+  "repository": {
+    "url": "https://github.com/rdkcentral/Lightning-UI-Components",
+    "directory": "packages/@lightningjs/ui-components-test-utils"
+  },
   "type": "module",
   "exports": "./index.js",
   "files": [

--- a/packages/@lightningjs/ui-components-theme-base/package.json
+++ b/packages/@lightningjs/ui-components-theme-base/package.json
@@ -2,6 +2,10 @@
   "name": "@lightningjs/ui-components-theme-base",
   "version": "1.0.1",
   "description": "The generic theme containing all necessary properties for the Lightning-UI shared components to map to for styling.",
+  "repository": {
+    "url": "https://github.com/rdkcentral/Lightning-UI-Components",
+    "directory": "packages/@lightningjs/ui-components-theme-base"
+  },
   "type": "module",
   "main": "theme.js",
   "files": [

--- a/packages/@lightningjs/ui-components/package.json
+++ b/packages/@lightningjs/ui-components/package.json
@@ -2,6 +2,10 @@
   "name": "@lightningjs/ui-components",
   "version": "2.0.1",
   "description": "A shared library of helpful LightningJS components utilizing theme files to easily customize for any LightningJS application.",
+  "repository": {
+    "url": "https://github.com/rdkcentral/Lightning-UI-Components",
+    "directory": "packages/@lightningjs/ui-components"
+  },
   "sideEffects": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Currently, the repository link that can appear on the right side of the NPM docs for our packages is empty: https://www.npmjs.com/package/@lightningjs/ui-components.
This field should make it show up.

Docs on `repository` field: https://docs.npmjs.com/cli/v9/configuring-npm/package-json#repository

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
