### PR TITLE
fix: add index.js to ui-components package to fix skypack cdn

### DIFF
--- a/packages/@lightningjs/ui-components/package.json
+++ b/packages/@lightningjs/ui-components/package.json
@@ -48,6 +48,7 @@
     "lint-staged": "^13.0.3"
   },
   "files": [
+    "index.js",
     "dist/*",
     "src/*"
   ],


### PR DESCRIPTION
## Description

The [Lightning Playground ](https://lightningjs.io/playground) utilizes Skypack to add packages from npm. The Skypack CDN link for @lightningjs/ui-components is currently throwing an error since the index.js file specified in exports for 'src' is not included in the package.

<img width="1299" alt="Screen Shot 2023-03-08 at 6 23 24 AM" src="https://user-images.githubusercontent.com/2578683/223748245-fe61c262-8c66-47f7-9ad8-258233130c2a.png">

## References

- https://cdn.skypack.dev/error/build:@lightningjs/ui-components@v2.0.1-gUMijdRNRmjt505d96LE
- https://lightningjs.io/playground

## Testing

`yarn workspace @lightningjs/ui-components exec yarn pack` should result in a tarball in /packages/@lightningjs/ui-components that includes the index.js file

After release the UI Components package should work in the Lightning Playground

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
