### PR TITLE
fix: make sure src folders are included in releases

### DIFF
--- a/packages/@lightningjs/ui-components-test-utils/package.json
+++ b/packages/@lightningjs/ui-components-test-utils/package.json
@@ -9,7 +9,8 @@
   "type": "module",
   "exports": "./index.js",
   "files": [
-    "src/*"
+    "index.js",
+    "src/**"
   ],
   "peerDependencies": {
     "@lightningjs/core": "^2.9.0"

--- a/packages/@lightningjs/ui-components/package.json
+++ b/packages/@lightningjs/ui-components/package.json
@@ -53,8 +53,8 @@
   },
   "files": [
     "index.js",
-    "dist/*",
-    "src/*"
+    "src/**",
+    "dist/**"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Description

The src folders are not contained in the releases for ui-components and ui-components-test-utils

## Testing

Use yarn pack commands to inspect tarball and make sure proper files are included in package

- yarn workspace @lightningjs/ui-components exec yarn pack
- yarn workspace @lightningjs/ui-components-test-utils exec yarn pack

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
