### PR TITLE
test: update config to not print coverage table in terminal

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -23,7 +23,7 @@ module.exports = {
   clearMocks: true,
   collectCoverage: true,
   coverageDirectory: 'coverage',
-  coverageReporters: ['text', 'html'],
+  coverageReporters: ['html', 'text-summary'],
   coverageThreshold: {
     global: {
       statements: 85,
@@ -34,7 +34,9 @@ module.exports = {
   maxWorkers: '4',
   moduleFileExtensions: ['js', 'json', 'jsx', 'node', 'ts', 'tsx', 'mjs'],
   roots: ['<rootDir>/src'],
-  setupFilesAfterEnv: ['<rootDir>/../ui-components-test-utils/src/jest.env.setup.js'],
+  setupFilesAfterEnv: [
+    '<rootDir>/../ui-components-test-utils/src/jest.env.setup.js'
+  ],
   testEnvironment: '<rootDir>/../ui-components-test-utils/src/lng-test-env',
   testEnvironmentOptions: { url: 'http://localhost', resources: 'usable' },
   transform: {},

--- a/packages/@lightningjs/ui-components/jest.config.mjs
+++ b/packages/@lightningjs/ui-components/jest.config.mjs
@@ -29,7 +29,6 @@ export default {
     '!**/coverage/**',
     '!**/docs/**',
     '!<rootDir>/**/*.{stories,test,xtest,styles}.js',
-    '!<rootDir>/**/{Item,Styles}/*.js', // exclude temporary components
     '!<rootDir>/test/**'
   ],
 


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
The Jest files summary sometimes prints in the middle of the coverage table. This seems like an issue with Jest itself, but the table also just adds a ton of lines and makes parsing the information difficult. Instead, we can utilize the `index.html` file at `packages/@lightningjs/ui-components/coverage`, which provides an interactive way to check individual lines of code coverage.

We can always explore more options in the future, sure as a separate script to show the table, but that may require separate jest config files in order to change the `coverageReporters` array.

## Testing

<!-- step by step instructions to review this PR's changes -->
1. Run `yarn test`
2. Observe the table is no longer there, but a new coverage summary and test file count summary are.