### PR TITLE
fix(Input): update listening control in disabled mode

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Input/Input.js
+++ b/packages/@lightningjs/ui-components/src/components/Input/Input.js
@@ -206,20 +206,15 @@ export default class Input extends Button {
       if (this.cursorBlink && !this.cursorBlink.isPlaying()) {
         this.cursorBlink.start();
       }
-      this._Cursor.smooth = {
-        alpha: 0,
-        color: this.style.cursorStyle.textColor
-      };
     } else {
-      this._Cursor.smooth = {
-        alpha: this.listening ? 1 : 0,
-        color: this.style.cursorStyle.textColor
-      };
       if (this.cursorBlink)
         this.isCursorActive
           ? this.cursorBlink.start()
           : this.cursorBlink.stop();
     }
+    this._Cursor.smooth = {
+      color: this.style.cursorStyle.textColor
+    };
   }
 
   _updateCursorBlink() {

--- a/packages/@lightningjs/ui-components/src/components/Input/Input.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Input/Input.mdx
@@ -61,7 +61,7 @@ class Example extends lng.Component {
 
 ### Setting/Inserting values
 
-"The `Input` component tracks its current value and cursor position, and provides different ways to manage the value state. When the listening mode is enabled, the cursor blinks as a `placeholder`, whether the component is in focused or unfocused mode."
+The `Input` component tracks its current value and cursor position, and provides different ways to manage the value state. When the listening mode is enabled, the cursor blinks as a `placeholder`, whether the component is in focused or unfocused mode.
 
 ```js
 this.tag('Input').value = 'Hello';

--- a/packages/@lightningjs/ui-components/src/components/Input/Input.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Input/Input.mdx
@@ -61,7 +61,7 @@ class Example extends lng.Component {
 
 ### Setting/Inserting values
 
-The `Input` component keeps track of it's current `value` and cursor `position`. You can manage the value state in a few ways. Let's work off of the above example. We see the cursor blinking which is the `placeholder` value when listening mode is true and component in focused mode.
+The `Input` component keeps track of it's current `value` and cursor `position`. You can manage the value state in a few ways. Let's work off of the above example. We see the cursor blinking which is the `placeholder` value when listening mode is true and component in focused and unfocused mode.
 
 ```js
 this.tag('Input').value = 'Hello';
@@ -100,6 +100,18 @@ this.tag('Input').position = 1;
 this.tag('Input').backspace();
 this.tag('Input').value; //=> 'oo'
 this.tag('Input').position; //=> 0
+```
+
+### listening
+
+When listening property is true, it enables cursor to blink which then allow user to enter text.
+
+```js
+this.tag('Input').listening = true;
+When listening is true, the cursor blinks and allows user to enter text.
+
+this.tag('Input').listening = false;
+When listening is false, the cursor will not be visible and does not allow user to enter text.
 ```
 
 ### Cursor position

--- a/packages/@lightningjs/ui-components/src/components/Input/Input.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Input/Input.mdx
@@ -61,7 +61,7 @@ class Example extends lng.Component {
 
 ### Setting/Inserting values
 
-The `Input` component keeps track of it's current `value` and cursor `position`. You can manage the value state in a few ways. Let's work off of the above example. We see the cursor blinking which is the `placeholder` value when listening mode is true and component in focused and unfocused mode.
+"The `Input` component tracks its current value and cursor position, and provides different ways to manage the value state. When the listening mode is enabled, the cursor blinks as a `placeholder`, whether the component is in focused or unfocused mode."
 
 ```js
 this.tag('Input').value = 'Hello';
@@ -102,16 +102,16 @@ this.tag('Input').value; //=> 'oo'
 this.tag('Input').position; //=> 0
 ```
 
-### listening
+### Listening
 
-When listening property is true, it enables cursor to blink which then allow user to enter text.
+When `listening` is true, the cursor begins blinking and the user is able to enter text.
 
 ```js
 this.tag('Input').listening = true;
-When listening is true, the cursor blinks and allows user to enter text.
+//When listening is true, the cursor blinks and allows user to enter text.
 
 this.tag('Input').listening = false;
-When listening is false, the cursor will not be visible and does not allow user to enter text.
+//When listening is false, the cursor will not be visible and does not allow user to enter text.
 ```
 
 ### Cursor position

--- a/packages/@lightningjs/ui-components/src/components/Input/Input.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Input/Input.stories.js
@@ -102,7 +102,7 @@ const sharedArgTypes = {
     control: 'boolean',
     description: 'When true the content will be masked to the user',
     table: {
-      defaultValue: { summary: 'undefined' }
+      defaultValue: { summary: false }
     }
   },
   mask: {
@@ -117,7 +117,7 @@ const sharedArgTypes = {
     description:
       'When true cursor will be visible only in focused and unfocused mode and can edit the canvas',
     table: {
-      defaultValue: { summary: 'undefined' }
+      defaultValue: { summary: false }
     }
   },
   prefix: {


### PR DESCRIPTION
## Description

In this PR, I have fixed listening control issue in disabled mode.

## References

LUI-716

## Testing

Navigate to Input in disabled mode, try setting listening to true and make sure the cursor is not active in disabled mode and 
should be active only in focused and unfocused mode.
