### PR TITLE
fix(Keyboard): remove centerKeys control

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.stories.js
@@ -104,7 +104,11 @@ Keyboard.sharedArgTypes = {
     table: {
       defaultValue: { summary: false }
     }
-  },
+  }
+};
+
+Keyboard.argTypes = {
+  ...Keyboard.sharedArgTypes,
   centerKeys: {
     description: "Center the keys within it's set width of keyboard",
     control: 'boolean',
@@ -113,6 +117,4 @@ Keyboard.sharedArgTypes = {
     }
   }
 };
-
-Keyboard.argTypes = Keyboard.sharedArgTypes;
 Keyboard.parameters = {};

--- a/packages/@lightningjs/ui-components/src/components/Keyboard/KeyboardEmail.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/KeyboardEmail.stories.js
@@ -47,7 +47,6 @@ export const KeyboardEmail = () =>
   };
 KeyboardEmail.args = {
   centerKeyboard: false,
-  centerKeys: false,
   mode: 'focused'
 };
 KeyboardEmail.storyName = 'KeyboardEmail';

--- a/packages/@lightningjs/ui-components/src/components/Keyboard/KeyboardFullscreen.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/KeyboardFullscreen.stories.js
@@ -62,4 +62,13 @@ KeyboardFullscreen.args = {
   mode: 'focused'
 };
 KeyboardFullscreen.parameters = {};
-KeyboardFullscreen.argTypes = Keyboard.sharedArgTypes;
+KeyboardFullscreen.argTypes = {
+  ...Keyboard.sharedArgTypes,
+  centerKeys: {
+    description: "Center the keys within it's set width of keyboard",
+    control: 'boolean',
+    table: {
+      defaultValue: { summary: false }
+    }
+  }
+};

--- a/packages/@lightningjs/ui-components/src/components/Keyboard/KeyboardInput.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/KeyboardInput.stories.js
@@ -100,7 +100,6 @@ const sharedInputArgTypes = {
 
 InputWithQwerty.args = {
   centerKeyboard: false,
-  centerKeys: false,
   prefix: null,
   suffix: null,
   mode: 'focused'
@@ -162,7 +161,6 @@ export const InputWithEmail = () =>
 
 InputWithEmail.args = {
   centerKeyboard: false,
-  centerKeys: false,
   prefix: null,
   suffix: null,
   mode: 'focused'

--- a/packages/@lightningjs/ui-components/src/components/Keyboard/KeyboardNumbers.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/KeyboardNumbers.stories.js
@@ -57,6 +57,13 @@ KeyboardNumbers.args = {
 
 KeyboardNumbers.argTypes = {
   ...Keyboard.sharedArgTypes,
+  centerKeys: {
+    description: "Center the keys within it's set width of keyboard",
+    control: 'boolean',
+    table: {
+      defaultValue: { summary: false }
+    }
+  },
   defaultFormat: {
     description: 'Select the format of dialpad',
     control: 'radio',

--- a/packages/@lightningjs/ui-components/src/components/Keyboard/KeyboardQwerty.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/KeyboardQwerty.stories.js
@@ -50,7 +50,6 @@ KeyboardQwerty.storyName = 'KeyboardQwerty';
 
 KeyboardQwerty.args = {
   centerKeyboard: false,
-  centerKeys: false,
   mode: 'focused'
 };
 


### PR DESCRIPTION
## Description

In this PR, removed centerKeys control from KeyboardEmail, KeyboardNumbers, KeyboardInput and KeyboardQuerty components.

## References

LUI-727
