### PR TITLE
fix(NavigationManager): default scrollIndex to 0 if negative

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -408,6 +408,10 @@ export default class NavigationManager extends FocusManager {
       : this.style.neverScroll;
   }
 
+  _setScrollIndex(index) {
+    return index >= 0 ? index : 0;
+  }
+
   _getScrollIndex() {
     return this._scrollIndex !== undefined
       ? this._scrollIndex

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.test.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.test.js
@@ -235,6 +235,13 @@ describe('NavigationManager', () => {
       });
     });
 
+    describe('updating the index to scroll from (scrollIndex)', () => {
+      it('should not allow negative numbers', () => {
+        navigationManager.scrollIndex = -10;
+        expect(navigationManager.scrollIndex).toBe(0);
+      });
+    });
+
     describe('updating the index at which scrolling should stop (lastScrollIndex)', () => {
       it('should set the index to that of the last item when alwaysScroll is enabled', () => {
         [navigationManager] = createNavigationManager({


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Per Sabrina Powell, if a negative number is set for the scrollIndex of NavigationManager/Column/Row/etc., unexpected scroll behavior occurs.

Unfortunately, you can still set the value to be a negative number manually due to the way the Storybook number control works, however, it will be set to 0 internally by the component. If you use the up and down arrows on the number input control, you will not be able to go down past 0.

## Testing

<!-- step by step instructions to review this PR's changes -->
1. Navigate to a Row component story, like TitleRow: http://localhost:8000/?path=/story/navigation-titlerow--title-row
2. Manually update the `scrollIndex` to a negative number
3. Observe that the scroll behavior of the component treats it as if the scrollIndex were 0.

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
