### PR TITLE
fix(Provider): replace tomato icon with xfinity

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Provider/Provider.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Provider/Provider.mdx
@@ -69,13 +69,13 @@ class Basic extends lng.Component {
 
 ### Properties
 
-| name            | type    | required | default   | description                                                                      |
-| --------------- | ------- | -------- | --------- | -------------------------------------------------------------------------------- |
-| disableRadius   | boolean | false    | false     | if true, disables the application of the radius style property to Icon providers |
-| counterText     | string  | false    | undefined | text to override counter's default '+Number' functionality                       |
-| providers       | array   | true     | undefined | list of provider images                                                          |
-| providersHidden | number  | readonly | undefined | the number of providers that will be hidden by the counter                       |
-| visibleCount    | number  | true     | undefined | the number of providers to show before adding a counter                          |
+| name            | type    | required | default   | description                                                   |
+| --------------- | ------- | -------- | --------- | ------------------------------------------------------------- |
+| disableRadius   | boolean | false    | false     | if true, disables the radius style property to Icon providers |
+| counterText     | string  | false    | undefined | text to override counter's default '+Number' functionality    |
+| providers       | array   | true     | undefined | list of provider images                                       |
+| providersHidden | number  | readonly | undefined | the number of providers that will be hidden by the counter    |
+| visibleCount    | number  | true     | undefined | the number of providers to show before adding a counter       |
 
 ### Style Properties
 

--- a/packages/@lightningjs/ui-components/src/components/Provider/Provider.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Provider/Provider.stories.js
@@ -21,6 +21,7 @@ import ProviderComponent from '.';
 import { default as Icon } from '../Icon';
 import mdx from './Provider.mdx';
 import xfinityLogo from '../../assets/images/XfinityLogo16x9.png';
+import xfinity from '../../assets/images/Xfinity-Provider-Logo-Square.png';
 import { CATEGORIES } from '../../docs/constants';
 
 export default {
@@ -68,8 +69,8 @@ export const Provider = () =>
         Provider: {
           type: ProviderComponent,
           providers: Array(10).fill({
-            icon: 'https://upload.wikimedia.org/wikipedia/commons/b/b6/Tomato-Torrent-Icon.png',
-            announce: 'Tomato'
+            icon: xfinity,
+            announce: 'xfinity'
           }),
           visibleCount: 3
         }
@@ -88,8 +89,8 @@ export const WithCustomIconSize = () =>
           type: ProviderComponent,
           providers: [
             {
-              icon: 'https://upload.wikimedia.org/wikipedia/commons/b/b6/Tomato-Torrent-Icon.png',
-              announce: 'tomato'
+              icon: xfinity,
+              announce: 'xfinity'
             },
             {
               type: Icon,
@@ -100,8 +101,8 @@ export const WithCustomIconSize = () =>
               announce: 'XFinity Logo Wide'
             },
             ...Array.apply(null, { length: 8 }).map(() => ({
-              icon: 'https://upload.wikimedia.org/wikipedia/commons/b/b6/Tomato-Torrent-Icon.png',
-              announce: 'tomato'
+              icon: xfinity,
+              announce: 'xfinity'
             }))
           ],
           visibleCount: 3

--- a/packages/@lightningjs/ui-components/src/components/Provider/Provider.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Provider/Provider.test.js
@@ -20,7 +20,7 @@ import {
   pathToDataURI,
   makeCreateComponent
 } from '@lightningjs/ui-components-test-utils';
-import { Icon } from '@lightningjs/ui-components';
+import Icon from '../Icon';
 import Provider from '.';
 
 const iconSquare = pathToDataURI(
@@ -90,6 +90,14 @@ describe('Provider', () => {
     });
     expect(provider._Row.items[3]).not.toBeInstanceOf(Icon);
     expect(provider._Row.items[3].tag('Text').content).toBe('+17');
+  });
+
+  it('disables radius when flag is enabled', () => {
+    [provider, testRenderer] = createComponent({
+      providers: Array(20).fill(iconSquare)
+    });
+    provider.disableRadius = true;
+    expect(provider._Row.items[2].radius).toEqual(0);
   });
 
   it('displays the correct counter with custom counterText', () => {


### PR DESCRIPTION
## Description

In this PR, I have updated tomato icon in stories file with xfinity icon to be able to see the difference in radius when disableRadius control is toggled.

NOTE: Since we have only one base theme(Radius is 0 in base theme), you will not be able to see the visual difference in storybook while toggling disableRadius control, but I tested this on develop inner repo it is working as expected.

## References

LUI-697

