### PR TITLE
test(NavigationManager): adds skipped test for lastScrollIndex conditional

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -408,6 +408,10 @@ export default class NavigationManager extends FocusManager {
       : this.style.neverScroll;
   }
 
+  _setScrollIndex(index) {
+    return index >= 0 ? index : 0;
+  }
+
   _getScrollIndex() {
     return this._scrollIndex !== undefined
       ? this._scrollIndex

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.test.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.test.js
@@ -253,7 +253,20 @@ describe('NavigationManager', () => {
       });
 
       // TODO: see note for if (this._lastScrollIndex > this.items.length) conditional
-      xit('should prevent setting an index greater than that of the last item', () => {});
+      it('should prevent setting an index greater than that of the last item', async () => {
+        [navigationManager] = createNavigationManager(
+          {
+            alwaysScroll: true,
+            items: [baseItem, baseItem, baseItem]
+          },
+          { spyOnMethods: ['_updateLayout'] }
+        );
+        await navigationManager.__updateLayoutSpyPromise;
+        expect(navigationManager._lastScrollIndex).toBe(2);
+        navigationManager._lastScrollIndex = 5;
+        await navigationManager.__updateLayoutSpyPromise;
+        expect(navigationManager._lastScrollIndex).toBe(2);
+      });
     });
 
     describe('emitting an $itemChanged signal to all ancestors', () => {

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.test.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.test.js
@@ -235,6 +235,13 @@ describe('NavigationManager', () => {
       });
     });
 
+    describe('updating the index to scroll from (scrollIndex)', () => {
+      it('should not allow negative numbers', () => {
+        navigationManager.scrollIndex = -10;
+        expect(navigationManager.scrollIndex).toBe(0);
+      });
+    });
+
     describe('updating the index at which scrolling should stop (lastScrollIndex)', () => {
       it('should set the index to that of the last item when alwaysScroll is enabled', () => {
         [navigationManager] = createNavigationManager({


### PR DESCRIPTION
## Description

This PR adds the skipped test on the lastScrollIndex conditional. Left the comment above the test as a reminder if for some reason we decided this conditional check is no longer needed.

## References

LUI-702

## Testing

clone branch
run `yarn run test NavigationManager` all tests for Navigation Manager should run with no test skipping.

## Automation


## Checklist

- [X] all commented code has been removed
- [X] any new console issues have been resolved
- [X] code linter and formatter has been run
- [X] test coverage meets repo requirements
- [X] PR name matches the expected semantic-commit syntax
