### PR TITLE
test(NavigationManager): adds back skipped test for lastIndexScroll

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.test.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.test.js
@@ -253,7 +253,20 @@ describe('NavigationManager', () => {
       });
 
       // TODO: see note for if (this._lastScrollIndex > this.items.length) conditional
-      xit('should prevent setting an index greater than that of the last item', () => {});
+      it('should prevent setting an index greater than that of the last item', async () => {
+        [navigationManager] = createNavigationManager(
+          {
+            alwaysScroll: true,
+            items: [baseItem, baseItem, baseItem]
+          },
+          { spyOnMethods: ['_updateLayout'] }
+        );
+        await navigationManager.__updateLayoutSpyPromise;
+        expect(navigationManager._lastScrollIndex).toBe(2);
+        navigationManager._lastScrollIndex = 5;
+        await navigationManager.__updateLayoutSpyPromise;
+        expect(navigationManager._lastScrollIndex).toBe(2);
+      });
     });
 
     describe('emitting an $itemChanged signal to all ancestors', () => {

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.test.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.test.js
@@ -52,7 +52,7 @@ describe('NavigationManager', () => {
       expect(navigationManager.Items.children[0].w).toBe(w);
     });
 
-    it('should set the length dimension property to that of closest parent with that propety defined', () => {
+    it('should set the length dimension property to that of closest parent with that property defined', () => {
       const w = 500;
       class CompWithWidth extends lng.Component {
         static _template() {


### PR DESCRIPTION
## Description

The pr adds back skipped test for lastIndexScroll and adds the actual test for the conditional. I left the comment above the test as reminder if we decided to remove the conditional in `_updateLastScrollIndex`

## References

LUI-702

## Testing

Clone branch
run `yarn run test NavigationManager` all tests for NavigationManager should run and all tests should pass

## Automation

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
