### PR TITLE
feat(withLightning): allow configuring story to remount on prop changes

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Column/Column.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.stories.js
@@ -31,8 +31,7 @@ export default {
   parameters: {
     docs: {
       page: mdx
-    },
-    remountAll: true
+    }
   }
 };
 

--- a/packages/@lightningjs/ui-components/src/components/Column/Column.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.stories.js
@@ -31,7 +31,8 @@ export default {
   parameters: {
     docs: {
       page: mdx
-    }
+    },
+    remountAll: true
   }
 };
 

--- a/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.stories.js
@@ -47,13 +47,8 @@ export default {
       control: 'number',
       description:
         'Number of content items prior to last content items where a "loadMoreItems" signal is emitted. Go to the "Actions" pannel to see when signal is fired.',
+      remount: true,
       table: { defaultValue: { summary: 0 } }
-    },
-    lazyScroll: {
-      control: 'boolean',
-      description:
-        'Will only scroll the row if the item is off screen and alwaysScroll and neverScroll are both false',
-      table: { defaultValue: { summary: true } }
     }
   }
 };

--- a/packages/@lightningjs/ui-components/src/components/Marquee/Marquee.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Marquee/Marquee.stories.js
@@ -68,6 +68,7 @@ Marquee.argTypes = {
   autoStart: {
     control: 'boolean',
     description: 'Start scrolling on initiation',
+    remount: true,
     table: { defaultValue: { summary: false } }
   },
   color: {
@@ -79,11 +80,13 @@ Marquee.argTypes = {
   repeat: {
     control: { type: 'number', min: -1 },
     description: 'Number of times to repeat scrolling',
+    remount: true,
     table: { defaultValue: { summary: -1 } }
   },
   delay: {
     control: { type: 'number', min: 1.5 },
     description: 'Delay before scrolling starts',
+    remount: true,
     table: { defaultValue: { summary: 1.5 } }
   },
   centerAlign: {

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
@@ -52,24 +52,28 @@ const sharedArgTypes = {
     control: { type: 'number', min: 0 },
     description:
       'Item index at which scrolling begins, provided the sum of item widths is greater than the width of the Row',
+    remount: true,
     table: { defaultValue: { summary: 0 } }
   },
   alwaysScroll: {
     control: 'boolean',
     description:
       'Determines whether the row will stop scrolling as it nears the right to prevent white space',
+    remount: true,
     table: { defaultValue: { summary: false } }
   },
   neverScroll: {
     control: 'boolean',
     description:
       'If true, the row will never scroll, unless alwaysScroll is set to true, and if false, the row will apply normal scrolling logic',
+    remount: true,
     table: { defaultValue: { summary: false } }
   },
   lazyScroll: {
     control: 'boolean',
     description:
       'Will only scroll the row if the item is off screen and alwaysScroll and neverScroll are both false',
+    remount: true,
     table: { defaultValue: { summary: false } }
   }
 };

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
@@ -31,7 +31,8 @@ export default {
   parameters: {
     docs: {
       page: mdx
-    }
+    },
+    remountAll: true
   }
 };
 
@@ -52,28 +53,24 @@ const sharedArgTypes = {
     control: { type: 'number', min: 0 },
     description:
       'Item index at which scrolling begins, provided the sum of item widths is greater than the width of the Row',
-    remount: true,
     table: { defaultValue: { summary: 0 } }
   },
   alwaysScroll: {
     control: 'boolean',
     description:
       'Determines whether the row will stop scrolling as it nears the right to prevent white space',
-    remount: true,
     table: { defaultValue: { summary: false } }
   },
   neverScroll: {
     control: 'boolean',
     description:
       'If true, the row will never scroll, unless alwaysScroll is set to true, and if false, the row will apply normal scrolling logic',
-    remount: true,
     table: { defaultValue: { summary: false } }
   },
   lazyScroll: {
     control: 'boolean',
     description:
       'Will only scroll the row if the item is off screen and alwaysScroll and neverScroll are both false',
-    remount: true,
     table: { defaultValue: { summary: false } }
   }
 };

--- a/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.stories.js
@@ -23,6 +23,16 @@ import mdx from './TitleRow.mdx';
 import { default as TitleRowComponent } from '.';
 import { CATEGORIES } from '../../docs/constants';
 
+// add remount to all Row argTypes individually since Row uses remountAll
+// TitleRow title prop can be updated without requiring a remount
+const rowArgTypes = Object.keys(RowBasic.argTypes).reduce((acc, key) => {
+  acc[key] = {
+    ...RowBasic.argTypes[key],
+    remount: key !== 'mode'
+  };
+  return acc;
+}, {});
+
 export default {
   title: `${CATEGORIES[64]}/TitleRow`,
   parameters: {
@@ -42,7 +52,7 @@ export default {
         defaultValue: { summary: 'undefined' }
       }
     },
-    ...RowBasic.argTypes
+    ...rowArgTypes
   }
 };
 

--- a/packages/@lightningjs/ui-components/src/mixins/withEditItems/withEditItems.stories.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withEditItems/withEditItems.stories.js
@@ -31,7 +31,8 @@ export default {
   parameters: {
     docs: {
       page: mdx
-    }
+    },
+    remountAll: true
   }
 };
 

--- a/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
+++ b/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
@@ -28,10 +28,13 @@ export const withLightning = (
   StoryComponent,
   { id, args, argTypes, parameters, globals }
 ) => {
-  let triggerUpdate = previousID !== id;
+  const storyChanged = previousID !== id;
+  let triggerUpdate = storyChanged;
   previousID = id;
 
-  if (triggerUpdate) {
+  if (parameters.remountAll) {
+    triggerUpdate = true;
+  } else if (storyChanged) {
     remountProps = {};
     Object.keys(argTypes).forEach(key => {
       if (argTypes[key].remount) {

--- a/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
+++ b/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright 2023 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,24 +34,28 @@ function shouldTriggerUpdate({ id, args, argTypes, parameters }) {
   let triggerUpdate = storyChanged;
   previousID = id;
 
-  if (parameters.remountAll && !Object.keys(remountProps).length) {
-    Object.keys(args).forEach(key => {
-      if (key === 'mode') {
-        return;
-      }
-      if (argTypes[key].remount) {
-        remountProps[key] = args[key];
-      }
-    });
-  } else if (storyChanged) {
+  // create remountProps object to track which props should trigger remounting
+  if (storyChanged) {
     remountProps = {};
-    Object.keys(argTypes).forEach(key => {
-      if (argTypes[key].remount) {
+    if (parameters.remountAll) {
+      // track all props except mode for triggering remount
+      Object.keys(args).forEach(key => {
+        if (key === 'mode') {
+          return;
+        }
         remountProps[key] = args[key];
-      }
-    });
+      });
+    } else {
+      // track only props with truthy remount property on their associated argType
+      Object.keys(argTypes).forEach(key => {
+        if (argTypes[key].remount) {
+          remountProps[key] = args[key];
+        }
+      });
+    }
   }
 
+  // evaluate if any props tracked in remountProps changed and should trigger a remount
   Object.keys(remountProps).forEach(key => {
     if (remountProps[key] !== args[key]) {
       triggerUpdate = true;

--- a/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
+++ b/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
@@ -34,8 +34,15 @@ function shouldTriggerUpdate({ id, args, argTypes, parameters }) {
   let triggerUpdate = storyChanged;
   previousID = id;
 
-  if (parameters.remountAll) {
-    triggerUpdate = true;
+  if (parameters.remountAll && !Object.keys(remountProps).length) {
+    Object.keys(args).forEach(key => {
+      if (key === 'mode') {
+        return;
+      }
+      if (argTypes[key].remount) {
+        remountProps[key] = args[key];
+      }
+    });
   } else if (storyChanged) {
     remountProps = {};
     Object.keys(argTypes).forEach(key => {

--- a/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
+++ b/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
@@ -20,15 +20,33 @@ import { GridOverlay, context, utils } from '@lightningjs/ui-components';
 import { createApp, clearInspector } from '../../../index';
 
 let previousID = null;
+let remountProps = {};
 
 /** creates a global decorator that creates a single instance of the Lightning app */
 
 export const withLightning = (
   StoryComponent,
-  { id, args, parameters, globals }
+  { id, args, argTypes, parameters, globals }
 ) => {
-  const triggerUpdate = previousID !== id;
+  let triggerUpdate = previousID !== id;
   previousID = id;
+
+  if (triggerUpdate) {
+    remountProps = {};
+    Object.keys(argTypes).forEach(key => {
+      if (argTypes[key].remount) {
+        remountProps[key] = args[key];
+      }
+    });
+  }
+
+  Object.keys(remountProps).forEach(key => {
+    if (remountProps[key] !== args[key]) {
+      triggerUpdate = true;
+      remountProps[key] = args[key];
+    }
+  });
+
   const app = createApp({ theme: globals.LUITheme });
   clearInspector();
   app.announcerEnabled = globals.announce;


### PR DESCRIPTION
## Description
Updates withLightning to allow configuring a story to remount the component when specified args or all args on a story change.
### **Remount from only specific properties changing:** 
- add `remount: true` as a property to the argType of property
```js
SomeComponent.argTypes = {
scrollIndex: {
  control: { type: 'number', min: 0 },
  description: '...',
  table: { defaultValue: { summary: 0 } },
  remount: true // remount the story component when scrollIndex changes
}
```

### **Remount for all properties changes:** 
- add `remountAll` true to the `parameters object. `mode` will be excluded from the properties that trigger remounting.
```js
OtherComponent.parameters = {
  remountAll: true
}
```

## Testing
**parameters.remountAll has been set to `true` in `Row.stories.js`**
In all Row stories:
1. navigate to any item on the Row besides the first (which is the default)
2. change the value of any controls
ER: the Row should remount. This can be observed by the seeing the component reload into view, which will reset the selected item in the row to the first item

**parameters.remountAll has been set to `true` in `TitleRow.stories.js`**
In all TitleRow stories
1. navigate to any item on the TitleRow besides the first (which is the default)
2. change the value of any control, excluding `title`
ER: the TitleRow should remount. This can be observed by the seeing the component reload into view, which will reset the selected item in the row to the first item
3. repeat step 1, then change only the `title` to a new value
ER: the TitleRow should not remount. The item that was in focus after step 3 should remain in focus and not remount with the first item selected until a different control changes.
<!-- step by step instructions to review this PR's changes -->