### PR TITLE
fix(Tile): resolve last letter removal issue in Tile metadata

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Marquee/Marquee.js
+++ b/packages/@lightningjs/ui-components/src/components/Marquee/Marquee.js
@@ -267,7 +267,15 @@ export default class Marquee extends Base {
   }
 
   get textContent() {
-    return this.title && this.title.text ? this.title.text : this.title;
+    if (this.title) {
+      if (typeof this.title === 'string') {
+        return this.title;
+      }
+      if (typeof this.title.text === 'string') {
+        return this.title.text;
+      }
+    }
+    return '';
   }
 
   get _loopWidth() {

--- a/packages/@lightningjs/ui-components/src/components/Marquee/Marquee.js
+++ b/packages/@lightningjs/ui-components/src/components/Marquee/Marquee.js
@@ -267,15 +267,7 @@ export default class Marquee extends Base {
   }
 
   get textContent() {
-    if (this.title) {
-      if (typeof this.title === 'string') {
-        return this.title;
-      }
-      if (typeof this.title.text === 'string') {
-        return this.title.text;
-      }
-    }
-    return '';
+    return this.title?.text ?? this.title ?? '';
   }
 
   get _loopWidth() {

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
@@ -121,18 +121,17 @@ export default class TextBox extends Base {
       // as a parent component may need to control that (i.e. Control Button)
 
       // guard to make sure _notifyAncestors is not called numerous times for components like Input
+      this._updateMarquee();
       if (this._Text || this._InlineContent) {
         this.w = this.h = 0;
         this._notifyAncestors(); // need to alert parents that the width and height are now 0
         // makes sure that elements are removed
         this.patch({ Text: undefined, InlineContent: undefined });
       }
-
       return;
     }
 
     this._isInlineContent ? this._updateInlineContent() : this._updateText();
-
     this._updateMarquee();
   }
 

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
@@ -121,17 +121,18 @@ export default class TextBox extends Base {
       // as a parent component may need to control that (i.e. Control Button)
 
       // guard to make sure _notifyAncestors is not called numerous times for components like Input
-      this._updateMarquee();
       if (this._Text || this._InlineContent) {
         this.w = this.h = 0;
         this._notifyAncestors(); // need to alert parents that the width and height are now 0
         // makes sure that elements are removed
+        this._updateMarquee();
         this.patch({ Text: undefined, InlineContent: undefined });
       }
+
       return;
     }
-
     this._isInlineContent ? this._updateInlineContent() : this._updateText();
+    this._updateMarquee();
   }
 
   _updateInlineContent() {

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
@@ -132,7 +132,6 @@ export default class TextBox extends Base {
     }
 
     this._isInlineContent ? this._updateInlineContent() : this._updateText();
-    this._updateMarquee();
   }
 
   _updateInlineContent() {


### PR DESCRIPTION
## Description

In this PR updated:
- In TextBox `this._updateMarquee() `is moved before the patches to Text and InlineContent to undefined. That change will now allow TextBox to update the Marquee component within it when content has been removed.
- In Marquee updated the getter for `Marquee.textContent` to only return strings and default to an empty string

## References

LUI-723

## Testing

Navigate to the Tile component  in the Storybook.
Try removing the Metadata Title or Description text and make sure it removes the entire text in canvas if you remove the entire text in controls.

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
