### PR TITLE
feat(withLightning): allow adding descriptions to canvas with story

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Column/Column.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.stories.js
@@ -367,6 +367,11 @@ export const CenteredInParent = () =>
     }
   };
 
+CenteredInParent.parameters = {
+  storyDetails:
+    'Each Row in the Column has centerInParent set to true on it so is horizontally centered in the Column it is an item of.'
+};
+
 class ColumnHeader extends lng.Component {
   static _template() {
     return {
@@ -590,7 +595,7 @@ LazyUpCount.argTypes = {
   lazyUpCount: {
     control: { type: 'number', min: 0 },
     description:
-      'Number of items to create on screen and new items will be created as user presses right on row.',
+      'Number of items to create on screen and new items will be created as user presses down on column.',
     table: { defaultValue: { summary: 'undefined' } }
   },
   alwaysScroll: {
@@ -599,6 +604,10 @@ LazyUpCount.argTypes = {
       'Determines whether the column will stop scrolling as it nears the bottom to prevent white space',
     table: { defaultValue: { summary: false } }
   }
+};
+LazyUpCount.parameters = {
+  storyDetails:
+    'There are 20 items initially passed to this Column. Then number of items that are initially rendered equals the sum of the lazyUpCount and 2. Each time the next item is selected, an additional item is added to the end of the Column until all 20 items have been rendered.'
 };
 
 export const AddingItems = args =>
@@ -652,7 +661,7 @@ export const AddingItems = args =>
             title: 'New Button 5'
           }
         ]);
-      }, 3750);
+      }, 4000);
     }
   };
 AddingItems.args = {
@@ -665,6 +674,10 @@ AddingItems.argTypes = {
       'Item index at which scrolling begins, provided the sum of item heights is greater than the height of the Column',
     table: { defaultValue: { summary: 0 } }
   }
+};
+AddingItems.parameters = {
+  storyDetails:
+    '3 seconds after rendering, 3 new buttons are added at index 3 of the Column via Column.appendItemsAt. 4 seconds after rendering, 3 additional buttons are added at start of the Column via Column.prependItems.'
 };
 
 export const RemovingItems = args =>
@@ -698,4 +711,8 @@ RemovingItems.argTypes = {
       'Item index at which scrolling begins, provided the sum of item heights is greater than the height of the Column',
     table: { defaultValue: { summary: 0 } }
   }
+};
+RemovingItems.parameters = {
+  storyDetails:
+    '3 seconds after rendering, the button at index 1 in the Column is removed via Column.removeItemAt.'
 };

--- a/packages/@lightningjs/ui-components/src/components/Column/Column.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.stories.js
@@ -607,7 +607,7 @@ LazyUpCount.argTypes = {
 };
 LazyUpCount.parameters = {
   storyDetails:
-    'There are 20 items initially passed to this Column. Then number of items that are initially rendered equals the sum of the lazyUpCount and 2. Each time the next item is selected, an additional item is added to the end of the Column until all 20 items have been rendered.'
+    'There are 20 items passed to this Column. The number of items that are initially rendered equals the sum of the lazyUpCount property and 2. Each time the next item is selected, an additional item is added to the end of the Column until all 20 items have been rendered.'
 };
 
 export const AddingItems = args =>

--- a/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.stories.js
@@ -139,6 +139,10 @@ export const LazyLoading = () =>
   };
 
 LazyLoading.args = { lazyLoadBuffer: 1 };
+LazyLoading.parameters = {
+  storyDetails:
+    'The loadMoreItems signal is emitted each time a contentItem is selected at and after the index defined by the lazyLoadBuffer property. This story adds a method that is invoked when that signal is emitted and adds 3 additional contentItems to the ControlRow via ControlRow.addContentItems. That method will append items twice, then will do nothing when it is invoked from the signal.'
+};
 
 export const AddingAndRemoving = () =>
   class AddingAndRemoving extends lng.Component {

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
@@ -239,6 +239,10 @@ export const CenteredInParent = () =>
       };
     }
   };
+CenteredInParent.parameters = {
+  storyDetails:
+    'This Row has 2 Columns as items. The second Column with 1 Button as an item has the centerInParent property enabled so it is vertically centered in the Row.'
+};
 
 export const Plinko = () => {
   return class Plinko extends lng.Component {
@@ -320,10 +324,6 @@ SkipFocus.argTypes = {
       'Enables wrapping behavior, so selectNext() selects the first item if the current item is the last on the list and vice versa',
     table: { defaultValue: { summary: false } }
   }
-};
-SkipFocus.parameters = {
-  storyDetails:
-    'The first item in the Row has a truthy skipFocus property so is not focusable.'
 };
 
 export const LazyScrollIndexes = ({
@@ -428,7 +428,7 @@ export const AddingItems = () =>
             w: 150
           }
         ]);
-      }, 3750);
+      }, 4000);
     }
   };
 AddingItems.args = {
@@ -436,6 +436,10 @@ AddingItems.args = {
 };
 AddingItems.argTypes = {
   ...sharedArgTypes
+};
+AddingItems.parameters = {
+  storyDetails:
+    '3 seconds after rendering, 3 new buttons are added at index 3 of the Row via Row.appendItemsAt. 4 seconds after rendering, 3 additional buttons are added at start of the Row via Row.prependItems. '
 };
 
 export const LazyUpCount = args =>
@@ -476,6 +480,10 @@ LazyUpCount.argTypes = {
     }
   }
 };
+LazyUpCount.parameters = {
+  storyDetails:
+    'There are 12 items passed to this Row. The number of items that are initially rendered equals the sum of the lazyUpCount and the lazyUpCountBuffer properties. Each time the next item is selected, an additional item is added to the end of the Row until all 12 items have been rendered.'
+};
 
 export const RemovingItems = () =>
   class RemovingItems extends lng.Component {
@@ -501,4 +509,8 @@ RemovingItems.args = {
 };
 RemovingItems.argTypes = {
   ...sharedArgTypes
+};
+RemovingItems.parameters = {
+  storyDetails:
+    '3 seconds after rendering, the button at index 1 in the Row is removed via Row.removeItemAt.'
 };

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
@@ -321,6 +321,10 @@ SkipFocus.argTypes = {
     table: { defaultValue: { summary: false } }
   }
 };
+SkipFocus.parameters = {
+  storyDetails:
+    'The first item in the Row has a truthy skipFocus property so is not focusable.'
+};
 
 export const LazyScrollIndexes = ({
   startLazyScrollIndex,
@@ -364,6 +368,10 @@ LazyScrollIndexes.argTypes = {
       'Index of item in items, and items preceding, at which lazy scrolling should occur',
     table: { defaultValue: { summary: 0 } }
   }
+};
+LazyScrollIndexes.parameters = {
+  storyDetails:
+    'Items before the item at startLazyScrollIndex and after the item at stopLazyScrollIndex will use alwaysScroll. Items at and between startLazyScrollIndex and stopLazyScrollIndex will use lazyScroll.'
 };
 
 export const AddingItems = () =>

--- a/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.stories.js
@@ -134,6 +134,9 @@ export const Basic = args =>
 
 Basic.args = sharedArgs;
 Basic.argTypes = sharedArgTypes;
+Basic.parameters = {
+  storyDetails: 'The ScrollWrapper content property is set as a string.'
+};
 
 export const TextArray = args =>
   class TextArray extends lng.Component {
@@ -174,6 +177,10 @@ export const TextArray = args =>
 
 TextArray.args = sharedArgs;
 TextArray.argTypes = sharedArgTypes;
+TextArray.parameters = {
+  storyDetails:
+    'The ScrollWrapper content property is set as an array of text objects. See the InlineContent documentation for more details on these types of objects.'
+};
 
 export const ObjectArray = args =>
   class ObjectArray extends lng.Component {
@@ -234,3 +241,7 @@ export const ObjectArray = args =>
 
 ObjectArray.args = sharedArgs;
 ObjectArray.argTypes = sharedArgTypes;
+ObjectArray.parameters = {
+  storyDetails:
+    'The ScrollWrapper content property is set as an array of Lightning elements.'
+};

--- a/packages/@lightningjs/ui-components/src/components/Slider/Slider.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Slider/Slider.stories.js
@@ -122,3 +122,8 @@ SignalHandling.args = {
 };
 
 SignalHandling.argTypes = createModeControl({ summaryValue: 'focused' });
+
+SignalHandling.parameters = {
+  storyDetails:
+    'When the onChange signal is emitted from the Slider the number in the TextBox is updated with the Slider value.'
+};

--- a/packages/@lightningjs/ui-components/src/components/Slider/SliderLarge.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Slider/SliderLarge.stories.js
@@ -107,3 +107,8 @@ SignalHandlingLarge.args = {
 };
 
 SignalHandlingLarge.argTypes = createModeControl({ summaryValue: 'focused' });
+
+SignalHandlingLarge.parameters = {
+  storyDetails:
+    'When the onChange signal is emitted from the Slider the number in the TextBox is updated with the Slider value.'
+};

--- a/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
+++ b/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
@@ -151,10 +151,16 @@ export const withLightning = (
   // // forces position update on theme change instead of just when triggerUpdate is true
   context.on('themeUpdate', () => {
     app.tag('StoryComponent') &&
-      app.tag('StoryComponent').patch({
-        x: context.theme.layout.marginX,
-        y: context.theme.layout.marginY
-      });
+      app.tag('StoryComponent').patch(
+        parameters.storyDetails
+          ? {
+              x: context.theme.layout.marginX
+            }
+          : {
+              x: context.theme.layout.marginX,
+              y: context.theme.layout.marginY
+            }
+      );
   });
   if (!app.tag('GridOverlay')) {
     app.childList.a({ GridOverlay: { type: GridOverlay, zIndex: 100 } });
@@ -185,7 +191,13 @@ export const withLightning = (
             }
           },
           x: context.theme.spacer.sm,
-          y: context.theme.spacer.sm
+          y: context.theme.spacer.sm,
+          onAfterUpdate: ({ y, h }) => {
+            if (h > context.theme.layout.marginY) {
+              console.log(y + h + context.theme.spacer.xl);
+              app.tag('StoryComponent').y = y + h + context.theme.spacer.xl;
+            }
+          }
         }
       };
       app.childList.a(StoryDetails);

--- a/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
+++ b/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
@@ -16,7 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GridOverlay, context, utils } from '@lightningjs/ui-components';
+import {
+  GridOverlay,
+  context,
+  utils,
+  TextBox
+} from '@lightningjs/ui-components';
 import { createApp, clearInspector } from '../../../index';
 
 let previousID = null;
@@ -165,6 +170,29 @@ export const withLightning = (
     showGutters: globals['GridOverlay-toggle-showGutters'] === 'true',
     showText: globals['GridOverlay-toggle-showText'] === 'true'
   });
+
+  // add optional story description to the canvas
+  if (parameters.storyDetails) {
+    if (!app.tag('StoryDetails')) {
+      const StoryDetails = {
+        StoryDetails: {
+          type: TextBox,
+          content: parameters.storyDetails,
+          style: {
+            textStyle: {
+              wordWrapWidth:
+                context.theme.layout.screenW - context.theme.spacer.sm * 2
+            }
+          },
+          x: context.theme.spacer.sm,
+          y: context.theme.spacer.sm
+        }
+      };
+      app.childList.a(StoryDetails);
+    }
+
+    app.tag('StoryDetails').patch({ content: parameters.storyDetails });
+  }
 
   const LightningUIComponent = app.tag('StoryComponent').childList.first;
 


### PR DESCRIPTION
## Description
Adds optional story parameter field, `storyDetails`, to allow adding a text description of a story on the canvas with it.

<img width="1665" alt="Screen Shot 2023-03-22 at 11 21 27 AM" src="https://user-images.githubusercontent.com/17414565/226952740-ef0e675b-f581-43be-b779-64d5d79adb2d.png">

## Testing
To demonstrate usage of this, I added descriptions to both Row/SkipFocus and Row/LazyScrollIndexes stories. View both those stories to confirm the text is visible in the story. Navigate to any other story, and there should be no text above the component as usual.
<!-- step by step instructions to review this PR's changes -->
