### PR TITLE
fix(TabBar): adds column container story for scrolling tab content

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
@@ -316,6 +316,14 @@ class ColumnContainer extends Base {
   _getFocused() {
     return this._Column;
   }
+
+  _update() {
+    //super.update();
+    this._updateTilePadding();
+  }
+  _updateTilePadding() {
+    console.log(this);
+  }
 }
 
 export const MultipleRows = () =>

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
@@ -283,14 +283,14 @@ class ColumnContainer extends Base {
     return {
       ClippingOffsetContainer: {
         w: 1920 - 160,
-        h: 500,
+        h: 600,
         clipping: true,
-        y: context.theme.layout.gutterY.sm * -1,
-        x: context.theme.layout.marginX * -1,
+        y: context.theme.layout.gutterY.xs * -1,
+        x: 40 * -1,
         Column: {
           type: Column,
-          y: context.theme.layout.gutterY.sm,
-          x: context.theme.layout.marginX,
+          y: 30,
+          x: 40,
           items: [
             {
               type: Row,
@@ -299,20 +299,39 @@ class ColumnContainer extends Base {
             },
             {
               type: Row,
+
               items: tilesA,
               autoResizeHeight: true
             },
             {
               type: Row,
+
               items: tilesA,
               autoResizeHeight: true
             },
             {
               type: Row,
+
               items: tilesA,
               autoResizeHeight: true
             }
-          ]
+          ],
+          onScreenEffect: function (onScreenItems) {
+            if (!(this instanceof Column)) return;
+            if (this.items && this.items.length) {
+              this.items.forEach((item, idx) => {
+                if (!(this instanceof Column)) return;
+                if (
+                  onScreenItems.includes(item) &&
+                  this.selectedIndex === this.items.length - 1
+                ) {
+                  item.alpha = 1; // so last row and second last row still show
+                } else if (idx < this.selectedIndex) {
+                  item.alpha = 0.5;
+                }
+              });
+            }
+          }
         }
       }
     };
@@ -336,7 +355,7 @@ export const MultipleRows = () =>
             },
             {
               type: Tab,
-              title: 'Tab 1',
+              title: 'Multiple Rows',
               tabContent: {
                 type: ColumnContainer
               }
@@ -353,5 +372,8 @@ export const MultipleRows = () =>
   };
 
 MultipleRows.args = {};
-
+MultipleRows.parameters = {
+  storyDetails:
+    'This is an example of adding multiple rows in the tab content column. A ColumnContainer was created to allow for clipping needed for scrolling'
+};
 MultipleRows.argTypes = {};

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
@@ -285,8 +285,12 @@ class ColumnContainer extends Base {
         w: 1920 - 160,
         h: 500,
         clipping: true,
+        y: context.theme.layout.gutterY.sm * -1,
+        x: context.theme.layout.marginX * -1,
         Column: {
           type: Column,
+          y: context.theme.layout.gutterY.sm,
+          x: context.theme.layout.marginX,
           items: [
             {
               type: Row,
@@ -315,14 +319,6 @@ class ColumnContainer extends Base {
   }
   _getFocused() {
     return this._Column;
-  }
-
-  _update() {
-    //super.update();
-    this._updateTilePadding();
-  }
-  _updateTilePadding() {
-    console.log(this);
   }
 }
 

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
@@ -330,7 +330,7 @@ export const MultipleRows = () =>
       return {
         TabBar: {
           type: TabBarComponent,
-          w: 1920 - 160,
+          w: context.theme.layout.marginX * 2,
           tabs: [
             {
               type: Tab,

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
@@ -289,6 +289,7 @@ class ColumnContainer extends Base {
         x: 40 * -1,
         Column: {
           type: Column,
+          y: context.theme.layout.gutterY.xs,
           x: 40,
           items: [
             {

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
@@ -331,7 +331,6 @@ export const MultipleRows = () =>
       return {
         TabBar: {
           type: TabBarComponent,
-          w: context.theme.layout.marginX * 2,
           autoResizeWidth: true,
           tabs: [
             {

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
@@ -289,7 +289,6 @@ class ColumnContainer extends Base {
         x: 40 * -1,
         Column: {
           type: Column,
-          y: 30,
           x: 40,
           items: [
             {
@@ -315,23 +314,7 @@ class ColumnContainer extends Base {
               items: tilesA,
               autoResizeHeight: true
             }
-          ],
-          onScreenEffect: function (onScreenItems) {
-            if (!(this instanceof Column)) return;
-            if (this.items && this.items.length) {
-              this.items.forEach((item, idx) => {
-                if (!(this instanceof Column)) return;
-                if (
-                  onScreenItems.includes(item) &&
-                  this.selectedIndex === this.items.length - 1
-                ) {
-                  item.alpha = 1; // so last row and second last row still show
-                } else if (idx < this.selectedIndex) {
-                  item.alpha = 0.5;
-                }
-              });
-            }
-          }
+          ]
         }
       }
     };

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
@@ -17,6 +17,7 @@
  */
 
 import lng from '@lightningjs/core';
+import Base from '../Base';
 import Tile from '../Tile';
 import Button from '../Button';
 import ButtonSmall from '../Button/ButtonSmall.js';
@@ -268,6 +269,55 @@ CustomTabs.args = {
 };
 CustomTabs.argTypes = {};
 
+class ColumnContainer extends Base {
+  static get __componentName() {
+    return 'ColumnContainer';
+  }
+  static get tags() {
+    return [
+      'ClippingOffsetContainer',
+      { name: 'Column', path: 'ClippingOffsetContainer.Column' }
+    ];
+  }
+  static _template() {
+    return {
+      ClippingOffsetContainer: {
+        w: 1920 - 160,
+        h: 500,
+        clipping: true,
+        Column: {
+          type: Column,
+          items: [
+            {
+              type: Row,
+              items: tilesA,
+              autoResizeHeight: true
+            },
+            {
+              type: Row,
+              items: tilesA,
+              autoResizeHeight: true
+            },
+            {
+              type: Row,
+              items: tilesA,
+              autoResizeHeight: true
+            },
+            {
+              type: Row,
+              items: tilesA,
+              autoResizeHeight: true
+            }
+          ]
+        }
+      }
+    };
+  }
+  _getFocused() {
+    return this._Column;
+  }
+}
+
 export const MultipleRows = () =>
   class MultipleRows extends lng.Component {
     static _template() {
@@ -275,55 +325,26 @@ export const MultipleRows = () =>
         TabBar: {
           type: TabBarComponent,
           w: 1920 - 160,
+          h: 200,
           tabs: [
             {
               type: Tab,
+              zIndex: 10,
               title: 'No Content Tab'
             },
             {
               type: Tab,
               title: 'Tab 1',
+              zIndex: 10,
               tabContent: {
-                type: Column,
-                h: 400, // random for testing
-                y: 40, // random for testing
-                // clipping: true, this should be set but where?
-                items: [
-                  {
-                    type: Row,
-                    items: tilesA,
-                    autoResizeHeight: true,
-                    lazyScroll: true
-                  },
-                  {
-                    type: Row,
-                    items: tilesA,
-                    autoResizeHeight: true,
-                    lazyScroll: true
-                  },
-                  {
-                    type: Row,
-                    items: tilesA,
-                    autoResizeHeight: true,
-                    lazyScroll: true
-                  }
-                ]
+                type: ColumnContainer
               }
             },
             {
               type: Tab,
+              zIndex: 10,
               title: 'Tab 2',
               tabContent: col1
-            },
-            {
-              type: Tab,
-              title: 'Tab 3',
-              tabContent: rowFunction
-            },
-            {
-              type: Tab,
-              title: 'Tab 4',
-              tabContent: colPromise
             }
           ]
         }

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
@@ -325,24 +325,20 @@ export const MultipleRows = () =>
         TabBar: {
           type: TabBarComponent,
           w: 1920 - 160,
-          h: 200,
           tabs: [
             {
               type: Tab,
-              zIndex: 10,
               title: 'No Content Tab'
             },
             {
               type: Tab,
               title: 'Tab 1',
-              zIndex: 10,
               tabContent: {
                 type: ColumnContainer
               }
             },
             {
               type: Tab,
-              zIndex: 10,
               title: 'Tab 2',
               tabContent: col1
             }

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
@@ -332,6 +332,7 @@ export const MultipleRows = () =>
         TabBar: {
           type: TabBarComponent,
           w: context.theme.layout.marginX * 2,
+          autoResizeWidth: true,
           tabs: [
             {
               type: Tab,

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.stories.js
@@ -267,3 +267,70 @@ CustomTabs.args = {
   alphaSelectedTab: false
 };
 CustomTabs.argTypes = {};
+
+export const MultipleRows = () =>
+  class MultipleRows extends lng.Component {
+    static _template() {
+      return {
+        TabBar: {
+          type: TabBarComponent,
+          w: 1920 - 160,
+          tabs: [
+            {
+              type: Tab,
+              title: 'No Content Tab'
+            },
+            {
+              type: Tab,
+              title: 'Tab 1',
+              tabContent: {
+                type: Column,
+                h: 400, // random for testing
+                y: 40, // random for testing
+                // clipping: true, this should be set but where?
+                items: [
+                  {
+                    type: Row,
+                    items: tilesA,
+                    autoResizeHeight: true,
+                    lazyScroll: true
+                  },
+                  {
+                    type: Row,
+                    items: tilesA,
+                    autoResizeHeight: true,
+                    lazyScroll: true
+                  },
+                  {
+                    type: Row,
+                    items: tilesA,
+                    autoResizeHeight: true,
+                    lazyScroll: true
+                  }
+                ]
+              }
+            },
+            {
+              type: Tab,
+              title: 'Tab 2',
+              tabContent: col1
+            },
+            {
+              type: Tab,
+              title: 'Tab 3',
+              tabContent: rowFunction
+            },
+            {
+              type: Tab,
+              title: 'Tab 4',
+              tabContent: colPromise
+            }
+          ]
+        }
+      };
+    }
+  };
+
+MultipleRows.args = {};
+
+MultipleRows.argTypes = {};


### PR DESCRIPTION
## Description

This PR adds a story in TabBar to show how adding a container helps expected scroll behavior when  TabBar content has multiple rows

## References

LUI-717

## Testing

- clone branch
- go to Tabar Multiple Rows story 
- navigate to Tab 1
- press down arrow to set focus on first row
- continue pressing down, former rows should not be visiable
 

## Automation


## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
