### PR TITLE
fix(Button): update content width

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Button/Button.js
+++ b/packages/@lightningjs/ui-components/src/components/Button/Button.js
@@ -193,7 +193,7 @@ export default class Button extends Surface {
 
     // reference transition targets to ensure we aren't checking against intermittent values
     if (this._Content.transition('w').targetValue !== this._contentW) {
-      contentDimensionsPatch.w = this._contentW;
+      this._Content.w = this._contentW;
     }
 
     if (this._Content.y !== y) {


### PR DESCRIPTION
## Description

The text was sliding from right to left instead of being mounted. Updated Button text sliding to be mounted. 

## References

LUI-674

## Testing

<!-- step by step instructions to review this PR's changes -->

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
