### PR TITLE
fix(ScrollWrapper): prevent excessive stage updates by checking final dimensions of TextBox

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.js
+++ b/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.js
@@ -92,10 +92,9 @@ export default class ScrollWrapper extends Base {
 
   _afterTextBoxUpdate(textBox) {
     // NOTE: this does get called every time ScrollWrapper updates (ex. on each scroll change)
-    if (this._prevW !== textBox.w) {
-      this._prevW = textBox.w;
-      // ScrollContainer uses flexbox, ensure a full stage layout so finalH is accurate
-      this.stage.update();
+    if (this._prevW !== textBox.finalW || this._prevH !== textBox.finalH) {
+      this._prevW = textBox.finalW;
+      this._prevH = textBox.finalH;
       this._updateScrollWrapperLayout();
       this._updateAlpha();
     }


### PR DESCRIPTION
## Description
In an application using Lightning UI Components, a bug was observed where the ScrollWrapper would not display its vertical slider. I believe this issue was caused by `this.stage.update()` being called within a method assigned to the `onAfterUpdate` property of a TextBox. Prior to `onAfterUpdate` being utilized in ScrollWrapper, `this.stage.update()` was called to ensure accurate finalW and finalH measurements of flex item elements in ScrollWrapper. Per [Lightning's Element TS type definition](https://github.com/rdkcentral/Lightning/blob/master/src/tree/Element.d.mts#L1226-L1229), `onAfterUpdate` is "called after the Element's flexbox layout is updated', so I believe `this.stage.update()` is no longer required to get the accurate final measurements. Although no errors/warnings were thrown, it seems calling `this.stage.update()` within `onAfterUpdate` yields unexpected results and could cause elements lower in the render tree to not be rendered.
<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## Testing
- view ScrollWrapper story and verify a scroll bar is rendered when there is scrollable content
<!-- step by step instructions to review this PR's changes -->