### PR TITLE
fix(Input): add TS definitions for public properties and methods

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Input/Input.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Input/Input.d.ts
@@ -39,6 +39,7 @@ export default class Input extends Button {
   mask?: string;
   password?: boolean;
   position?: number;
+  get isCursorActive(): boolean;
   get style(): InputStyle;
   set style(v: StylePartial<InputStyle>);
 
@@ -47,4 +48,11 @@ export default class Input extends Button {
   get _HelpText(): lng.Component;
   get _Cursor(): lng.Component;
   get _HiddenContent(): lng.Component;
+
+  // public methods
+  clear: () => void;
+  insert: (content: string) => void;
+  backspace: () => void;
+  moveLeft: () => void;
+  moveRight: () => void;
 }


### PR DESCRIPTION
## Description
Adds a public property and methods that were previously not included in the `Input` component's TypeScript definition file.

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References
Addresses issue 1 of 3 in https://github.com/rdkcentral/Lightning-UI-Components/issues/176
>The Input field is missing type definitions for the insert(x: string) and backspace() methods. These methods are functional but not defined in the type spec of the input.
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
1. view the Input component at `packages/@lightningjs/ui-components/src/components/Input/Input.js`
2. compare it to the Input TS definition at `packages/@lightningjs/ui-components/src/components/Input/Input.d.ts`
ER: all public properties and methods in the Input component are defined in the TS def file.
<!-- step by step instructions to review this PR's changes -->

## Automation
N/A
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
