### PR TITLE
fix(Input): add value getter and setter to match documentation

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Input/Input.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Input/Input.d.ts
@@ -39,9 +39,8 @@ export default class Input extends Button {
   mask?: string;
   password?: boolean;
   position?: number;
+  value?: string;
   get isCursorActive(): boolean;
-  set value(value: string);
-  get value(): string;
   get style(): InputStyle;
   set style(v: StylePartial<InputStyle>);
 

--- a/packages/@lightningjs/ui-components/src/components/Input/Input.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Input/Input.d.ts
@@ -40,6 +40,8 @@ export default class Input extends Button {
   password?: boolean;
   position?: number;
   get isCursorActive(): boolean;
+  set value(value: string);
+  get value(): string;
   get style(): InputStyle;
   set style(v: StylePartial<InputStyle>);
 

--- a/packages/@lightningjs/ui-components/src/components/Input/Input.js
+++ b/packages/@lightningjs/ui-components/src/components/Input/Input.js
@@ -264,6 +264,16 @@ export default class Input extends Button {
     return this._fixedWordWrapWidth;
   }
 
+  set value(value) {
+    this.title = this.actualTitle = value;
+    this.position = 0;
+    this._updatePassword();
+  }
+
+  get value() {
+    return this.actualTitle;
+  }
+
   clear() {
     if (this.isCursorActive) {
       this.title = this.actualTitle = '';

--- a/packages/@lightningjs/ui-components/src/components/Input/Input.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Input/Input.mdx
@@ -71,7 +71,7 @@ The cursor position can be manually updated by setting the `position` property. 
 // dislay Hello in the input
 this.tag('Input').value = 'Hello';
 
-// update the cursor position in the input from index 0 (before the H in Hellow) to index 5 (after the o in Hello)
+// update the cursor position in the input from index 0 (before the H in Hello) to index 5 (after the o in Hello)
 this.tag('Input').position = 5;
 ```
 

--- a/packages/@lightningjs/ui-components/src/components/Input/Input.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Input/Input.mdx
@@ -63,7 +63,7 @@ class Example extends lng.Component {
 
 The `Input` component provides different ways to manage the input text and cursor position. When the `listening` property is enabled, the cursor blinks as a placeholder, whether the component is in focused or unfocused mode.
 
-The text displayed in the `Input` can can be directly set via the `value` property. The following example will display the input with the text "Hello".
+The text displayed in the `Input` can be directly set via the `value` property. The following example will display the input with the text "Hello".
 Setting the `value` on the `Input` directly like this will remove any existing text in the input and set the cursor `position` in the Input to `0` (before the 'H' in 'Hello').
 The cursor position can be manually updated by setting the `position` property. Setting `value` and `position` like this will update the `Input` regardless of whether or not `listening` is enabled.
 
@@ -95,7 +95,7 @@ The `Input` must be in focused or unfocused mode and the `listening` property en
 this.tag('Input').clear();
 ```
 
-To handle insert deletions use the `backspace()` method. This will remove the character at the current cursor `position - 1` and moves the cursor back.
+To remove the character 1 position before the cursor position, use `backspace()`. This will remove that character and move the cursor back one position.
 The `Input` must be in focused or unfocused mode and the `listening` property enabled to use `backspace()`.
 
 ```js

--- a/packages/@lightningjs/ui-components/src/components/Input/Input.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Input/Input.mdx
@@ -61,19 +61,22 @@ class Example extends lng.Component {
 
 ### Setting/Inserting values
 
-The `Input` component tracks its current value and cursor position, and provides different ways to manage the value state. When the listening mode is enabled, the cursor blinks as a `placeholder`, whether the component is in focused or unfocused mode.
+The `Input` component provides different ways to manage the input text and cursor position. When the `listening` property is enabled, the cursor blinks as a placeholder, whether the component is in focused or unfocused mode.
+
+The text displayed in the `Input` can can be directly set via the `value` property. The following example will display the input with the text "Hello".
+Setting the `value` on the `Input` directly like this will remove any existing text in the input and set the cursor `position` in the Input to `0` (before the 'H' in 'Hello').
+The cursor position can be manually updated by setting the `position` property. Setting `value` and `position` like this will update the `Input` regardless of whether or not `listening` is enabled.
 
 ```js
+// dislay Hello in the input
 this.tag('Input').value = 'Hello';
-```
 
-Now we will see "Hello" in the input, but the cursor will be at the beginning of the text. We can set the position:
-
-```js
+// update the cursor position in the input from index 0 (before the H in Hellow) to index 5 (after the o in Hello)
 this.tag('Input').position = 5;
 ```
 
-If we want to set the value _and_ change the position, we can use the `insert()` method.
+To set the `value` _and_ update the `position` to after the last character in the added text, use the `insert()` method.
+The `Input` must be in focused or unfocused mode and the `listening` property enabled to use `insert()`.
 
 ```js
 this.tag('Input').insert('Hello');
@@ -85,13 +88,15 @@ this.tag('Input').position = 5;
 
 ### Deletion
 
-To clear the current value, use `clear()`. This also repositions the cursor.
+To clear the current value use `clear()`. This also repositions the cursor to index `0`.
+The `Input` must be in focused or unfocused mode and the `listening` property enabled to use `clear()`.
 
 ```js
 this.tag('Input').clear();
 ```
 
-Use the `backspace()` method to handle insert deletions. This will remove the character at the current cursor `position - 1` and moves the cursor back. To illustrate this behavior, let's look at a simple example:
+To handle insert deletions use the `backspace()` method. This will remove the character at the current cursor `position - 1` and moves the cursor back.
+The `Input` must be in focused or unfocused mode and the `listening` property enabled to use `backspace()`.
 
 ```js
 this.tag('Input').value = 'foo';

--- a/packages/@lightningjs/ui-components/src/components/Input/Input.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Input/Input.test.js
@@ -236,6 +236,22 @@ describe('Input', () => {
     expect(input._HiddenContent.alpha).toBe(0.001);
   });
 
+  it('should overwrite existing text when usign the value setter', () => {
+    expect(input.value).toBe('');
+    expect(input.position).toBe(0);
+
+    input.listening = true;
+    input.insert('foo');
+
+    expect(input.value).toBe('foo');
+    expect(input.position).toBe(3);
+
+    input.value = 'bar';
+
+    expect(input.value).toBe('bar');
+    expect(input.position).toBe(0);
+  });
+
   describe('when the input value width exceeds the input container width', () => {
     it('should keep the cursor and entered text in view', async () => {
       [input, testRenderer] = createInput(


### PR DESCRIPTION
## Description
Setting the text contents of the Input via the `value` property has been in the Input documentation but was not implemented. This change adds a setter and getter for the `value` property.  In addition, I revised the Input documentation on the various methods to provide more details and use consistent verbiage.

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References
Addresses issue 2 of 3 in https://github.com/rdkcentral/Lightning-UI-Components/issues/176
>The documentation includes information about setting the value directly using input.value = "newvalue", but this does not work, regardless of the listening setting.
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
I'm not sure there needs to be story for updating the Input with these setters. A unit test has been added to test this behavior, so running all unit tests should pass.
<!-- step by step instructions to review this PR's changes -->

## Automation
N/A
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
