### PR TITLE
fix(Tab): export Tab TS def at root

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/index.d.ts
@@ -84,7 +84,7 @@ export { default as ScrollWrapper, ScrollWrapperStyle } from './ScrollWrapper';
 export { default as Shadow, ShadowStyle } from './Shadow';
 export { default as Slider, SliderStyle } from './Slider';
 export { default as Surface, SurfaceStyle } from './Surface';
-export { default as TabBar, TabBarStyle } from './TabBar';
+export { default as TabBar, TabBarStyle, Tab, TabStyle } from './TabBar';
 export { default as TextBox, TextBoxStyle } from './TextBox';
 export { default as Tile, TileStyle } from './Tile';
 export { default as TitleRow, TitleRowStyle } from './TitleRow';


### PR DESCRIPTION
## Description
The `Tab` component's TypeScript definition was not being exported at the root of the project. This resulted in TypeScript users not seeing the component as a valid export from the package. This change updates the root export of TypeScript definitions to include `Tab` and `TabStyles`.
<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References
Addresses issue 3 of 3 in https://github.com/rdkcentral/Lightning-UI-Components/issues/176
> The Tab component does not appear to be exported from the package. I am only able to find the TabBar component.
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
In a project consuming `@lightningjs/ui-components` `Tab` should be visible in IntelliSense as a valid export from that package.
<!-- step by step instructions to review this PR's changes -->

## Automation
N/A
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
