### PR TITLE
chore(Keyboard): replace preview with canvas

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.mdx
@@ -16,7 +16,7 @@
   SPDX-License-Identifier: Apache-2.0
 -->
 
-import { Preview, Story } from '@storybook/addon-docs';
+import { Canvas, Story } from '@storybook/addon-docs';
 
 # Keyboard
 
@@ -45,9 +45,9 @@ class Example extends lng.Component {
 }
 ```
 
-<Preview>
-  <Story id="keyboard-keyboard--basic" />
-</Preview>
+<Canvas>
+  <Story id="keyboard-keyboard--keyboard" />
+</Canvas>
 
 To create your own formats, you can pass an object of arrays to represent each format.
 The array can be flat or two dimensional. If the keyboard is passed other params like `columnCount` or `rowCount`, both will auto layout the keyboard.


### PR DESCRIPTION
## Description

In this Pr, I have replaced preview with canvas in keyboard docs to be consistent with other components.

## Testing

Navigate to the Keyboard component in Storybook and verify if the canvas is visible in the Storybook docs section.

