### PR TITLE
fix: update Base, Surface, Button TS declarations to follow lightning/core subclassable components instructions

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Base/Base.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Base/Base.d.ts
@@ -19,18 +19,41 @@
 import lng from '@lightningjs/core';
 import { SpeechType } from '../../mixins/withAnnouncer';
 
-export default class Base extends lng.Component {
-  skipPlinko: boolean;
-  centerInParent: boolean;
-  _announce: SpeechType;
-  _whenEnabled: Promise<void>;
-  _getFocusScale(): number;
-  _getUnfocusScale(): number;
-  _update(): void;
-  _focus(): void;
-  _unfocus(): void;
-  _smooth?: boolean;
+declare namespace Base {
+  export interface TemplateSpec extends lng.Component.TemplateSpec {}
 
-  set announce(announce: SpeechType);
-  get announce(): SpeechType;
+  export interface EventMap extends lng.Component.EventMap {}
+
+  export interface TypeConfig extends lng.Component.TypeConfig {
+    skipPlinko: boolean;
+    centerInParent: boolean;
+    loaded?: Promise<void>;
+    _smooth?: boolean;
+    _announce: SpeechType;
+    _whenEnabled: Promise<void>;
+
+    isFullyOnScreen(): boolean;
+    getFocusScale(): unknown;
+    getUnfocusScale(): number;
+    _focus(): void;
+    _unfocus(): void;
+    _update(): void;
+
+    get _isDisabledMode(): boolean;
+    get _isUnfocusedMode(): boolean;
+    get _isFocusedMode(): boolean;
+
+    get shouldSmooth(): boolean;
+    set shouldSmooth(v: boolean);
+
+    set announce(announce: SpeechType);
+    get announce(): SpeechType;
+  }
 }
+
+declare class Base<
+  TemplateSpec extends Base.TemplateSpec = Base.TemplateSpec,
+  TypeConfig extends Base.TypeConfig = Base.TypeConfig
+> extends lng.Component<TemplateSpec, TypeConfig> {}
+
+export default Base;

--- a/packages/@lightningjs/ui-components/src/components/Base/Base.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Base/Base.d.ts
@@ -31,7 +31,7 @@ declare class Base<
   _whenEnabled: Promise<void>;
 
   isFullyOnScreen(): boolean;
-  getFocusScale(): unknown;
+  getFocusScale(): number;
   getUnfocusScale(): number;
   _focus(): void;
   _unfocus(): void;

--- a/packages/@lightningjs/ui-components/src/components/Base/Base.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Base/Base.d.ts
@@ -19,10 +19,22 @@
 import lng from '@lightningjs/core';
 import { SpeechType } from '../../mixins/withAnnouncer';
 
+declare namespace Base {
+  export interface TemplateSpec extends lng.Component.TemplateSpec {
+    skipPlinko: boolean;
+    centerInParent: boolean;
+    loaded?: Promise<void>;
+    _smooth?: boolean;
+    _announce: SpeechType;
+    _whenEnabled: Promise<void>;
+  }
+}
+
 declare class Base<
-  TemplateSpec extends lng.Component.TemplateSpec,
+  TemplateSpec extends Base.TemplateSpec,
   TypeConfig extends lng.Component.TypeConfig
 > extends lng.Component<TemplateSpec, TypeConfig> {
+  // redeclare properties in class declaration
   skipPlinko: boolean;
   centerInParent: boolean;
   loaded?: Promise<void>;
@@ -30,6 +42,7 @@ declare class Base<
   _announce: SpeechType;
   _whenEnabled: Promise<void>;
 
+  // methods/accessors should only be included in the class declaration
   isFullyOnScreen(): boolean;
   getFocusScale(): number;
   getUnfocusScale(): number;

--- a/packages/@lightningjs/ui-components/src/components/Base/Base.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Base/Base.d.ts
@@ -17,16 +17,29 @@
  */
 
 import lng from '@lightningjs/core';
-import { SpeechType } from '../../mixins/withAnnouncer';
 
 declare namespace Base {
   export interface TemplateSpec extends lng.Component.TemplateSpec {
-    skipPlinko: boolean;
+    /**
+     * string to be read by `withAnnouncer`
+     */
+    announce?: string;
+
+    /**
+     * when true, it places the child component in center of the parent
+     */
     centerInParent: boolean;
+
+    /**
+     * a promise that is resolved at the end of the component's `_construct` lifecycle method
+     * By default this is a resolved promise. Components can use _resetLoadedPromise if they require the functionality
+     */
     loaded?: Promise<void>;
-    _smooth?: boolean;
-    _announce: SpeechType;
-    _whenEnabled: Promise<void>;
+
+    /**
+     * when true, plinko will use the previous item to determine the horizontal index of the next focused item
+     */
+    skipPlinko: boolean;
   }
 }
 
@@ -34,31 +47,73 @@ declare class Base<
   TemplateSpec extends Base.TemplateSpec,
   TypeConfig extends lng.Component.TypeConfig
 > extends lng.Component<TemplateSpec, TypeConfig> {
-  // redeclare properties in class declaration
-  skipPlinko: boolean;
+  /**
+   * string to be read by `withAnnouncer`
+   */
+  announce?: string;
+
+  /**
+   * when true, it places the child component in center of the parent
+   */
   centerInParent: boolean;
+
+  /**
+   * a promise that is resolved at the end of the component's `_construct` lifecycle method
+   * By default this is a resolved promise. Components can use _resetLoadedPromise if they require the functionality
+   */
   loaded?: Promise<void>;
-  _smooth?: boolean;
-  _announce: SpeechType;
-  _whenEnabled: Promise<void>;
 
-  // methods/accessors should only be included in the class declaration
-  isFullyOnScreen(): boolean;
+  shouldSmooth?: boolean;
+
+  /**
+   * when true, plinko will use the previous item to determine the horizontal index of the next focused item
+   */
+  skipPlinko: boolean;
+
+  /**
+   * conditionally transitions in values based on the state of `shouldSmooth`
+   */
+  // TODO took a stab at these types, could probably make this type-safe
+  applySmooth(
+    // ref tag ref of target component
+    ref: lng.Component<lng.Component.TemplateSpecLoose>,
+
+    // patch object of properties to patch to target
+    patch: lng.Element.PatchTemplate,
+
+    // smooth object of properties to smooth to target
+    smooth: lng.Element.PatchTemplate
+  );
+
+  /**
+   * returns the layout.focusScale property of the current theme
+   */
   getFocusScale(): number;
-  getUnfocusScale(): number;
-  _focus(): void;
-  _unfocus(): void;
-  _update(): void;
 
+  /**
+   * returns default scale value, 1
+   */
+  getUnfocusScale(): number;
+
+  /**
+   * returns true if this component is fully within the stage and boundsMargin
+   */
+  isFullyOnScreen(): boolean;
+
+  /**
+   * check if the component is disabled
+   */
   get _isDisabledMode(): boolean;
-  get _isUnfocusedMode(): boolean;
+
+  /**
+   * check if the component is in focus
+   */
   get _isFocusedMode(): boolean;
 
-  get shouldSmooth(): boolean;
-  set shouldSmooth(v: boolean);
-
-  set announce(announce: SpeechType);
-  get announce(): SpeechType;
+  /**
+   * check if the component is unfocused
+   */
+  get _isUnfocusedMode(): boolean;
 }
 
 export default Base;

--- a/packages/@lightningjs/ui-components/src/components/Base/Base.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Base/Base.d.ts
@@ -19,41 +19,33 @@
 import lng from '@lightningjs/core';
 import { SpeechType } from '../../mixins/withAnnouncer';
 
-declare namespace Base {
-  export interface TemplateSpec extends lng.Component.TemplateSpec {}
-
-  export interface EventMap extends lng.Component.EventMap {}
-
-  export interface TypeConfig extends lng.Component.TypeConfig {
-    skipPlinko: boolean;
-    centerInParent: boolean;
-    loaded?: Promise<void>;
-    _smooth?: boolean;
-    _announce: SpeechType;
-    _whenEnabled: Promise<void>;
-
-    isFullyOnScreen(): boolean;
-    getFocusScale(): unknown;
-    getUnfocusScale(): number;
-    _focus(): void;
-    _unfocus(): void;
-    _update(): void;
-
-    get _isDisabledMode(): boolean;
-    get _isUnfocusedMode(): boolean;
-    get _isFocusedMode(): boolean;
-
-    get shouldSmooth(): boolean;
-    set shouldSmooth(v: boolean);
-
-    set announce(announce: SpeechType);
-    get announce(): SpeechType;
-  }
-}
-
 declare class Base<
-  TemplateSpec extends Base.TemplateSpec = Base.TemplateSpec,
-  TypeConfig extends Base.TypeConfig = Base.TypeConfig
-> extends lng.Component<TemplateSpec, TypeConfig> {}
+  TemplateSpec extends lng.Component.TemplateSpec,
+  TypeConfig extends lng.Component.TypeConfig
+> extends lng.Component<TemplateSpec, TypeConfig> {
+  skipPlinko: boolean;
+  centerInParent: boolean;
+  loaded?: Promise<void>;
+  _smooth?: boolean;
+  _announce: SpeechType;
+  _whenEnabled: Promise<void>;
+
+  isFullyOnScreen(): boolean;
+  getFocusScale(): unknown;
+  getUnfocusScale(): number;
+  _focus(): void;
+  _unfocus(): void;
+  _update(): void;
+
+  get _isDisabledMode(): boolean;
+  get _isUnfocusedMode(): boolean;
+  get _isFocusedMode(): boolean;
+
+  get shouldSmooth(): boolean;
+  set shouldSmooth(v: boolean);
+
+  set announce(announce: SpeechType);
+  get announce(): SpeechType;
+}
 
 export default Base;

--- a/packages/@lightningjs/ui-components/src/components/Base/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Base/index.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './Base';

--- a/packages/@lightningjs/ui-components/src/components/Base/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Base/index.d.ts
@@ -16,4 +16,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export * from './Base';
+export { default as default } from './Base';

--- a/packages/@lightningjs/ui-components/src/components/Button/Button.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Button/Button.d.ts
@@ -35,21 +35,34 @@ declare namespace Button {
   export interface TemplateSpec extends Surface.TemplateSpec {
     Content: typeof lng.Component<lng.Component.TemplateSpecLoose>;
     /**
+     * forces Button to have a statically set width
      * when true, `w` overrides dynamically calculated width
      */
     fixed?: boolean;
+
+    /**
+     * alignment of the button's content
+     */
     justify?: 'center' | 'left' | 'right';
+
+    /**
+     * Lightning components to be placed to the left of the title
+     */
     prefix?:
       | typeof lng.Component<lng.Component.TemplateSpecLoose>
       | Array<typeof lng.Component<lng.Component.TemplateSpecLoose>>;
 
     /**
-     * text contents of the Button
+     * Lightning components to be placed to the right of the title
      */
-    title?: string;
     suffix?:
       | typeof lng.Component<lng.Component.TemplateSpecLoose>
       | Array<typeof lng.Component<lng.Component.TemplateSpecLoose>>;
+
+    /**
+     * Button text
+     */
+    title?: string;
   }
 }
 
@@ -57,32 +70,29 @@ declare class Button<
   TemplateSpec extends Button.TemplateSpec,
   TypeConfig extends lng.Component.TypeConfig
 > extends Surface<TemplateSpec, TypeConfig> {
-  /**
-   * when true, `w` overrides dynamically calculated width
-   */
   fixed?: boolean;
-  justify?: 'center' | 'left' | 'right';
-  prefix?:
-    | lng.Component<lng.Component.TemplateSpecLoose>
-    | Array<lng.Component<lng.Component.TemplateSpecLoose>>;
 
-  /**
-   * text contents of the Button
-   */
-  title?: string;
+  justify?: 'center' | 'left' | 'right';
+
+  prefix?:
+    | typeof lng.Component<lng.Component.TemplateSpecLoose>
+    | Array<typeof lng.Component<lng.Component.TemplateSpecLoose>>;
+
+  suffix?:
+    | typeof lng.Component<lng.Component.TemplateSpecLoose>
+    | Array<typeof lng.Component<lng.Component.TemplateSpecLoose>>;
 
   get style(): ButtonStyle;
   set style(v: StylePartial<ButtonStyle>);
 
-  suffix?:
-    | lng.Component<lng.Component.TemplateSpecLoose>
-    | Array<lng.Component<lng.Component.TemplateSpecLoose>>;
+  title?: string;
 
   // tags
-  get _TextWrapper(): lng.Component;
-  get _Title(): lng.Component;
+  // TODO do we need these?
   get _Prefix(): lng.Component;
   get _Suffix(): lng.Component;
+  get _TextWrapper(): lng.Component;
+  get _Title(): lng.Component;
 }
 
 export default Button;

--- a/packages/@lightningjs/ui-components/src/components/Button/Button.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Button/Button.d.ts
@@ -46,14 +46,14 @@ declare namespace Button {
     justify?: 'center' | 'left' | 'right';
 
     /**
-     * Lightning components to be placed to the left of the title
+     * Lightning component(s) to be placed to the left of the title
      */
     prefix?:
       | typeof lng.Component<lng.Component.TemplateSpecLoose>
       | Array<typeof lng.Component<lng.Component.TemplateSpecLoose>>;
 
     /**
-     * Lightning components to be placed to the right of the title
+     * Lightning component(s )to be placed to the right of the title
      */
     suffix?:
       | typeof lng.Component<lng.Component.TemplateSpecLoose>
@@ -70,14 +70,27 @@ declare class Button<
   TemplateSpec extends Button.TemplateSpec,
   TypeConfig extends lng.Component.TypeConfig
 > extends Surface<TemplateSpec, TypeConfig> {
+  /**
+   * forces Button to have a statically set width
+   * when true, `w` overrides dynamically calculated width
+   */
   fixed?: boolean;
 
+  /**
+   * alignment of the button's content
+   */
   justify?: 'center' | 'left' | 'right';
 
+  /**
+   * Lightning component(s) to be placed to the left of the title
+   */
   prefix?:
     | typeof lng.Component<lng.Component.TemplateSpecLoose>
     | Array<typeof lng.Component<lng.Component.TemplateSpecLoose>>;
 
+  /**
+   * Lightning component(s )to be placed to the right of the title
+   */
   suffix?:
     | typeof lng.Component<lng.Component.TemplateSpecLoose>
     | Array<typeof lng.Component<lng.Component.TemplateSpecLoose>>;
@@ -85,10 +98,12 @@ declare class Button<
   get style(): ButtonStyle;
   set style(v: StylePartial<ButtonStyle>);
 
+  /**
+   * Button text
+   */
   title?: string;
 
   // tags
-  // TODO do we need these?
   get _Prefix(): lng.Component;
   get _Suffix(): lng.Component;
   get _TextWrapper(): lng.Component;

--- a/packages/@lightningjs/ui-components/src/components/Button/Button.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Button/Button.d.ts
@@ -19,8 +19,7 @@
 import lng from '@lightningjs/core';
 import type { Color, StylePartial } from '../../types/lui';
 import Surface, { SurfaceStyle } from '../Surface';
-// text in Button is all using our own version of TextBox
-import type { TextBoxStyle } from '../TextBox';
+import type { TextBoxStyle } from '../TextBox'; // text in Button is all using our own version of TextBox
 
 export type ButtonStyle = SurfaceStyle & {
   justify: 'center' | 'left' | 'right';
@@ -32,14 +31,52 @@ export type ButtonStyle = SurfaceStyle & {
   contentColor: Color;
 };
 
-export default class Button extends Surface {
+declare namespace Button {
+  export interface TemplateSpec extends Surface.TemplateSpec {
+    Content: typeof lng.Component<lng.Component.TemplateSpecLoose>;
+    /**
+     * when true, `w` overrides dynamically calculated width
+     */
+    fixed?: boolean;
+    justify?: 'center' | 'left' | 'right';
+    prefix?:
+      | typeof lng.Component<lng.Component.TemplateSpecLoose>
+      | Array<typeof lng.Component<lng.Component.TemplateSpecLoose>>;
+
+    /**
+     * text contents of the Button
+     */
+    title?: string;
+    suffix?:
+      | typeof lng.Component<lng.Component.TemplateSpecLoose>
+      | Array<typeof lng.Component<lng.Component.TemplateSpecLoose>>;
+  }
+}
+
+declare class Button<
+  TemplateSpec extends Button.TemplateSpec,
+  TypeConfig extends lng.Component.TypeConfig
+> extends Surface<TemplateSpec, TypeConfig> {
+  /**
+   * when true, `w` overrides dynamically calculated width
+   */
   fixed?: boolean;
   justify?: 'center' | 'left' | 'right';
-  prefix?: lng.Component | Array<lng.Component>;
-  suffix?: lng.Component | Array<lng.Component>;
+  prefix?:
+    | lng.Component<lng.Component.TemplateSpecLoose>
+    | Array<lng.Component<lng.Component.TemplateSpecLoose>>;
+
+  /**
+   * text contents of the Button
+   */
   title?: string;
+
   get style(): ButtonStyle;
   set style(v: StylePartial<ButtonStyle>);
+
+  suffix?:
+    | lng.Component<lng.Component.TemplateSpecLoose>
+    | Array<lng.Component<lng.Component.TemplateSpecLoose>>;
 
   // tags
   get _TextWrapper(): lng.Component;
@@ -47,3 +84,5 @@ export default class Button extends Surface {
   get _Prefix(): lng.Component;
   get _Suffix(): lng.Component;
 }
+
+export default Button;

--- a/packages/@lightningjs/ui-components/src/components/Button/ButtonSmall.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Button/ButtonSmall.d.ts
@@ -16,6 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import lng from '@lightningjs/core';
 import Button from './Button';
 
-export default class ButtonSmall extends Button {}
+export default class ButtonSmall<
+  TemplateSpec extends Button.TemplateSpec,
+  TypeConfig extends lng.Component.TypeConfig
+> extends Button<TemplateSpec, TypeConfig> {}

--- a/packages/@lightningjs/ui-components/src/components/Surface/Surface.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Surface/Surface.d.ts
@@ -34,7 +34,8 @@ export type SurfaceStyle = {
 };
 
 declare namespace Surface {
-  export interface TemplateSpec extends lng.Component.TemplateSpec {
+  export interface TemplateSpec extends Base.TemplateSpec {
+    // TODO we may actually not want to include this here
     Background: typeof lng.Component<lng.Component.TemplateSpecLoose>; // TemplateSpecLoose allows us to patch in any arbitrary lng.Component
   }
 }

--- a/packages/@lightningjs/ui-components/src/components/Surface/Surface.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Surface/Surface.d.ts
@@ -34,24 +34,23 @@ export type SurfaceStyle = {
 };
 
 declare namespace Surface {
-  export interface TemplateSpec extends Base.TemplateSpec {}
-
-  export interface EventMap extends Base.EventMap {}
-
-  export interface TypeConfig extends Base.TypeConfig {
-    get innerH(): number;
-    get innerW(): number;
-    get style(): SurfaceStyle;
-    set style(v: StylePartial<SurfaceStyle>);
-
-    // tags
-    get _Background(): typeof lng.Component; // TODO should this be typeof?
+  export interface TemplateSpec extends lng.Component.TemplateSpec {
+    Background: typeof lng.Component;
   }
 }
 
 declare class Surface<
-  TemplateSpec extends Surface.TemplateSpec = Surface.TemplateSpec,
-  TypeConfig extends Surface.TypeConfig = Surface.TypeConfig
-> extends Base<Base.TemplateSpec, Base.TypeConfig> {}
+  TemplateSpec extends Surface.TemplateSpec,
+  TypeConfig extends lng.Component.TypeConfig
+> extends Base<TemplateSpec, TypeConfig> {
+  get innerH(): number;
+  get innerW(): number;
+
+  get style(): SurfaceStyle;
+  set style(v: StylePartial<SurfaceStyle>);
+
+  // tags
+  get _Background(): typeof lng.Component; // TODO should this be typeof?
+}
 
 export default Surface;

--- a/packages/@lightningjs/ui-components/src/components/Surface/Surface.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Surface/Surface.d.ts
@@ -44,7 +44,14 @@ declare class Surface<
   TemplateSpec extends Surface.TemplateSpec,
   TypeConfig extends lng.Component.TypeConfig
 > extends Base<TemplateSpec, TypeConfig> {
+  /**
+   * alias for this.h
+   */
   get innerH(): number;
+
+  /**
+   * alias for this.w
+   */
   get innerW(): number;
 
   get style(): SurfaceStyle;

--- a/packages/@lightningjs/ui-components/src/components/Surface/Surface.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Surface/Surface.d.ts
@@ -17,10 +17,10 @@
  */
 
 import lng from '@lightningjs/core';
-import Base from '../Base';
+import Base from '../Base/Base';
 import type { Color, StylePartial } from '../../types/lui';
 
-type TransitionObject = {
+export type TransitionObject = {
   delay: number;
   duration: number;
   timingFunction: string;
@@ -33,12 +33,25 @@ export type SurfaceStyle = {
   scale: number;
 };
 
-export default class Surface extends Base {
-  get innerH(): number;
-  get innerW(): number;
-  get style(): SurfaceStyle;
-  set style(v: StylePartial<SurfaceStyle>);
+declare namespace Surface {
+  export interface TemplateSpec extends Base.TemplateSpec {}
 
-  // tags
-  get _Background(): lng.Component;
+  export interface EventMap extends Base.EventMap {}
+
+  export interface TypeConfig extends Base.TypeConfig {
+    get innerH(): number;
+    get innerW(): number;
+    get style(): SurfaceStyle;
+    set style(v: StylePartial<SurfaceStyle>);
+
+    // tags
+    get _Background(): typeof lng.Component; // TODO should this be typeof?
+  }
 }
+
+declare class Surface<
+  TemplateSpec extends Surface.TemplateSpec = Surface.TemplateSpec,
+  TypeConfig extends Surface.TypeConfig = Surface.TypeConfig
+> extends Base<Base.TemplateSpec, Base.TypeConfig> {}
+
+export default Surface;

--- a/packages/@lightningjs/ui-components/src/components/Surface/Surface.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Surface/Surface.d.ts
@@ -35,7 +35,7 @@ export type SurfaceStyle = {
 
 declare namespace Surface {
   export interface TemplateSpec extends lng.Component.TemplateSpec {
-    Background: typeof lng.Component;
+    Background: typeof lng.Component<lng.Component.TemplateSpecLoose>; // TemplateSpecLoose allows us to patch in any arbitrary lng.Component
   }
 }
 
@@ -50,7 +50,7 @@ declare class Surface<
   set style(v: StylePartial<SurfaceStyle>);
 
   // tags
-  get _Background(): typeof lng.Component; // TODO should this be typeof?
+  get _Background(): lng.Component;
 }
 
 export default Surface;


### PR DESCRIPTION
This PR updates the Base, Surface, Button and ButtonSmall component declaration files to be properly subclassable, following along these [docs from lightning-core](https://github.com/rdkcentral/Lightning/blob/6bb0f9e424c1711a2831db67cf273fd4113230d6/docs/TypeScript/Components/SubclassableComponents.md)

In each component type declaration file you'll find:
- a new namespace wrapping the component's TemplateSpec(and optionally Typeconfig)
- an updated class definition that uses the TemplateSpecs and TypeConfigs
- more detailed class declarations including comments for methods and properties
  - these comments will appear in the IDE tips for any users using typescript in their project


## Checklist

- [x] all commented code has been removed
- [ ] any new console issues have been resolved
- [x] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
