### PR TITLE
fix(Column): updates render methods to match Row render methods

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Column/Column.js
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.js
@@ -60,8 +60,47 @@ export default class Column extends NavigationManager {
     } else if (next && !next.selectedIndex) {
       next.selectedIndex = 0;
     }
+    if (!this.Items.children.length) {
+      this.applySmooth(this.Items, { y: this.itemPosY });
+      if (!this.shouldSmooth) {
+        this._updateTransitionTarget(this.Items, 'y', this.itemPosY);
+      }
+    } else if (this._shouldScroll()) {
+      let scrollItem =
+        this.selectedIndex > this._lastScrollIndex
+          ? this.Items.children[this._lastScrollIndex - this.scrollIndex]
+          : this.selected;
+      if (this.Items.children[this._firstFocusableIndex()] === scrollItem) {
+        scrollItem = this.Items.children[0];
+      }
+      const scrollOffset = (this.Items.children[this.scrollIndex] || { y: 0 })
+        .y;
+      const smoothObj = [
+        -(scrollItem || this.Items.childList.first).transition('y')
+          .targetValue + (scrollItem === this.selected ? scrollOffset : 0),
+        this.style.itemTransition
+      ];
+      const scrollTarget =
+        -scrollItem.y + (scrollItem === this.selected ? scrollOffset : 0);
+      this.applySmooth(
+        this.Items,
+        {
+          y: scrollTarget
+        },
+        {
+          y: smoothObj
+        }
+      );
+      if (!this.shouldSmooth) {
+        this._updateTransitionTarget(this.Items, 'y', scrollTarget);
+      }
+    }
 
-    this._performRender();
+    this.onScreenEffect(this.onScreenItems);
+  }
+
+  _performRender() {
+    this.render(this.selected, this.prevSelected);
   }
 
   checkSkipPlinko(prev, next) {
@@ -102,46 +141,6 @@ export default class Column extends NavigationManager {
       : prevIndex + direction; // +/- 1, item index before prev
 
     return this.items[prevPlinkoIndex];
-  }
-
-  _performRender() {
-    if (!this.Items.children.length) {
-      this.applySmooth(this.Items, { y: this.itemPosY });
-      if (!this.shouldSmooth) {
-        this._updateTransitionTarget(this.Items, 'y', this.itemPosY);
-      }
-    } else if (this._shouldScroll()) {
-      let scrollItem =
-        this.selectedIndex > this._lastScrollIndex
-          ? this.Items.children[this._lastScrollIndex - this.scrollIndex]
-          : this.selected;
-      if (this.Items.children[this._firstFocusableIndex()] === scrollItem) {
-        scrollItem = this.Items.children[0];
-      }
-      const scrollOffset = (this.Items.children[this.scrollIndex] || { y: 0 })
-        .y;
-      const smoothObj = [
-        -(scrollItem || this.Items.childList.first).transition('y')
-          .targetValue + (scrollItem === this.selected ? scrollOffset : 0),
-        this.style.itemTransition
-      ];
-      const scrollTarget =
-        -scrollItem.y + (scrollItem === this.selected ? scrollOffset : 0);
-      this.applySmooth(
-        this.Items,
-        {
-          y: scrollTarget
-        },
-        {
-          y: smoothObj
-        }
-      );
-      if (!this.shouldSmooth) {
-        this._updateTransitionTarget(this.Items, 'y', scrollTarget);
-      }
-    }
-
-    this.onScreenEffect(this.onScreenItems);
   }
 
   get _itemsY() {

--- a/packages/@lightningjs/ui-components/src/components/Column/Column.js
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.js
@@ -46,7 +46,7 @@ export default class Column extends NavigationManager {
     return shouldScroll;
   }
 
-  render(next, prev) {
+  _render(next, prev) {
     this._prevLastScrollIndex = this._lastScrollIndex;
 
     if (
@@ -100,7 +100,7 @@ export default class Column extends NavigationManager {
   }
 
   _performRender() {
-    this.render(this.selected, this.prevSelected);
+    this._render(this.selected, this.prevSelected);
   }
 
   checkSkipPlinko(prev, next) {

--- a/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.js
+++ b/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.js
@@ -203,12 +203,12 @@ export default class FocusManager extends Base {
   }
 
   _selectedChange(selected, prevSelected) {
-    this.render(selected, prevSelected);
+    this._render(selected, prevSelected);
     this.signal('selectedChange', selected, prevSelected);
   }
 
   // Override
-  render() {}
+  _render() {}
 
   _firstFocusableIndex() {
     if (!this.items.length) return 0;

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.js
@@ -171,7 +171,7 @@ export default class Row extends NavigationManager {
     return itemsContainerX;
   }
 
-  render(next, prev) {
+  _render(next, prev) {
     if (this.plinko && prev && prev.selected) {
       next.selectedIndex = this._getIndexOfItemNear(next, prev);
     }
@@ -195,7 +195,7 @@ export default class Row extends NavigationManager {
   }
 
   _performRender() {
-    this.render(this.selected, this.prevSelected);
+    this._render(this.selected, this.prevSelected);
   }
 
   _isOnScreen(child) {

--- a/packages/@lightningjs/ui-components/src/mixins/withEditItems/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withEditItems/index.js
@@ -86,7 +86,7 @@ export default function (Base) {
         ) {
           if (this.selected) {
             this._selectedIndex = index;
-            this.render(this.selected, this.prevSelected);
+            this._render(this.selected, this.prevSelected);
             this.signal('selectedChange', this.selected, this.prevSelected);
           }
           // Don't call refocus until after a new render in case of a situation like Plinko nav


### PR DESCRIPTION
## Description

This PR does the following:

- In `Column` moves logic from preformRender to render method and makes both render methods private
- In `Row` changes `render` to a private method
- In  `FocusManager` changed `render` to private method
- In `withEditItems` changed `render` to private method

## References

LUI-737

## Testing
- Clone branch
- go to Row and Column stories and check that the are working as expected
- check that all tests pass `yarn run test`

## Automation

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
