### PR TITLE
fix(ListItem): move truncation to update on TextBox change

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.js
@@ -69,6 +69,7 @@ export default class ListItem extends Button {
 
   _onTextBoxChanged() {
     this._updateTitle();
+    this._updateTruncation();
   }
 
   _update() {
@@ -81,7 +82,8 @@ export default class ListItem extends Button {
   _updateTitle() {
     this._TextWrapper.patch({
       Title: {
-        content: this.title
+        content: this.title,
+        style: { textStyle: this.style.titleTextStyle }
       }
     });
   }
@@ -90,13 +92,7 @@ export default class ListItem extends Button {
     if (this._hasDescription) {
       let descriptionPatch = {
         content: this.description,
-        style: {
-          textStyle: {
-            ...this.style.descriptionTextStyle,
-            wordWrap: true,
-            wordWrapWidth: this._fixedWordWrapWidth
-          }
-        },
+        style: { textStyle: this.style.descriptionTextStyle },
         visible: !this._collapse
       };
       if (!this._Description) {
@@ -115,11 +111,12 @@ export default class ListItem extends Button {
   }
 
   _updateTruncation() {
-    if (this._Title) {
-      this._Title.patch({
+    super._updateTruncation();
+    if (this._Description) {
+      this._Description.patch({
         style: {
           textStyle: {
-            ...this.style.textStyle,
+            ...this.style.descriptionTextStyle,
             wordWrap: true,
             wordWrapWidth: this._fixedWordWrapWidth
           }

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.js
@@ -81,8 +81,7 @@ export default class ListItem extends Button {
   _updateTitle() {
     this._TextWrapper.patch({
       Title: {
-        content: this.title,
-        style: { textStyle: this.style.titleTextStyle }
+        content: this.title
       }
     });
   }
@@ -91,7 +90,13 @@ export default class ListItem extends Button {
     if (this._hasDescription) {
       let descriptionPatch = {
         content: this.description,
-        style: { textStyle: this.style.descriptionTextStyle },
+        style: {
+          textStyle: {
+            ...this.style.descriptionTextStyle,
+            wordWrap: true,
+            wordWrapWidth: this._fixedWordWrapWidth
+          }
+        },
         visible: !this._collapse
       };
       if (!this._Description) {
@@ -110,12 +115,11 @@ export default class ListItem extends Button {
   }
 
   _updateTruncation() {
-    super._updateTruncation();
-    if (this._Description) {
-      this._Description.patch({
+    if (this._Title) {
+      this._Title.patch({
         style: {
           textStyle: {
-            ...this.style.descriptionTextStyle,
+            ...this.style.textStyle,
             wordWrap: true,
             wordWrapWidth: this._fixedWordWrapWidth
           }

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemPicker.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemPicker.js
@@ -191,12 +191,13 @@ export default class ListItemPicker extends ListItem {
   }
 
   get _fixedWordWrapWidth() {
-    const titleWrapWidth =
+    const wordWrapWidthFocused =
       this.w -
       this._paddingX -
       this.style.arrowWidth * 2 -
       2 * this.style.titlePadding;
-    return titleWrapWidth;
+    const wordWrapWidth = this.w - this._paddingLeft - this._paddingRight;
+    return this._isFocusedMode ? wordWrapWidthFocused : wordWrapWidth;
   }
 
   get _collapse() {

--- a/packages/@lightningjs/ui-components/src/components/ListItem/__snapshots__/ListItemPicker.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/__snapshots__/ListItemPicker.test.js.snap
@@ -260,7 +260,7 @@ exports[`ListItemPicker renders 1`] = `
                     "textColor": 4294506490,
                     "type": "TextTexture",
                     "verticalAlign": "middle",
-                    "wordWrapWidth": 292,
+                    "wordWrapWidth": 412,
                   },
                   "visible": true,
                   "w": 0,


### PR DESCRIPTION
## Description

In this PR, I have moved _updateTruncation to update on text box change and added separate wordWrapWidth properties for when the picker is focused and not focused.

## References

LUI-771

## Testing

1. Navigate to any ListItemVariant element.
2. Enter a long text that exceeds the width of the container.
3. Verify that the text is truncated and ellipses (...) are displayed at the end of the truncated text.

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
