### PR TITLE
fix(withSelections): changes export definition to withSelections

### DIFF
--- a/packages/@lightningjs/ui-components/src/mixins/withSelections/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/mixins/withSelections/index.d.ts
@@ -48,7 +48,7 @@ export interface WithSelectionsConstructor {
   new (...args: any[]): WithSelections;
 }
 
-export default function withExtensions<BaseType extends typeof lng.Component>(
+export default function withSelections<BaseType extends typeof lng.Component>(
   base: BaseType,
   options: WithSelectionsOptions
 ): BaseType & WithSelectionsConstructor;


### PR DESCRIPTION
## Description

This PR updates export on typescript file, was `withExtensions` now is `withSelections`

## References

LUI-803

## Testing
Check that the default export in the typescript file for `withSelections` has been updated

## Automation

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
