### PR TITLE
fix(TextBox): remove typography from TextBox styles

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
@@ -261,13 +261,13 @@ export default class TextBox extends Base {
 
   get _textStyleSet() {
     const fontStyle = {
-      ...(this.style.typography[this.style.defaultTextStyle] ||
-        this.style.typography.body1),
+      ...(this.theme.typography[this.style.defaultTextStyle] ||
+        this.theme.typography.body1),
       ...(null !== this.style.textStyle &&
       'object' === typeof this.style.textStyle &&
       Object.keys(this.style.textStyle)
         ? this.style.textStyle
-        : this.style.typography[this.style.textStyle])
+        : this.theme.typography[this.style.textStyle])
     };
 
     this.constructor.properties.forEach(prop => {

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.styles.js
@@ -19,6 +19,5 @@
 export const base = theme => ({
   offsetY: theme.spacer.xxs,
   offsetX: 0,
-  textStyle: theme.typography.body1,
-  typography: theme.typography
+  textStyle: theme.typography.body1
 });

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.test.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.test.js
@@ -148,10 +148,10 @@ describe('TextBox', () => {
       textBox.style.textStyle = null;
       testRenderer.forceAllUpdates();
       expect(textBox._Text.text.fontSize).toBe(
-        textBox.style.typography[textBox.style.defaultTextStyle].fontSize
+        textBox.theme.typography[textBox.style.defaultTextStyle].fontSize
       );
       expect(textBox._Text.text.fontWeight).toBe(
-        textBox.style.typography[textBox.style.defaultTextStyle].fontWeight
+        textBox.theme.typography[textBox.style.defaultTextStyle].fontWeight
       );
     });
 


### PR DESCRIPTION
## Description

As user I don't need to reference the style property in TextBox styles, so the style property can be removed. Instead just reference context.theme.typography directly in the component.

## References

[LUI-739](https://ccp.sys.comcast.net/browse/LUI-739)

## Testing

TextBox should work as expected. 

## Automation

All existing tests should pass as expected

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
