### PR TITLE
ci: swap to PAT (GH_TOKEN) for semantic release to get around branch rules

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,8 @@ name: Pull Request
 
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
 permissions: read-all
 jobs:
   quality:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,5 +6,4 @@ on:
 permissions: read-all
 jobs:
   quality:
-    name: Quality
     uses: ./.github/workflows/quality.yml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,8 @@
 name: Pull Request
 
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, edited]
 permissions: read-all
 jobs:
   quality:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Make sure to get all history for semantic release
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,11 @@ jobs:
         run: cp ./README.md ./packages/@lightningjs/ui-components/README.md
       - name: Semantic Release
         run: |
-          yarn workspace @lightningjs/ui-components-theme-base run semantic-release --no-ci -e semantic-release-monorepo 
-          yarn workspace @lightningjs/ui-components run semantic-release --no-ci -e semantic-release-monorepo 
+          yarn workspace @lightningjs/ui-components-theme-base run semantic-release --no-ci -e semantic-release-monorepo
+          yarn workspace @lightningjs/ui-components run semantic-release --no-ci -e semantic-release-monorepo
           yarn workspace @lightningjs/ui-components-test-utils run semantic-release --no-ci -e semantic-release-monorepo
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       - name: Setup git config


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Currently, the semantic-release-bot uses the GITHUB_TOKEN instead of the GH_TOKEN, which is our service account's PAT and will have permissions to edit the branches.

@HarryLinux is going to look into whether we need `persist-credential: false`:
https://github.com/semantic-release/semantic-release/discussions/2557