### PR TITLE
chore(NavigationManager): reduce number of update calls from onAfterU…

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Button/Button.js
+++ b/packages/@lightningjs/ui-components/src/components/Button/Button.js
@@ -279,9 +279,7 @@ export default class Button extends Surface {
   }
 
   get _hasPrefix() {
-    return this._Prefix && Array.isArray(this.prefix)
-      ? this.prefix.length
-      : this.prefix;
+    return !!(this.prefix && Object.keys(this.prefix).length);
   }
 
   get _prefixW() {
@@ -318,9 +316,7 @@ export default class Button extends Surface {
   }
 
   get _hasSuffix() {
-    return this._Suffix && Array.isArray(this.suffix)
-      ? this.suffix.length
-      : this.suffix;
+    return !!(this.suffix && Object.keys(this.suffix).length);
   }
 
   get _suffixW() {

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -349,6 +349,7 @@ export default class NavigationManager extends FocusManager {
     items.forEach(item => this._appendItem(item));
 
     this.queueRequestUpdate();
+    this._refocus();
   }
 
   appendItemsAt(items = [], idx) {

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -271,6 +271,8 @@ export default class NavigationManager extends FocusManager {
   }
 
   _withAfterUpdate(component) {
+    const initialOnAfterUpdate = component.__core?._onAfterUpdate;
+
     component.onAfterUpdate = function (element) {
       let hasChanged = false;
       const watchProps = [
@@ -297,6 +299,11 @@ export default class NavigationManager extends FocusManager {
 
       if (hasChanged) {
         this.queueRequestUpdate();
+      }
+
+      // if a component already has an onAfterUpdate function, preserve that behavior
+      if (initialOnAfterUpdate) {
+        initialOnAfterUpdate(element);
       }
     }.bind(this);
 

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -17,7 +17,7 @@
  */
 
 import FocusManager from '../FocusManager';
-import { getX, getY, getH, getW, max } from '../../utils';
+import { getX, getY, getH, getW, max, watchForUpdates } from '../../utils';
 import * as styles from './NavigationManager.styles';
 
 const directionPropNames = {
@@ -270,44 +270,18 @@ export default class NavigationManager extends FocusManager {
     this.transitionDone();
   }
 
-  _withAfterUpdate(component) {
-    const initialOnAfterUpdate = component.__core?._onAfterUpdate;
-
-    component.onAfterUpdate = function (element) {
-      let hasChanged = false;
-      const watchProps = [
+  _withAfterUpdate(element) {
+    return watchForUpdates({
+      element,
+      watchProps: [
         this._directionPropNames.crossAxis,
         'w',
         'h',
         'innerW',
         'innerH'
-      ];
-
-      watchProps.forEach(prop => {
-        if (element.transition(prop) && element.transition(prop).isRunning()) {
-          return;
-        }
-
-        const prevValueKey = `_navItemPrev${prop}`;
-        const nextValue = element[prop];
-
-        if (nextValue !== element[prevValueKey]) {
-          element[prevValueKey] = nextValue;
-          hasChanged = true;
-        }
-      });
-
-      if (hasChanged) {
-        this.queueRequestUpdate();
-      }
-
-      // if a component already has an onAfterUpdate function, preserve that behavior
-      if (initialOnAfterUpdate) {
-        initialOnAfterUpdate(element);
-      }
-    }.bind(this);
-
-    return component;
+      ],
+      sideEffect: this.queueRequestUpdate.bind(this)
+    });
   }
 
   // can be overwritten

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -348,9 +348,7 @@ export default class NavigationManager extends FocusManager {
     }
     items.forEach(item => this._appendItem(item));
 
-    this.stage.update();
     this.queueRequestUpdate();
-    this._refocus();
   }
 
   appendItemsAt(items = [], idx) {

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright 2023 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -273,12 +273,24 @@ export default class NavigationManager extends FocusManager {
   _withAfterUpdate(component) {
     component.onAfterUpdate = function (element) {
       let hasChanged = false;
-      const watchProps = ['w', 'h', 'x', 'y', 'innerW', 'innerH'];
+      const watchProps = [
+        this._directionPropNames.crossAxis,
+        'w',
+        'h',
+        'innerW',
+        'innerH'
+      ];
 
       watchProps.forEach(prop => {
+        if (element.transition(prop) && element.transition(prop).isRunning()) {
+          return;
+        }
+
         const prevValueKey = `_navItemPrev${prop}`;
-        if (!hasChanged && element[prop] !== element[prevValueKey]) {
-          element[prevValueKey] = element[prop];
+        const nextValue = element[prop];
+
+        if (nextValue !== element[prevValueKey]) {
+          element[prevValueKey] = nextValue;
           hasChanged = true;
         }
       });


### PR DESCRIPTION
## Description
When items are added to NavigationManager, a function is assigned to an `onAfterUpdate` property on each item. Each function triggers an update if one of the specified sizing or positioning properties ([defined by the watchProps variable](https://github.com/rdkcentral/Lightning-UI-Components/pull/200/files#diff-4cf29152f6e19e45ffb9a2a5c968d8a4857ad5d4c413c184e9304e59efe050f8R278-R284)) changes.

### Related Pull Request
A follow up PR, https://github.com/rdkcentral/Lightning-UI-Components/pull/222,  has been created to abstract the onAfterUpdate logic used in NavigationManager. _withAfterUpdate to a utility function that can be reused in other components.

### NavigationManager
 The changes in this PR are intended to reduce the number of updates triggered from this process. The approaches taken were:
- remove the property associated with the main axis of the NavigationManager subclass from the list of properties evaluated for changes to trigger an update(ex. `x` for `Row`, `y` for `Column`). These properties are updated when the component updates (via `NavigationManager._updateLayout`). Each item's main axis property would then be updated with a new value, triggering that item's `onAfterUpdate` function to run and run through another update cycle.
- if a property is transitioning to its next value, only trigger an update from it after that transition has completed. Prior to this change, `_update` was triggered multiple times as the value of the property transitioned to its target value.
- removed a forced stage update (`this.stage.update()`) from the appendItem method. I'm not sure the history of why that was initially needed, but removing it does not appear to break anything and it seems like the component continues to render correctly.

### Button:
- Removing the stage update from `NavigationManager.appendItems` caused the `KeyboardInput` story to stop rendering and throw an error when attempting to patch `x` to `this._Prefix` or `this._Suffix` in `Button._updatePositions`. Neither of those tags were defined, because `this.prefix` and `this.suffix` are set to `[]` in the KeyboardInputStories.
- Two getters, for `_hasPrefix` and `_hasSuffix` were previously evaluating to truthy values if an empty array or object was passed to `Button.prefix` or `Button.suffix`. This PR updates those getters to always return a boolean and return `false` if an empty array or object is set on those properties.

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References
LUI-797
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
Compare stories in the following components to those on the deployed storybook instance. No visible changes between the branches should be present: 
- Row 
- Column
- Button
- Control (subclass of button)
- ControlRow (utilizes both NavigationManager and Control)
<!-- step by step instructions to review this PR's changes -->

## Automation
n/a
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
