### PR TITLE
fix: styleConfig mode hierarchy

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Keyboard/__snapshots__/Keyboard.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/__snapshots__/Keyboard.test.js.snap
@@ -8357,19 +8357,19 @@ exports[`Keyboard renders 1`] = `
                           "attached": true,
                           "boundsMargin": null,
                           "children": {
-                            "TextWrapper": {
+                            "Prefix": {
                               "active": false,
                               "alpha": 1,
                               "attached": true,
                               "boundsMargin": null,
                               "children": {
-                                "Title": {
+                                "Items": {
                                   "active": false,
-                                  "alpha": 0.001,
+                                  "alpha": 1,
                                   "attached": true,
                                   "boundsMargin": null,
                                   "children": {
-                                    "Text": {
+                                    "Element-188": {
                                       "active": false,
                                       "alpha": 1,
                                       "attached": true,
@@ -8379,42 +8379,33 @@ exports[`Keyboard renders 1`] = `
                                       "enabled": true,
                                       "flex": false,
                                       "flexItem": false,
-                                      "h": 0,
-                                      "isComponent": undefined,
+                                      "h": 40,
+                                      "hasFinalFocus": false,
+                                      "hasFocus": false,
+                                      "isComponent": true,
                                       "mount": 0,
                                       "mountX": 0,
                                       "mountY": 0,
                                       "pivot": 0.5,
                                       "pivotX": 0.5,
                                       "pivotY": 0.5,
-                                      "ref": "Text",
+                                      "ref": null,
                                       "renderOfScreen": undefined,
                                       "renderToTexture": false,
                                       "scale": 1,
                                       "scaleX": 1,
                                       "scaleY": 1,
-                                      "state": undefined,
+                                      "state": "",
                                       "tag": [Function],
-                                      "tags": [
-                                        "Text",
-                                      ],
                                       "texture": {
-                                        "fontFace": "Arial",
-                                        "fontSize": 30,
-                                        "letterSpacing": -0.2,
-                                        "lineHeight": 40,
-                                        "maxLines": 1,
-                                        "text": "Delete",
-                                        "textBaseline": "bottom",
-                                        "textColor": 4294506490,
-                                        "type": "TextTexture",
-                                        "verticalAlign": "middle",
-                                        "wordWrapWidth": 130,
+                                        "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJAAAACQCAYAAADnRuK4AAAAAXNSR0IArs4c6QAACmpJREFUeF7tnVmoZUcVhv/feY4gBEVEH/KgCCZxCK2itNo4xQQH+kUN0TjEiDGKKBqnaExwBjUaR6KY+NQgiQkOMSYhYEScIopGJOqDE2hHjfP0y4p1Oqdv33v2qr32Prv2Paug6Ye7Vu2qv75TtWvtGohMqUBAAQZ80zUVQAKUEIQUSIBC8qVzApQMhBRIgELypXMClAyEFEiAQvKlcwKUDIQUSIBC8qVzApQMhBRIgELypXMClAyEFEiAQvKlcwKUDIQUSIBC8qVzApQMhBRIgELypXMClAyEFEiAQvKlcwKUDIQUSIBC8qVzApQMhBRIgELypXMClAyEFEiAQvKlcwKUDIQUSIBC8qVzApQMhBRIgELypfPsAJJ0NYC92XRHKPB3AAfLv18BuBLAFSR/NKZWswJI0vkA3jCmILsw75sAvIfkR8eo22wAknQSgMvGEGFD8vwxgFeQvGrI+s4CIEnHAPgugHsMWfkNzevDAM4i+Z8h6t88QJLuXOB5yBAVzjxuVeBaAM8ieXNUjzkAdAmA50Yrmv5HKPATACeQ/GNEm6YBkvRyANblZhpHAXsfekpkOGsWIEmPAHA9gDuOo13mWhS4gOSZfdVoEiBJ9wFwA4D7961Y+lUpsK/v7KxVgL4K4ElOCS4l+Uyn7a41k3Q0gMcC2ANgH4CHV1T2OyStx69OzQEk6TwAZztr8lMAx5P8s9N+Y8wk2cTjfQDu66z080h+zml7yKwpgCSdCOByZyX+BuBRJH/otN84M0kWN/s0gOc4Kv8Nko922B1m0gxAkh4I4AcVwcL9JA/UVnjT7CXdHYD9yEzfVUkAjib5uxqNmgCoBAu/CeBhzsJ/kORZTtuNN5Nk70bXAZ0Hy59G8qIawVoB6LMAnu8suE3tH0/y3077NAMg6esAuoaoC0la7M2dJgdI0ssAXOgs8W8BHEvS/s9UoYCkdwN4bYfL5STto7U7TQpQZbDQehzreawHylSpgKSTAVza4XYDyeNqsp4MoB7BwteQfH9N5dL2NgWK3l0vyAdJWhDXnSYBSNLtANh3GO/KwgMk97trlYbbKiDJPpzea5U8JKuYqDIeql0kvQPAG5352ZLMR5L8q9M+zXZQYFcAJOnJAL7sbGWLMFuk2SLOmYIKzB6gEiz8HoB7O7U4meQXnLZp1qGApD8BuOcsh7AewcL3kuyadg4OjSSbhRxH0j4BjJok2Ufga0j+YdQHlcznDlBNsPAa+xpP8r/rEHbxjAKPbRuyHvKFY0Ik6QUALOprPfIT1gHRbAGSdDoA77aSX5Zg4e8nhGfx6FEgWoJn8Zy1QCTplq5vjc3NwnoEC/eQ/HYD8IwC0TbwrA2i2QHUI1h4JskLGoJnUIhWwLMWiGYFkCSLMX2t5WDhlneeLm5Dw5kDntEhkmRhEVvesWNqZgiTdC6AN3W1Svn72oOFkuxF+WcVIQUrai+IKuA5BBHJ453auc1mA1AJFn7Jsf7EKj9ZsLBHw1ZDtI5neAmaBUBzCxaO2cBj5u2FZtlO0l8A3K3ZIaxHsPB8kt5vYn00c/mM0dBj5OmqzAqjOQDUfLBwJ32HbPAh84pCM5seSNJLAHzcWeFJgoVdZRui4YfIo6ucff8uyVY03LW5IawyWPgvW5u77mChV/QIABFfb/kidk0CVKbDth3Huw35dJLeniqiV2/fniDYx1f7vlWTeoUFah6wZQhrqwcqwUKbrtsaH0+6mOQpHsOpbXpCVFPstcJjBZNkmzHv0swQJultAN7iVO375TyafzjtJzcbEaK1w9McQJXBQlvvYmtsfjE5FZUFGAGiSeBpCqDKYKFtmX0qya9Utl0z5gNCNBk8BSA7CtiODNwxjf4trEew8BySNtTNOg0A0aTwtARQTbDQeh3rfawXmn0KQDQ5PC0B9EkAL3LSkAD9X6hWALIJzJ3mNoSdS9I7U3NyuX6zQO+zKOzkEEmaHqDSFdpZM97tOfkSfRvvk0LUDEAFIgseetf85DS+AYgk/bPr1NvRZ2HLg4ektwI4xzmgZCBxYohaBMjWPeenDOcvaIvZ2oez5gAqQ5mtLbb3oa4z+Bb6nTHW1UP92vFIr54vzJ8BcGplGdYKkSRbCXGHSWdh2z1ckp1taGccroxyFt9cznG4iGuDqFmASk9kZxxakNGTckHZBBA1DVCB6BMAXuwhyA4VmGL/+05l6zlsbdt7DJmXU0uXmSQ7JvD2zQ1hiwJJsotRvlVxXO87SU5+heUYDT5Gni5KVhg1D1DphWqCjOYy6RlAYzb0mHn3gWkWABWIaoKMubHwSBpGebGWZNdc2vmUO6a1BhJXFUSSff/yLuOYamvzzwEcVfFr7tWwPXqi6uN2PXWYG0C1Qca1n8RaDlewl3kPRL3gWXo/XBwo1dXWdk/a3jEOnJoVQGUoqw0yvpLkh7oUHvLvTohC8FRANBo8pT3sxLeVJ/M2M4QtiVYTZJzkNPoOiAaBxwHRqPDMFqBS8Jog4yT3YewA0aDwrIBodHhmDVApvG0mtO3PnjTJjTxbIBoFnm0gWgs8pQ06lxY3N4QtCWZBRgPDezdnHvPr+alV2EiaL0DlF2Dbn20bdB40XtHwQ5nOHqAC0SyCjEM1Wkv57AqACkRvBvB2p7hrDzI6yzU7s90EUPNBxtnR4SjwrgGo9EK1Qca8cM4ByU4mkuz++F93ZHELyZX3iW31n+S+sKWZWfNBxkCbNeUq6ekArugo1I0kH1xT8EkBKj1R80HGGkFbtZVkZ3bb2d2r0tUkn1hTh8kBKhB9DMBLnQWfJMjoLFuTZpJsO/ONAB7UUcBLSHqvX781q1YAqg0yfoDkq5psrQYLJeldAF7nKFr1x+wmACq9kAUZLazvvTV4P8kDDlE22kTSQ4uuK9dCF5HuR/I3NYI1A1CBaB+AK50VsAMj7TJeixNl2kYBSccCsB/ZMQ6Brif5GIfdYSZNAVQg8rzsLSphl/Hapby2LDZTUaBcq/56ALb1fOVxLkuinULy4loRmwOoQGQX7T7DWZnPk3y203bXmkl6AIA91isDOBGADV3e1HsJbasA1QYZvUKl3fYKPI2knXFQnZoEqPRCNUHG6oqnwyEFLiJ5Wl89mgWoQFQTZOyrwSb7WUztcSRtu0+v1DRABaKPADijV+3SaZUCNgE5geTNEZnmAFBtkDGix6b4Xld2BNvJcaHUPEClF6oNMoZE2eXOtm3q1ZFha1mfWQBUINoL4Kqurbm7vPEj1bOAqx3udW0kk62+swGoQHQ2gPOGFGAD8roJgF0t+qkx6jorgApElwE4aQwxZp6n3YNxsPyzA7yst/4iSdvEMFqaHUCjKZEZ91IgAeolWzotFEiAkoWQAglQSL50ToCSgZACCVBIvnROgJKBkAIJUEi+dE6AkoGQAglQSL50ToCSgZACCVBIvnROgJKBkAIJUEi+dE6AkoGQAglQSL50ToCSgZACCVBIvnROgJKBkAIJUEi+dE6AkoGQAglQSL50ToCSgZACCVBIvnROgJKBkAIJUEi+dE6AkoGQAglQSL50ToCSgZACCVBIvnT+H0jPT81J3xWWAAAAAElFTkSuQmCC",
+                                        "type": "ImageTexture",
                                       },
+                                      "type": "Icon",
                                       "visible": true,
-                                      "w": 0,
+                                      "w": 40,
                                       "x": 0,
-                                      "y": 2,
+                                      "y": 0,
                                       "zIndex": 0,
                                     },
                                   },
@@ -8423,35 +8414,70 @@ exports[`Keyboard renders 1`] = `
                                   "enabled": true,
                                   "flex": false,
                                   "flexItem": false,
-                                  "h": 0,
-                                  "hasFinalFocus": false,
-                                  "hasFocus": false,
-                                  "isComponent": true,
+                                  "h": 40,
+                                  "isComponent": undefined,
                                   "mount": 0,
                                   "mountX": 0,
-                                  "mountY": 0.5,
+                                  "mountY": 0,
                                   "pivot": 0.5,
                                   "pivotX": 0.5,
                                   "pivotY": 0.5,
-                                  "ref": "Title",
+                                  "ref": "Items",
                                   "renderOfScreen": undefined,
                                   "renderToTexture": false,
                                   "scale": 1,
                                   "scaleX": 1,
                                   "scaleY": 1,
-                                  "state": "",
+                                  "state": undefined,
                                   "tag": [Function],
                                   "tags": [
-                                    "Title",
+                                    "Items",
                                   ],
-                                  "type": "TextBox",
                                   "visible": true,
-                                  "w": 0,
+                                  "w": 40,
                                   "x": 0,
-                                  "y": [Function],
+                                  "y": 0,
                                   "zIndex": 0,
                                 },
                               },
+                              "clipping": false,
+                              "color": 4294967295,
+                              "enabled": true,
+                              "flex": false,
+                              "flexItem": false,
+                              "h": 40,
+                              "hasFinalFocus": false,
+                              "hasFocus": false,
+                              "isComponent": true,
+                              "mount": 0,
+                              "mountX": 0,
+                              "mountY": 0.5,
+                              "pivot": 0.5,
+                              "pivotX": 0.5,
+                              "pivotY": 0.5,
+                              "ref": "Prefix",
+                              "renderOfScreen": undefined,
+                              "renderToTexture": false,
+                              "scale": 1,
+                              "scaleX": 1,
+                              "scaleY": 1,
+                              "state": "Row",
+                              "tag": [Function],
+                              "tags": [
+                                "Prefix",
+                              ],
+                              "type": "Row",
+                              "visible": true,
+                              "w": 40,
+                              "x": 0,
+                              "y": 0,
+                              "zIndex": 0,
+                            },
+                            "TextWrapper": {
+                              "active": false,
+                              "alpha": 1,
+                              "attached": true,
+                              "boundsMargin": null,
                               "clipping": false,
                               "color": 4294967295,
                               "enabled": true,
@@ -8461,7 +8487,7 @@ exports[`Keyboard renders 1`] = `
                               "isComponent": undefined,
                               "mount": 0,
                               "mountX": 0,
-                              "mountY": 0.5,
+                              "mountY": 0,
                               "pivot": 0.5,
                               "pivotX": 0.5,
                               "pivotY": 0.5,
@@ -8508,7 +8534,7 @@ exports[`Keyboard renders 1`] = `
                             "Content",
                           ],
                           "visible": true,
-                          "w": 0,
+                          "w": 40,
                           "x": 75,
                           "y": 45,
                           "zIndex": 2,
@@ -11928,7 +11954,7 @@ exports[`KeyboardInput renders 1`] = `
                       "attached": true,
                       "boundsMargin": null,
                       "children": {
-                        "Element-8802": {
+                        "Element-8832": {
                           "active": false,
                           "alpha": 1,
                           "attached": true,
@@ -11940,7 +11966,7 @@ exports[`KeyboardInput renders 1`] = `
                               "attached": true,
                               "boundsMargin": null,
                               "children": {
-                                "Element-8804": {
+                                "Element-8834": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -12177,7 +12203,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8807": {
+                                "Element-8837": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -12414,7 +12440,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8810": {
+                                "Element-8840": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -12651,7 +12677,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8813": {
+                                "Element-8843": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -12888,7 +12914,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8816": {
+                                "Element-8846": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -13125,7 +13151,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8819": {
+                                "Element-8849": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -13362,7 +13388,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8822": {
+                                "Element-8852": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -13599,7 +13625,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8825": {
+                                "Element-8855": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -13836,7 +13862,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8828": {
+                                "Element-8858": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -14073,7 +14099,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8831": {
+                                "Element-8861": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -14310,7 +14336,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8834": {
+                                "Element-8864": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -14360,19 +14386,19 @@ exports[`KeyboardInput renders 1`] = `
                                       "attached": true,
                                       "boundsMargin": null,
                                       "children": {
-                                        "TextWrapper": {
+                                        "Prefix": {
                                           "active": false,
                                           "alpha": 1,
                                           "attached": true,
                                           "boundsMargin": null,
                                           "children": {
-                                            "Title": {
+                                            "Items": {
                                               "active": false,
-                                              "alpha": 0.001,
+                                              "alpha": 1,
                                               "attached": true,
                                               "boundsMargin": null,
                                               "children": {
-                                                "Text": {
+                                                "Element-9015": {
                                                   "active": false,
                                                   "alpha": 1,
                                                   "attached": true,
@@ -14382,42 +14408,33 @@ exports[`KeyboardInput renders 1`] = `
                                                   "enabled": true,
                                                   "flex": false,
                                                   "flexItem": false,
-                                                  "h": 0,
-                                                  "isComponent": undefined,
+                                                  "h": 40,
+                                                  "hasFinalFocus": false,
+                                                  "hasFocus": false,
+                                                  "isComponent": true,
                                                   "mount": 0,
                                                   "mountX": 0,
                                                   "mountY": 0,
                                                   "pivot": 0.5,
                                                   "pivotX": 0.5,
                                                   "pivotY": 0.5,
-                                                  "ref": "Text",
+                                                  "ref": null,
                                                   "renderOfScreen": undefined,
                                                   "renderToTexture": false,
                                                   "scale": 1,
                                                   "scaleX": 1,
                                                   "scaleY": 1,
-                                                  "state": undefined,
+                                                  "state": "",
                                                   "tag": [Function],
-                                                  "tags": [
-                                                    "Text",
-                                                  ],
                                                   "texture": {
-                                                    "fontFace": "Arial",
-                                                    "fontSize": 30,
-                                                    "letterSpacing": -0.2,
-                                                    "lineHeight": 40,
-                                                    "maxLines": 1,
-                                                    "text": "Delete",
-                                                    "textBaseline": "bottom",
-                                                    "textColor": 4294506490,
-                                                    "type": "TextTexture",
-                                                    "verticalAlign": "middle",
-                                                    "wordWrapWidth": 130,
+                                                    "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJAAAACQCAYAAADnRuK4AAAAAXNSR0IArs4c6QAACmpJREFUeF7tnVmoZUcVhv/feY4gBEVEH/KgCCZxCK2itNo4xQQH+kUN0TjEiDGKKBqnaExwBjUaR6KY+NQgiQkOMSYhYEScIopGJOqDE2hHjfP0y4p1Oqdv33v2qr32Prv2Paug6Ye7Vu2qv75TtWvtGohMqUBAAQZ80zUVQAKUEIQUSIBC8qVzApQMhBRIgELypXMClAyEFEiAQvKlcwKUDIQUSIBC8qVzApQMhBRIgELypXMClAyEFEiAQvKlcwKUDIQUSIBC8qVzApQMhBRIgELypXMClAyEFEiAQvKlcwKUDIQUSIBC8qVzApQMhBRIgELypXMClAyEFEiAQvKlcwKUDIQUSIBC8qVzApQMhBRIgELypfPsAJJ0NYC92XRHKPB3AAfLv18BuBLAFSR/NKZWswJI0vkA3jCmILsw75sAvIfkR8eo22wAknQSgMvGEGFD8vwxgFeQvGrI+s4CIEnHAPgugHsMWfkNzevDAM4i+Z8h6t88QJLuXOB5yBAVzjxuVeBaAM8ieXNUjzkAdAmA50Yrmv5HKPATACeQ/GNEm6YBkvRyANblZhpHAXsfekpkOGsWIEmPAHA9gDuOo13mWhS4gOSZfdVoEiBJ9wFwA4D7961Y+lUpsK/v7KxVgL4K4ElOCS4l+Uyn7a41k3Q0gMcC2ANgH4CHV1T2OyStx69OzQEk6TwAZztr8lMAx5P8s9N+Y8wk2cTjfQDu66z080h+zml7yKwpgCSdCOByZyX+BuBRJH/otN84M0kWN/s0gOc4Kv8Nko922B1m0gxAkh4I4AcVwcL9JA/UVnjT7CXdHYD9yEzfVUkAjib5uxqNmgCoBAu/CeBhzsJ/kORZTtuNN5Nk70bXAZ0Hy59G8qIawVoB6LMAnu8suE3tH0/y3077NAMg6esAuoaoC0la7M2dJgdI0ssAXOgs8W8BHEvS/s9UoYCkdwN4bYfL5STto7U7TQpQZbDQehzreawHylSpgKSTAVza4XYDyeNqsp4MoB7BwteQfH9N5dL2NgWK3l0vyAdJWhDXnSYBSNLtANh3GO/KwgMk97trlYbbKiDJPpzea5U8JKuYqDIeql0kvQPAG5352ZLMR5L8q9M+zXZQYFcAJOnJAL7sbGWLMFuk2SLOmYIKzB6gEiz8HoB7O7U4meQXnLZp1qGApD8BuOcsh7AewcL3kuyadg4OjSSbhRxH0j4BjJok2Ufga0j+YdQHlcznDlBNsPAa+xpP8r/rEHbxjAKPbRuyHvKFY0Ik6QUALOprPfIT1gHRbAGSdDoA77aSX5Zg4e8nhGfx6FEgWoJn8Zy1QCTplq5vjc3NwnoEC/eQ/HYD8IwC0TbwrA2i2QHUI1h4JskLGoJnUIhWwLMWiGYFkCSLMX2t5WDhlneeLm5Dw5kDntEhkmRhEVvesWNqZgiTdC6AN3W1Svn72oOFkuxF+WcVIQUrai+IKuA5BBHJ453auc1mA1AJFn7Jsf7EKj9ZsLBHw1ZDtI5neAmaBUBzCxaO2cBj5u2FZtlO0l8A3K3ZIaxHsPB8kt5vYn00c/mM0dBj5OmqzAqjOQDUfLBwJ32HbPAh84pCM5seSNJLAHzcWeFJgoVdZRui4YfIo6ucff8uyVY03LW5IawyWPgvW5u77mChV/QIABFfb/kidk0CVKbDth3Huw35dJLeniqiV2/fniDYx1f7vlWTeoUFah6wZQhrqwcqwUKbrtsaH0+6mOQpHsOpbXpCVFPstcJjBZNkmzHv0swQJultAN7iVO375TyafzjtJzcbEaK1w9McQJXBQlvvYmtsfjE5FZUFGAGiSeBpCqDKYKFtmX0qya9Utl0z5gNCNBk8BSA7CtiODNwxjf4trEew8BySNtTNOg0A0aTwtARQTbDQeh3rfawXmn0KQDQ5PC0B9EkAL3LSkAD9X6hWALIJzJ3mNoSdS9I7U3NyuX6zQO+zKOzkEEmaHqDSFdpZM97tOfkSfRvvk0LUDEAFIgseetf85DS+AYgk/bPr1NvRZ2HLg4ektwI4xzmgZCBxYohaBMjWPeenDOcvaIvZ2oez5gAqQ5mtLbb3oa4z+Bb6nTHW1UP92vFIr54vzJ8BcGplGdYKkSRbCXGHSWdh2z1ckp1taGccroxyFt9cznG4iGuDqFmASk9kZxxakNGTckHZBBA1DVCB6BMAXuwhyA4VmGL/+05l6zlsbdt7DJmXU0uXmSQ7JvD2zQ1hiwJJsotRvlVxXO87SU5+heUYDT5Gni5KVhg1D1DphWqCjOYy6RlAYzb0mHn3gWkWABWIaoKMubHwSBpGebGWZNdc2vmUO6a1BhJXFUSSff/yLuOYamvzzwEcVfFr7tWwPXqi6uN2PXWYG0C1Qca1n8RaDlewl3kPRL3gWXo/XBwo1dXWdk/a3jEOnJoVQGUoqw0yvpLkh7oUHvLvTohC8FRANBo8pT3sxLeVJ/M2M4QtiVYTZJzkNPoOiAaBxwHRqPDMFqBS8Jog4yT3YewA0aDwrIBodHhmDVApvG0mtO3PnjTJjTxbIBoFnm0gWgs8pQ06lxY3N4QtCWZBRgPDezdnHvPr+alV2EiaL0DlF2Dbn20bdB40XtHwQ5nOHqAC0SyCjEM1Wkv57AqACkRvBvB2p7hrDzI6yzU7s90EUPNBxtnR4SjwrgGo9EK1Qca8cM4ByU4mkuz++F93ZHELyZX3iW31n+S+sKWZWfNBxkCbNeUq6ekArugo1I0kH1xT8EkBKj1R80HGGkFbtZVkZ3bb2d2r0tUkn1hTh8kBKhB9DMBLnQWfJMjoLFuTZpJsO/ONAB7UUcBLSHqvX781q1YAqg0yfoDkq5psrQYLJeldAF7nKFr1x+wmACq9kAUZLazvvTV4P8kDDlE22kTSQ4uuK9dCF5HuR/I3NYI1A1CBaB+AK50VsAMj7TJeixNl2kYBSccCsB/ZMQ6Brif5GIfdYSZNAVQg8rzsLSphl/Hapby2LDZTUaBcq/56ALb1fOVxLkuinULy4loRmwOoQGQX7T7DWZnPk3y203bXmkl6AIA91isDOBGADV3e1HsJbasA1QYZvUKl3fYKPI2knXFQnZoEqPRCNUHG6oqnwyEFLiJ5Wl89mgWoQFQTZOyrwSb7WUztcSRtu0+v1DRABaKPADijV+3SaZUCNgE5geTNEZnmAFBtkDGix6b4Xld2BNvJcaHUPEClF6oNMoZE2eXOtm3q1ZFha1mfWQBUINoL4Kqurbm7vPEj1bOAqx3udW0kk62+swGoQHQ2gPOGFGAD8roJgF0t+qkx6jorgApElwE4aQwxZp6n3YNxsPyzA7yst/4iSdvEMFqaHUCjKZEZ91IgAeolWzotFEiAkoWQAglQSL50ToCSgZACCVBIvnROgJKBkAIJUEi+dE6AkoGQAglQSL50ToCSgZACCVBIvnROgJKBkAIJUEi+dE6AkoGQAglQSL50ToCSgZACCVBIvnROgJKBkAIJUEi+dE6AkoGQAglQSL50ToCSgZACCVBIvnROgJKBkAIJUEi+dE6AkoGQAglQSL50ToCSgZACCVBIvnT+H0jPT81J3xWWAAAAAElFTkSuQmCC",
+                                                    "type": "ImageTexture",
                                                   },
+                                                  "type": "Icon",
                                                   "visible": true,
-                                                  "w": 0,
+                                                  "w": 40,
                                                   "x": 0,
-                                                  "y": 2,
+                                                  "y": 0,
                                                   "zIndex": 0,
                                                 },
                                               },
@@ -14426,35 +14443,70 @@ exports[`KeyboardInput renders 1`] = `
                                               "enabled": true,
                                               "flex": false,
                                               "flexItem": false,
-                                              "h": 0,
-                                              "hasFinalFocus": false,
-                                              "hasFocus": false,
-                                              "isComponent": true,
+                                              "h": 40,
+                                              "isComponent": undefined,
                                               "mount": 0,
                                               "mountX": 0,
-                                              "mountY": 0.5,
+                                              "mountY": 0,
                                               "pivot": 0.5,
                                               "pivotX": 0.5,
                                               "pivotY": 0.5,
-                                              "ref": "Title",
+                                              "ref": "Items",
                                               "renderOfScreen": undefined,
                                               "renderToTexture": false,
                                               "scale": 1,
                                               "scaleX": 1,
                                               "scaleY": 1,
-                                              "state": "",
+                                              "state": undefined,
                                               "tag": [Function],
                                               "tags": [
-                                                "Title",
+                                                "Items",
                                               ],
-                                              "type": "TextBox",
                                               "visible": true,
-                                              "w": 0,
+                                              "w": 40,
                                               "x": 0,
-                                              "y": [Function],
+                                              "y": 0,
                                               "zIndex": 0,
                                             },
                                           },
+                                          "clipping": false,
+                                          "color": 4294967295,
+                                          "enabled": true,
+                                          "flex": false,
+                                          "flexItem": false,
+                                          "h": 40,
+                                          "hasFinalFocus": false,
+                                          "hasFocus": false,
+                                          "isComponent": true,
+                                          "mount": 0,
+                                          "mountX": 0,
+                                          "mountY": 0.5,
+                                          "pivot": 0.5,
+                                          "pivotX": 0.5,
+                                          "pivotY": 0.5,
+                                          "ref": "Prefix",
+                                          "renderOfScreen": undefined,
+                                          "renderToTexture": false,
+                                          "scale": 1,
+                                          "scaleX": 1,
+                                          "scaleY": 1,
+                                          "state": "Row",
+                                          "tag": [Function],
+                                          "tags": [
+                                            "Prefix",
+                                          ],
+                                          "type": "Row",
+                                          "visible": true,
+                                          "w": 40,
+                                          "x": 0,
+                                          "y": 0,
+                                          "zIndex": 0,
+                                        },
+                                        "TextWrapper": {
+                                          "active": false,
+                                          "alpha": 1,
+                                          "attached": true,
+                                          "boundsMargin": null,
                                           "clipping": false,
                                           "color": 4294967295,
                                           "enabled": true,
@@ -14464,7 +14516,7 @@ exports[`KeyboardInput renders 1`] = `
                                           "isComponent": undefined,
                                           "mount": 0,
                                           "mountX": 0,
-                                          "mountY": 0.5,
+                                          "mountY": 0,
                                           "pivot": 0.5,
                                           "pivotX": 0.5,
                                           "pivotY": 0.5,
@@ -14511,7 +14563,7 @@ exports[`KeyboardInput renders 1`] = `
                                         "Content",
                                       ],
                                       "visible": true,
-                                      "w": 0,
+                                      "w": 40,
                                       "x": 75,
                                       "y": 45,
                                       "zIndex": 2,
@@ -14609,7 +14661,7 @@ exports[`KeyboardInput renders 1`] = `
                           "y": 0,
                           "zIndex": 0,
                         },
-                        "Element-8837": {
+                        "Element-8867": {
                           "active": false,
                           "alpha": 1,
                           "attached": true,
@@ -14621,7 +14673,7 @@ exports[`KeyboardInput renders 1`] = `
                               "attached": true,
                               "boundsMargin": null,
                               "children": {
-                                "Element-8839": {
+                                "Element-8869": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -14858,7 +14910,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8842": {
+                                "Element-8872": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -15095,7 +15147,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8845": {
+                                "Element-8875": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -15332,7 +15384,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8848": {
+                                "Element-8878": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -15569,7 +15621,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8851": {
+                                "Element-8881": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -15806,7 +15858,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8854": {
+                                "Element-8884": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -16043,7 +16095,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8857": {
+                                "Element-8887": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -16280,7 +16332,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8860": {
+                                "Element-8890": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -16517,7 +16569,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8863": {
+                                "Element-8893": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -16754,7 +16806,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8866": {
+                                "Element-8896": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -16991,7 +17043,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8869": {
+                                "Element-8899": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -17290,7 +17342,7 @@ exports[`KeyboardInput renders 1`] = `
                           "y": 10,
                           "zIndex": 0,
                         },
-                        "Element-8872": {
+                        "Element-8902": {
                           "active": false,
                           "alpha": 1,
                           "attached": true,
@@ -17302,7 +17354,7 @@ exports[`KeyboardInput renders 1`] = `
                               "attached": true,
                               "boundsMargin": null,
                               "children": {
-                                "Element-8874": {
+                                "Element-8904": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -17539,7 +17591,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8877": {
+                                "Element-8907": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -17776,7 +17828,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8880": {
+                                "Element-8910": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -18013,7 +18065,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8883": {
+                                "Element-8913": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -18250,7 +18302,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8886": {
+                                "Element-8916": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -18487,7 +18539,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8889": {
+                                "Element-8919": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -18724,7 +18776,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8892": {
+                                "Element-8922": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -18961,7 +19013,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8895": {
+                                "Element-8925": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -19198,7 +19250,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8898": {
+                                "Element-8928": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -19435,7 +19487,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8901": {
+                                "Element-8931": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -19672,7 +19724,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8904": {
+                                "Element-8934": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -19971,7 +20023,7 @@ exports[`KeyboardInput renders 1`] = `
                           "y": 20,
                           "zIndex": 0,
                         },
-                        "Element-8907": {
+                        "Element-8937": {
                           "active": false,
                           "alpha": 1,
                           "attached": true,
@@ -19983,7 +20035,7 @@ exports[`KeyboardInput renders 1`] = `
                               "attached": true,
                               "boundsMargin": null,
                               "children": {
-                                "Element-8909": {
+                                "Element-8939": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -20220,7 +20272,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8912": {
+                                "Element-8942": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -20457,7 +20509,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8915": {
+                                "Element-8945": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -20694,7 +20746,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8918": {
+                                "Element-8948": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -20931,7 +20983,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8921": {
+                                "Element-8951": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -21168,7 +21220,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8924": {
+                                "Element-8954": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -21405,7 +21457,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8927": {
+                                "Element-8957": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -21642,7 +21694,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8930": {
+                                "Element-8960": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -21879,7 +21931,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8933": {
+                                "Element-8963": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -22116,7 +22168,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8936": {
+                                "Element-8966": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -22353,7 +22405,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8939": {
+                                "Element-8969": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -22652,7 +22704,7 @@ exports[`KeyboardInput renders 1`] = `
                           "y": 30,
                           "zIndex": 0,
                         },
-                        "Element-8942": {
+                        "Element-8972": {
                           "active": false,
                           "alpha": 1,
                           "attached": true,
@@ -22664,7 +22716,7 @@ exports[`KeyboardInput renders 1`] = `
                               "attached": true,
                               "boundsMargin": null,
                               "children": {
-                                "Element-8944": {
+                                "Element-8974": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -22901,7 +22953,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8947": {
+                                "Element-8977": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,
@@ -23138,7 +23190,7 @@ exports[`KeyboardInput renders 1`] = `
                                   "y": 0,
                                   "zIndex": 0,
                                 },
-                                "Element-8950": {
+                                "Element-8980": {
                                   "active": false,
                                   "alpha": 1,
                                   "attached": true,

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
@@ -113,9 +113,6 @@ export default function withThemeStyles(Base, mixinStyle) {
      * Allows themes to override component values
      */
     get _styleOverrides() {
-      // if (this.constructor.name === 'Card') {
-      //   console.log(clone(this.styleConfig || {}, this._componentConfig?.styleConfig))
-      // }
       return clone(this.styleConfig || {}, this._componentConfig?.styleConfig);
     }
 

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
@@ -102,9 +102,6 @@ export default function withThemeStyles(Base, mixinStyle) {
         .reduce((acc, curr) => {
           return clone(acc, this.theme?.componentConfig?.[curr] || {});
         }, {});
-      // if (this.constructor.name === 'Card') {
-      //   console.log(result, this.theme.componentConfig);
-      // }
       return result;
     }
 


### PR DESCRIPTION
## Description

When updating the theme you should be able to override the unfocused and focused backgroundColor. using styleConfig on extended components like Card. 

## References

[LUI-807](https://ccp.sys.comcast.net/browse/LUI-807)

## Testing

Adding the following to the theme should allow the card to be red when it has focus.

![Screen Shot 2023-05-04 at 10 49 42 AM](https://user-images.githubusercontent.com/2578683/236290090-b4f9490a-abb0-4f24-9527-af4e1dadf93d.png)

To test it is helpful to update this package in node_modules with the following. Then restart storybook.

```
componentConfig: {
     Card: {
          styleConfig: {
               mode: {
                    focused: {
                         backgroundColor: utils.getHexColor('#FF0000'),
                    },
               },
          },
    }
}
```


## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
