### PR TITLE
fix(NavigationManager): only follow one scroll behavior at a time

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Column/Column.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.mdx
@@ -103,6 +103,11 @@ class ExpandableHeightItems extends lng.Component {
   <Story id="navigation-column--column" />
 </Canvas>
 
+### Scrolling
+
+Scroll behavior is determined based on what is passed to the `alwaysScroll` and `neverScroll` properties.
+If both of those properties are enabled, `alwaysScroll` will take precedence over `neverScroll`.
+
 ## API
 
 ### Properties

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -483,6 +483,9 @@ export default class NavigationManager extends FocusManager {
   }
 
   _getNeverScroll() {
+    if (this.alwaysScroll) {
+      return false;
+    }
     return this._neverScroll !== undefined
       ? this._neverScroll
       : this.style.neverScroll;

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.mdx
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.mdx
@@ -46,6 +46,8 @@ class CustomRow extends NavigationManager {}
 ### Scrolling
 
 The `scrollIndex` property determines the index at which scrolling should begin. By default, that index is 0.
+Scroll behavior is determined based on what is passed to the `alwaysScroll` and `neverScroll` properties.
+If both of those properties are enabled, `alwaysScroll` will take precedence over `neverScroll`.
 
 ### directionProps
 

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.test.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.test.js
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *b
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.test.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.test.js
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
+ *b
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -415,5 +415,15 @@ describe('NavigationManager', () => {
 
       expect(navigationManager.selectedIndex).toBe(0);
     });
+  });
+
+  it('should favor alwaysScroll over neverScroll for scroll behavior', () => {
+    [navigationManager] = createNavigationManager({
+      alwaysScroll: true,
+      neverScroll: true
+    });
+
+    expect(navigationManager.alwaysScroll).toBe(true);
+    expect(navigationManager.neverScroll).toBe(false);
   });
 });

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.js
@@ -210,4 +210,22 @@ export default class Row extends NavigationManager {
   get _totalAddedWidth() {
     return this._totalAddedLength;
   }
+
+  _getLazyScroll() {
+    if (this.alwaysScroll) {
+      return false;
+    }
+    return this._lazyScroll !== undefined
+      ? this._lazyScroll
+      : this.style.lazyScroll;
+  }
+
+  _getNeverScroll() {
+    if (this.alwaysScroll || this.lazyScroll) {
+      return false;
+    }
+    return this._neverScroll !== undefined
+      ? this._neverScroll
+      : this.style.neverScroll;
+  }
 }

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.mdx
@@ -58,6 +58,8 @@ class Basic extends lng.Component {
 By default, `Row` will scroll horizontally to see any items that are not visible within the width of the Row((or just outside of the `Row` width)
 
 The `scrollIndex` property determines the index at which scrolling should begin. By default, that index is 0.
+Scroll behavior is determined based on what is passed to the `alwaysScroll`, `lazyScroll`, and `neverScroll` properties.
+If multiple of these properties are enabled, the order of precedence from highest to lowest is: `alwaysScroll`, `lazyScroll`, `neverScroll`.
 
 ## API
 

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.test.js
@@ -616,12 +616,16 @@ describe('Row', () => {
     expect(row.neverScroll).toBe(false);
 
     row.alwaysScroll = false;
+    row.lazyScroll = true;
+    row.neverScroll = true;
 
     expect(row.alwaysScroll).toBe(false);
     expect(row.lazyScroll).toBe(true);
     expect(row.neverScroll).toBe(false);
 
+    row.alwaysScroll = false;
     row.lazyScroll = false;
+    row.neverScroll = true;
 
     expect(row.alwaysScroll).toBe(false);
     expect(row.lazyScroll).toBe(false);

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.test.js
@@ -604,4 +604,27 @@ describe('Row', () => {
       });
     });
   });
+  it('should determine scroll behavior folowing this precedence from highest to lowest: alwaysScroll > lazyScroll > neverScroll', () => {
+    [row] = createRow({
+      alwaysScroll: true,
+      lazyScroll: true,
+      neverScroll: true
+    });
+
+    expect(row.alwaysScroll).toBe(true);
+    expect(row.lazyScroll).toBe(false);
+    expect(row.neverScroll).toBe(false);
+
+    row.alwaysScroll = false;
+
+    expect(row.alwaysScroll).toBe(false);
+    expect(row.lazyScroll).toBe(true);
+    expect(row.neverScroll).toBe(false);
+
+    row.lazyScroll = false;
+
+    expect(row.alwaysScroll).toBe(false);
+    expect(row.lazyScroll).toBe(false);
+    expect(row.neverScroll).toBe(true);
+  });
 });


### PR DESCRIPTION
## Description
Bug: Prior to this change, when both `alwaysScroll` and `lazyScroll` were enabled, the `Row` component would correctly follow neither. It would instead mix logic from both behaviors for an undesired scrolling experience.

This updates the NavigationManager, Row, and Column to only follow one scroll behavior regardless of how many of those properties are enabled. When multiple scroll behavior properties are enabled, this is how one is chosen from highest to lowest precedence:
1. alwaysScroll
2. lazyScroll
3. neverScroll
<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References
LUI-729
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
In NavigationManager, Row, and Column stories:
1. enable any combination of `alwaysScroll`, `lazyScroll`, `neverScroll` (note: `lazyScroll` is only supported in `Row`)
ER: Only 1 of those behaviors will be followed by the component, following the hierarchy outlined above.
<!-- step by step instructions to review this PR's changes -->

## Automation
n/a
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
