### PR TITLE
fix: make sure context listeners are removed on _detach

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Icon/Icon.js
+++ b/packages/@lightningjs/ui-components/src/components/Icon/Icon.js
@@ -114,14 +114,14 @@ function getIconTemplate(icon, w, h) {
       break;
     case isImageURI(icon):
       template.src = icon;
-      break
+      break;
     default:
       // Cover case where image is a blob url. See theme-manager.js
       template.texture = {
         type: lng.textures.ImageTexture,
         hasAlpha: true,
         src: icon
-      }
+      };
       break;
   }
   return template;

--- a/packages/@lightningjs/ui-components/src/components/Icon/Icon.js
+++ b/packages/@lightningjs/ui-components/src/components/Icon/Icon.js
@@ -93,10 +93,10 @@ export default class Icon extends Base {
   }
 }
 
-const [isSvgTag, isSvgURI, isImageURI] = [
+const [isSvgTag, isSvgURI, isBlobURI] = [
   /^<svg.*<\/svg>$/,
   /\.svg$/,
-  /\.(a?png|bmp|gif|ico|cur|jpe?g|pjp(eg)?|jfif|tiff?|webp)$/
+  /^blob:/
 ].map(regex => RegExp.prototype.test.bind(regex));
 
 function getIconTemplate(icon, w, h) {
@@ -112,17 +112,15 @@ function getIconTemplate(icon, w, h) {
     case isSvgURI(icon):
       template.texture = lng.Tools.getSvgTexture(icon, w, h);
       break;
-    case isImageURI(icon):
-      template.src = icon;
-      break;
-    default:
-      // Cover case where image is a blob url. See theme-manager.js
+    case isBlobURI(icon):
       template.texture = {
         type: lng.textures.ImageTexture,
         hasAlpha: true,
         src: icon
       };
       break;
+    default:
+      template.src = icon;
   }
   return template;
 }

--- a/packages/@lightningjs/ui-components/src/components/Icon/Icon.js
+++ b/packages/@lightningjs/ui-components/src/components/Icon/Icon.js
@@ -93,9 +93,10 @@ export default class Icon extends Base {
   }
 }
 
-const [isSvgTag, isSvgURI] = [
+const [isSvgTag, isSvgURI, isImageURI] = [
   /^<svg.*<\/svg>$/,
-  /\.svg$/
+  /\.svg$/,
+  /\.(a?png|bmp|gif|ico|cur|jpe?g|pjp(eg)?|jfif|tiff?|webp)$/
 ].map(regex => RegExp.prototype.test.bind(regex));
 
 function getIconTemplate(icon, w, h) {
@@ -111,7 +112,11 @@ function getIconTemplate(icon, w, h) {
     case isSvgURI(icon):
       template.texture = lng.Tools.getSvgTexture(icon, w, h);
       break;
+    case isImageURI(icon):
+      template.src = icon;
+      break
     default:
+      // Cover case where image is a blob url. See theme-manager.js
       template.texture = {
         type: lng.textures.ImageTexture,
         hasAlpha: true,

--- a/packages/@lightningjs/ui-components/src/components/Icon/Icon.js
+++ b/packages/@lightningjs/ui-components/src/components/Icon/Icon.js
@@ -93,15 +93,13 @@ export default class Icon extends Base {
   }
 }
 
-const [isSvgTag, isSvgURI, isImageURI] = [
+const [isSvgTag, isSvgURI] = [
   /^<svg.*<\/svg>$/,
-  /\.svg$/,
-  /\.(a?png|bmp|gif|ico|cur|jpe?g|pjp(eg)?|jfif|tiff?|webp)$/
+  /\.svg$/
 ].map(regex => RegExp.prototype.test.bind(regex));
 
 function getIconTemplate(icon, w, h) {
   const template = { w, h };
-
   switch (true) {
     case isSvgTag(icon):
       template.texture = lng.Tools.getSvgTexture(
@@ -113,11 +111,12 @@ function getIconTemplate(icon, w, h) {
     case isSvgURI(icon):
       template.texture = lng.Tools.getSvgTexture(icon, w, h);
       break;
-    case isImageURI(icon):
-      template.src = icon;
-      break;
     default:
-      template.src = icon;
+      template.texture = {
+        type: lng.textures.ImageTexture,
+        hasAlpha: true,
+        src: icon
+      }
       break;
   }
   return template;

--- a/packages/@lightningjs/ui-components/src/globals/context/theme-manager.js
+++ b/packages/@lightningjs/ui-components/src/globals/context/theme-manager.js
@@ -274,7 +274,7 @@ class ThemeManager {
   _clearCache() {
     // Clean up any base64 image that were converted to blobs using createObjectURL
     base64Cache.filter(image => {
-      URL.revokeObjectURL(image);
+      if (window.URL && typeof window.URL.revokeObjectURL === 'function') URL.revokeObjectURL(image);
       return false;
     });
 
@@ -368,7 +368,7 @@ class ThemeManager {
       }
       // Base64 encoded values can cause memory leaks convert to an image
       const { isImage, mimeType } = checkBase64EncodedImage(value);
-      if (isImage) {
+      if (window.URL && typeof window.URL.createObjectURL === 'function' && isImage) {
         // base64Cache
         try {
           const blobURL = base64ToBlobURL(value, mimeType);

--- a/packages/@lightningjs/ui-components/src/globals/context/theme-manager.js
+++ b/packages/@lightningjs/ui-components/src/globals/context/theme-manager.js
@@ -38,7 +38,7 @@ const merge = {
   }
 };
 
-let base64Cache = [];
+const base64Cache = [];
 
 const isSubTheme = themeName => 'subTheme' === themeName.slice(0, 8);
 
@@ -274,7 +274,8 @@ class ThemeManager {
   _clearCache() {
     // Clean up any base64 image that were converted to blobs using createObjectURL
     base64Cache.filter(image => {
-      if (window.URL && typeof window.URL.revokeObjectURL === 'function') URL.revokeObjectURL(image);
+      if (window.URL && typeof window.URL.revokeObjectURL === 'function')
+        URL.revokeObjectURL(image);
       return false;
     });
 
@@ -368,7 +369,11 @@ class ThemeManager {
       }
       // Base64 encoded values can cause memory leaks convert to an image
       const { isImage, mimeType } = checkBase64EncodedImage(value);
-      if (window.URL && typeof window.URL.createObjectURL === 'function' && isImage) {
+      if (
+        window.URL &&
+        typeof window.URL.createObjectURL === 'function' &&
+        isImage
+      ) {
         // base64Cache
         try {
           const blobURL = base64ToBlobURL(value, mimeType);

--- a/packages/@lightningjs/ui-components/src/globals/context/theme-manager.js
+++ b/packages/@lightningjs/ui-components/src/globals/context/theme-manager.js
@@ -21,12 +21,12 @@ import {
   getValFromObjPath,
   getHexColor,
   getValidColor
-} from '../../utils';
+} from '../../utils/index.js'; // Keep index.js so it can be used by node
 import baseTheme from '@lightningjs/ui-components-theme-base';
 import logger from './logger.js';
 import events from './events.js';
 import { fontLoader, cleanupFonts } from './fonts.js';
-import { THEME_KEY_REPLACER } from './constants';
+import { THEME_KEY_REPLACER } from './constants.js'; // Add js so it can be used
 
 const merge = {
   all: objArray => {
@@ -37,7 +37,79 @@ const merge = {
     return result;
   }
 };
+
+let base64Cache = [];
+
 const isSubTheme = themeName => 'subTheme' === themeName.slice(0, 8);
+
+/**
+ * Extracts the MIME type from a Data URI.
+ *
+ * @param {string} dataUri - The Data URI string.
+ * @returns {string|null} The extracted MIME type, or null if not found.
+ */
+function getMimeTypeFromDataUri(dataUri) {
+  const matches = dataUri.match(/^data:(.*?);base64,/);
+  if (matches && matches.length === 2) {
+    return matches[1];
+  }
+  return null;
+}
+
+/**
+ * Checks if a string represents a Base64-encoded image and extracts the MIME type.
+ *
+ * @param {string} str - The string to check.
+ * @returns {{ isImage: boolean, mimeType: string|null }} An object indicating whether the string is an image and the extracted MIME type.
+ */
+function checkBase64EncodedImage(str) {
+  const regex = /^data:image\/(jpeg|jpg|png|gif);base64,/;
+  const isImage = regex.test(str);
+  const mimeType = isImage ? getMimeTypeFromDataUri(str.match(regex)[0]) : null;
+
+  return {
+    isImage,
+    mimeType
+  };
+}
+
+/**
+ * Converts a Base64-encoded image to a Blob URL.
+ * Note: Make sure to handle potential memory leaks caused by the browser's image caching.
+ *
+ * @param {string} base64String - The Base64-encoded image string.
+ * @param {string} mimeType - The MIME type of the image.
+ * @returns {string|null} The Blob URL representing the converted image, or null if conversion fails.
+ */
+function base64ToBlobURL(base64String, mimeType) {
+  const byteCharacters = atob(
+    base64String.substring(base64String.indexOf(',') + 1)
+  );
+  const byteArrays = [];
+
+  try {
+    for (let offset = 0; offset < byteCharacters.length; offset += 512) {
+      const slice = byteCharacters.slice(offset, offset + 512);
+      const byteNumbers = new Array(slice.length);
+
+      for (let i = 0; i < slice.length; i++) {
+        byteNumbers[i] = slice.charCodeAt(i);
+      }
+
+      const byteArray = new Uint8Array(byteNumbers);
+      byteArrays.push(byteArray);
+    }
+
+    const blob = new Blob(byteArrays, { type: mimeType });
+    const blobURL = URL.createObjectURL(blob);
+
+    return blobURL;
+  } catch (error) {
+    logger.info('Unable to convert base64 image to URL');
+    return null;
+  }
+}
+
 class ThemeManager {
   constructor() {
     this._cache = new Map();
@@ -52,7 +124,7 @@ class ThemeManager {
     }
   }
 
-  // Handle separate instances of context accross the application and keep them in sync
+  // Handle separate instances of context across the application and keep them in sync
   _setCache(key, payload) {
     if (typeof window === 'undefined') return;
     window.LUI.themeManagerInstances.forEach(({ themeManager }) => {
@@ -200,6 +272,12 @@ class ThemeManager {
   }
 
   _clearCache() {
+    // Clean up any base64 image that were converted to blobs using createObjectURL
+    base64Cache.filter(image => {
+      URL.revokeObjectURL(image);
+      return false;
+    });
+
     this._cache.forEach((value, key) => {
       if ('string' !== typeof key || !isSubTheme(key)) {
         this._deleteCache(key);
@@ -288,6 +366,19 @@ class ThemeManager {
 
         value = replacement;
       }
+      // Base64 encoded values can cause memory leaks convert to an image
+      const { isImage, mimeType } = checkBase64EncodedImage(value);
+      if (isImage) {
+        // base64Cache
+        try {
+          const blobURL = base64ToBlobURL(value, mimeType);
+          base64Cache.push(blobURL);
+          return blobURL;
+        } catch (error) {
+          return value;
+        }
+      }
+
       if (
         Array.isArray(value) &&
         2 === value.length &&

--- a/packages/@lightningjs/ui-components/src/globals/context/theme-manager.js
+++ b/packages/@lightningjs/ui-components/src/globals/context/theme-manager.js
@@ -21,12 +21,12 @@ import {
   getValFromObjPath,
   getHexColor,
   getValidColor
-} from '../../utils/index.js'; // Keep index.js so it can be used by node
+} from '../../utils/index.js';
 import baseTheme from '@lightningjs/ui-components-theme-base';
 import logger from './logger.js';
 import events from './events.js';
 import { fontLoader, cleanupFonts } from './fonts.js';
-import { THEME_KEY_REPLACER } from './constants.js'; // Add js so it can be used
+import { THEME_KEY_REPLACER } from './constants.js';
 
 const merge = {
   all: objArray => {

--- a/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.js
@@ -136,15 +136,28 @@ export default function withExtensions(Base) {
       this._appliedExtensionLength = 0; // After the extensions are applied we store the length of all to determine later on if they have been applied before
       this._extendedList = {};
       this._extensionInstance = {}; // This will hold the extension instance once created
-      context.on('themeUpdate', () => {
-        this._currentComponentExtensionLength =
-          this._calculateComponentExtensionLength();
-        this._createExtension.call(this);
-      });
+      this._updateExtensionBound = this._updateExtension.bind(this);
+      context.on('themeUpdate', this._updateExtensionBound);
+      this._updateExtension();
+      super._construct();
+    }
+
+    /**
+     * Detach the event listeners to prevent memory leaks.
+     */
+    _detach() {
+      super._detach();
+      this._clearExtensionListeners();
+    }
+
+    _clearExtensionListeners() {
+      context.off('themeUpdate', this._updateExtensionBound);
+    }
+
+    _updateExtension() {
       this._currentComponentExtensionLength =
         this._calculateComponentExtensionLength();
       this._createExtension();
-      super._construct();
     }
 
     _resetComponent() {

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
@@ -116,7 +116,6 @@ export default function withThemeStyles(Base, mixinStyle) {
     /**
      * Must check for subThemes on _setup lifecycle event to allow the component to traverse the tree to find child theme properties
      */
-
     _setup() {
       super._setup && super._setup();
       this._targetSubTheme = this._getSubTheme();
@@ -125,6 +124,14 @@ export default function withThemeStyles(Base, mixinStyle) {
         this._generateComponentStyleSource();
         this.queueThemeUpdate.call(this);
       }
+    }
+
+    /**
+     * Detach the event listeners to prevent memory leaks.
+     */
+    _detach() {
+      super._detach();
+      this._clearThemeStyleListeners();
     }
 
     /**
@@ -275,6 +282,16 @@ export default function withThemeStyles(Base, mixinStyle) {
       }
     }
 
+    _clearThemeStyleListeners() {
+      context.off('themeUpdate', this._updateThemeBound);
+      if (this._targetSubTheme) {
+        context.off(
+          `themeUpdate${this._targetSubTheme}`,
+          this._updateThemeBound
+        );
+      }
+    }
+
     _updateTheme() {
       this._clearComponentStyleCache();
       this._generateComponentStyleSource();
@@ -283,20 +300,6 @@ export default function withThemeStyles(Base, mixinStyle) {
 
     _clearComponentStyleCache() {
       this._componentStyleCache = {};
-    }
-
-    _clearListeners() {
-      context.off('themeUpdate', this._updateTheme);
-      if (this._targetSubTheme) {
-        context.off('themeUpdate', this._updateTheme);
-      }
-    }
-
-    /**
-     * Detach the event listeners attached to prevent memory leaks.
-     */
-    _detach() {
-      this._clearListeners();
     }
 
     /**


### PR DESCRIPTION
## Description

Cleanup themeUpdate event listeners when when a component in destroyed in withThemeStyles as well as withExtensions mixins.

This PR also will convert every base64 encoded image stored in a theme to a URL using `URL.createObjectURL`.

It has been observed that base64 encoded strings seamed to get cached in memory causing performance issues. By converting these images into urls we hope to alleviate this issue. 

## References

- [LUI-817](https://ccp.sys.comcast.net/browse/LUI-817)
- [LUI-825](https://ccp.sys.comcast.net/browse/LUI-825)

## Testing

Create and destroy an Artwork component or Tile many times. Memory should be freed up once the component is removed. 


## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
