### PR TITLE
fix(CardContentVerticalSmall): remove unused control

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContentHorizontal.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContentHorizontal.stories.js
@@ -67,13 +67,6 @@ CardContentHorizontal.args = {
 };
 CardContentHorizontal.argTypes = {
   ...createModeControl({ summaryValue: 'focused' }),
-  shouldCollapse: {
-    control: 'boolean',
-    description: controlDescriptions.shouldCollapse,
-    table: {
-      defaultValue: { summary: false }
-    }
-  },
   collapseToMetadata: {
     control: 'boolean',
     description: controlDescriptions.collapseToMetadata,

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContentHorizontalLarge.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContentHorizontalLarge.stories.js
@@ -70,13 +70,6 @@ CardContentHorizontalLarge.args = {
 };
 CardContentHorizontalLarge.argTypes = {
   ...createModeControl({ summaryValue: CardContentHorizontalLarge.args.mode }),
-  shouldCollapse: {
-    control: 'boolean',
-    description: controlDescriptions.shouldCollapse,
-    table: {
-      defaultValue: { summary: false }
-    }
-  },
   collapseToMetadata: {
     control: 'boolean',
     description: controlDescriptions.collapseToMetadata,

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVertical.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVertical.stories.js
@@ -26,7 +26,6 @@ import { default as Icon } from '../Icon';
 import xfinityLogo from '../../assets/images/Xfinity-Provider-Logo-2x1.png';
 import { CardContent } from './CardContent.stories';
 import { CATEGORIES } from '../../docs/constants';
-import { controlDescriptions } from '../../docs/constants';
 
 export default {
   title: `${CATEGORIES[128]}/CardContentVertical`,
@@ -67,13 +66,6 @@ CardContentVertical.args = {
 };
 CardContentVertical.argTypes = {
   ...createModeControl({ summaryValue: 'focused' }),
-  shouldCollapse: {
-    control: 'boolean',
-    description: controlDescriptions.shouldCollapse,
-    table: {
-      defaultValue: { summary: false }
-    }
-  },
   ...CardContent.argTypes
 };
 

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVerticalSmall.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVerticalSmall.stories.js
@@ -24,7 +24,6 @@ import { createModeControl, generateSubStory } from '../../docs/utils';
 import CardContentVerticalSmallComponent from './CardContentVerticalSmall';
 import { CardContent } from './CardContent.stories';
 import { CATEGORIES } from '../../docs/constants';
-import { controlDescriptions } from '../../docs/constants';
 
 export default {
   title: `${CATEGORIES[128]}/CardContentVerticalSmall`,
@@ -49,22 +48,22 @@ export const CardContentVerticalSmall = args =>
   };
 
 CardContentVerticalSmall.storyName = 'CardContentVerticalSmall';
+const cardContentArgs = CardContent.args;
+delete cardContentArgs.metadata_details;
 
 CardContentVerticalSmall.args = {
   mode: 'focused',
   ...CardContent.args
 };
+
+const cardContentArgsTypes = CardContent.argTypes;
+delete cardContentArgsTypes.metadata_details;
+
 CardContentVerticalSmall.argTypes = {
   ...createModeControl({ summaryValue: CardContentVerticalSmall.args.mode }),
-  shouldCollapse: {
-    control: 'boolean',
-    description: controlDescriptions.shouldCollapse,
-    table: {
-      defaultValue: { summary: false }
-    }
-  },
   ...CardContent.argTypes
 };
+
 CardContentVerticalSmall.parameters = {
   argActions: CardContent.tileProps.argActions('CardContentVerticalSmall')
 };

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVerticalSmall.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVerticalSmall.stories.js
@@ -55,7 +55,7 @@ delete cardContentArgs.metadata_details;
 
 CardContentVerticalSmall.args = {
   mode: 'focused',
-  ...CardContent.args
+  ...cardContentArgs
 };
 
 //Creating a shallow copy of CardContent.argTypes object and removing metadata details property from cardContentArgsTypes
@@ -64,7 +64,7 @@ delete cardContentArgsTypes.metadata_details;
 
 CardContentVerticalSmall.argTypes = {
   ...createModeControl({ summaryValue: CardContentVerticalSmall.args.mode }),
-  ...CardContent.argTypes
+  ...cardContentArgsTypes
 };
 
 CardContentVerticalSmall.parameters = {

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVerticalSmall.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVerticalSmall.stories.js
@@ -48,7 +48,9 @@ export const CardContentVerticalSmall = args =>
   };
 
 CardContentVerticalSmall.storyName = 'CardContentVerticalSmall';
-const cardContentArgs = CardContent.args;
+
+//Creating a shallow copy of CardContent.args object and removing metadata details property from cardContentArgs
+const cardContentArgs = { ...CardContent.args };
 delete cardContentArgs.metadata_details;
 
 CardContentVerticalSmall.args = {
@@ -56,7 +58,8 @@ CardContentVerticalSmall.args = {
   ...CardContent.args
 };
 
-const cardContentArgsTypes = CardContent.argTypes;
+//Creating a shallow copy of CardContent.argTypes object and removing metadata details property from cardContentArgsTypes
+const cardContentArgsTypes = { ...CardContent.argTypes };
 delete cardContentArgsTypes.metadata_details;
 
 CardContentVerticalSmall.argTypes = {


### PR DESCRIPTION
## Description

This PR removed the metadata details property from cardContentArgs and cardContentArgsTypes and also shouldCollapse control has been removed from the CardContent variant components because this control is already included in the parent component (CardContent) and since all other variants are extending it, there is no need for a duplicate control.

## References

LUI-818

Testing:

1. Navigate to the CardContentVerticalSmall component in Storybook.
2. Verify that the delete control is not present in the component's story.
3. Also make sure shouldCollapse property is working as expected in each variant of the CardContent component.