### PR TITLE
fix(Tab): fix icon rendering in Tab component

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/TabBar/Tab.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/Tab.js
@@ -134,24 +134,20 @@ export default class Tab extends Surface {
   }
 
   _updateContent() {
-    const iconWidth = this._iconW || 0;
-    const titleWidth = this.title
-      ? this.style.iconMarginRight + this._textW
-      : 0;
     this._Content.patch({
-      w: iconWidth + titleWidth,
+      w:
+        this._iconW +
+        (this.title ? this.style.iconMarginRight : 0) +
+        this._textW,
       h: Math.max(this._iconH, this._Text.h)
     });
   }
 
   _updateTabSize() {
-    const contentWidth = this._iconW + this.style.iconMarginRight + this._textW;
-    const contentHeight = Math.max(this._iconH, this._Text.h);
-
     if (this.title || this.icon) {
       this.patch({
-        w: this._paddingX * 2 + contentWidth,
-        h: this.style.paddingY * 2 + contentHeight
+        w: this._paddingX * 2 + this._Content.w,
+        h: this.style.paddingY * 2 + this._Content.h
       });
     } else {
       this.patch({ w: 0, h: 0 });

--- a/packages/@lightningjs/ui-components/src/components/TabBar/Tab.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/Tab.js
@@ -81,31 +81,38 @@ export default class Tab extends Surface {
   }
 
   _updateIcon() {
-    if (this.icon) {
-      const iconPatch = {
-        src: this.icon,
-        w: this.style.iconSize,
-        h: this.style.iconSize,
-        y: this._Content.h / 2,
-        color: this.style.contentColor
-      };
-      if (!this.title) {
-        iconPatch.mountX = 0.5;
-        iconPatch.x = this._Content.w / 2;
-      }
-      if (this._Icon) {
-        this._Icon.patch(iconPatch);
-      } else {
-        this._Content.patch({
-          Icon: {
-            type: Icon,
-            mountY: 0.5,
-            ...iconPatch
-          }
-        });
-      }
-    } else {
+    if (!this.icon) {
       this._Content.patch({ Icon: undefined });
+      return;
+    }
+    const iconPatch = {
+      icon: this.icon,
+      w: this.style.iconSize,
+      h: this.style.iconSize,
+      y: this._Content.h / 2,
+      style: {
+        color: this.style.contentColor
+      }
+    };
+
+    if (this.title) {
+      iconPatch.x = 0;
+      iconPatch.mountX = 0;
+    } else {
+      iconPatch.x = this._Content.w / 2;
+      iconPatch.mountX = 0.5;
+    }
+
+    if (this._Icon) {
+      this._Icon.patch(iconPatch);
+    } else {
+      this._Content.patch({
+        Icon: {
+          type: Icon,
+          mountY: 0.5,
+          ...iconPatch
+        }
+      });
     }
   }
 
@@ -116,30 +123,35 @@ export default class Tab extends Surface {
       y: this._Content.h / 2
     };
     if (this.icon) {
-      textPatch.mountX = 0;
       textPatch.x = this._iconW + this.style.iconMarginRight;
+      textPatch.mountX = 0;
     } else {
-      textPatch.mountX = 0.5;
       textPatch.x = this._Content.w / 2;
+      textPatch.mountX = 0.5;
     }
+
     this._Text.patch(textPatch);
   }
 
   _updateContent() {
+    const iconWidth = this._iconW || 0;
+    const titleWidth = this.title
+      ? this.style.iconMarginRight + this._textW
+      : 0;
     this._Content.patch({
-      w:
-        this._iconW +
-        (this.title ? this.style.iconMarginRight : 0) +
-        this._textW,
+      w: iconWidth + titleWidth,
       h: Math.max(this._iconH, this._Text.h)
     });
   }
 
   _updateTabSize() {
+    const contentWidth = this._iconW + this.style.iconMarginRight + this._textW;
+    const contentHeight = Math.max(this._iconH, this._Text.h);
+
     if (this.title || this.icon) {
       this.patch({
-        w: this._paddingX * 2 + this._Content.w,
-        h: this.style.paddingY * 2 + this._Content.h
+        w: this._paddingX * 2 + contentWidth,
+        h: this.style.paddingY * 2 + contentHeight
       });
     } else {
       this.patch({ w: 0, h: 0 });

--- a/packages/@lightningjs/ui-components/src/components/TabBar/Tab.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/Tab.stories.js
@@ -45,7 +45,7 @@ export const Tab = () =>
 
 Tab.args = {
   icon: null,
-  title: 'Tab23',
+  title: 'Tab',
   mode: 'focused'
 };
 

--- a/packages/@lightningjs/ui-components/src/components/TabBar/Tab.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/Tab.stories.js
@@ -45,7 +45,7 @@ export const Tab = () =>
 
 Tab.args = {
   icon: null,
-  title: 'Tab2',
+  title: 'Tab23',
   mode: 'focused'
 };
 

--- a/packages/@lightningjs/ui-components/src/components/TabBar/Tab.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/Tab.stories.js
@@ -45,7 +45,7 @@ export const Tab = () =>
 
 Tab.args = {
   icon: null,
-  title: 'Tab',
+  title: 'Tab2',
   mode: 'focused'
 };
 

--- a/packages/@lightningjs/ui-components/src/components/TabBar/__snapshots__/Tab.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/__snapshots__/Tab.test.js.snap
@@ -53,7 +53,7 @@ exports[`Tab renders 1`] = `
           "attached": true,
           "boundsMargin": null,
           "clipping": false,
-          "color": "fff8f7fa",
+          "color": 4294967295,
           "enabled": true,
           "flex": false,
           "flexItem": false,
@@ -78,6 +78,10 @@ exports[`Tab renders 1`] = `
           "tags": [
             "Icon",
           ],
+          "texture": {
+            "src": "../../assets/images/ic_lightning_white_32.png",
+            "type": "ImageTexture",
+          },
           "type": "Icon",
           "visible": true,
           "w": 50,


### PR DESCRIPTION
## Description

In this PR, I have updated to use the icon property instead of src for specifying the icon and also wrapped content color within the style object.

## References

LUI-822

## Testing

1. Open the Tab and set Icon in icon control.
2. Click on the "Base" theme.
3. Confirm that the icon remains visible at all times, even when the title is removed or the mode is changed. The icon should persist until it is explicitly set to null.

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
