### PR TITLE
fix(FocusManager): update declaration file, remove centerInParent from props array

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.d.ts
@@ -19,44 +19,129 @@
 import lng from '@lightningjs/core';
 import Base from '../Base';
 
-export default class FocusManager extends Base {
-  protected _selectedChange(
-    selected: lng.Component | undefined,
-    prevSelected: lng.Component | undefined
-  ): void;
-  protected _selectedIndex: number;
-
-  direction?: string;
-  set items(
+export type NavigationDirectionType = 'none' | 'column' | 'row';
+export type FocusItemsType = Array<
+  lng.Component.NewPatchTemplate<lng.Component.Constructor> | lng.Component
+>;
+declare namespace FocusManager {
+  export interface TemplateSpec extends Base.TemplateSpec {
+    /**
+     * the navigation direction
+     */
+    direction?: NavigationDirectionType;
+    /**
+     * child element or elements of the FocusManager
+     */
     items: Array<
-      lng.Component.NewPatchTemplate<lng.Component.Constructor> | lng.Component
-    >
-  );
-  get items(): Array<
-    lng.Component.NewPatchTemplate<lng.Component.Constructor> | lng.Component
-  >;
+      | lng.Component.NewPatchTemplate<lng.Component.Constructor>
+      | typeof lng.Component
+    >;
+    /**
+     * index of currently selected item
+     */
+    selectedIndex?: number;
+
+    /**
+     * enables wrapping behavior, so `selectNext` selects the first item if the current item is the last on the list and vice versa
+     */
+    wrapSelected?: boolean;
+  }
+}
+
+declare class FocusManager<
+  TemplateSpec extends FocusManager.TemplateSpec,
+  TypeConfig extends lng.Component.TypeConfig
+> extends Base<TemplateSpec, TypeConfig> {
+  // Properties
+
+  /**
+   * the navigation direction
+   */
+  direction?: NavigationDirectionType;
+
+  /**
+   * child element or elements of the FocusManager
+   */
+  items: FocusItemsType;
+
+  /**
+   * index of currently selected item
+   */
+  selectedIndex: number;
+
+  /**
+   * enables wrapping behavior, so `selectNext` selects the first item if the current item is the last on the list and vice versa
+   */
+  wrapSelected: boolean;
+
+  // Accessors
+
   get Items(): lng.Element;
 
+  /**
+   * returns the currently selected component
+   */
   get selected(): lng.Component;
-  get selectedIndex(): number;
-  set selectedIndex(index: number);
+
+  /**
+   * returns an array containing the children of the FocusManager that are fully within the visible bounds of the FocusManager
+   */
   get fullyOnScreenItems(): Array<lng.Component>;
 
-  appendItems(
-    items: Array<lng.Component.NewPatchTemplate<lng.Component.Constructor>>
-  ): void;
-  appendItemsAt(
-    items: Array<lng.Component.NewPatchTemplate<lng.Component.Constructor>>,
-    idx: number
-  ): void;
-  prependItems(
-    items: Array<lng.Component.NewPatchTemplate<lng.Component.Constructor>>
-  ): void;
+  // Methods
+
+  /**
+   * adds the provided Rows to the end of the FocusManager children
+   * @param items array of Rows or Row-type patch objects
+   */
+  appendItems(items: FocusItemsType): void;
+
+  /**
+   * adds the provided Rows to the end of the FocusManager children at the provided index
+   * @param items array of Rows or Row-type patch objects
+   * @param idx index to insert rows at
+   */
+  appendItemsAt(items: FocusItemsType, idx: number): void;
+
+  /**
+   * adds the provided Rows to the beginning of the FocusManager children
+   * @param items array of Rows or Row-type patch objects
+   */
+  prependItems(items: FocusItemsType): void;
+
+  /**
+   * removes Item from FocusManager children at the given index
+   * @param index index of row to remove
+   */
   removeItemAt(idx: number): void;
+
+  /**
+   * returns the transition value for `x` of FocusManager.Items
+   */
+  getTransitionXTargetValue(): string;
+
+  /**
+   * returns the transition value for `y` of FocusManager.Items
+   */
+  getTransitionYTargetValue(): string;
+
+  /**
+   * A no-op function that is called when `selectedIndex` is set. Can be overridden by classes that extend `FocusManager` for custom render behavior.
+   */
   render(): void;
+
+  /**
+   * Selects previous item. If this.wrapSelected=true, will select the last element in the list if focus is currently on the first item.
+   */
   selectPrevious(): void;
+
+  /**
+   * Selects next item. If this.wrapSelected=true, will select the first element in the list if focus is currently on the last item.
+   */
   selectNext(): void;
 
   // tags
   get _Items(): lng.Component;
 }
+
+export default FocusManager;

--- a/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.d.ts
@@ -92,26 +92,26 @@ declare class FocusManager<
 
   /**
    * adds the provided Rows to the end of the FocusManager children
-   * @param items array of Rows or Row-type patch objects
+   * @param items array of Components or Component patch objects
    */
   appendItems(items: FocusItemsType): void;
 
   /**
    * adds the provided Rows to the end of the FocusManager children at the provided index
-   * @param items array of Rows or Row-type patch objects
-   * @param idx index to insert rows at
+   * @param items array of Components or Component patch objects
+   * @param idx index to insert `items` at
    */
   appendItemsAt(items: FocusItemsType, idx: number): void;
 
   /**
    * adds the provided Rows to the beginning of the FocusManager children
-   * @param items array of Rows or Row-type patch objects
+   * @param items array of Components or Component patch objects
    */
   prependItems(items: FocusItemsType): void;
 
   /**
    * removes Item from FocusManager children at the given index
-   * @param index index of row to remove
+   * @param index index of item to remove
    */
   removeItemAt(idx: number): void;
 

--- a/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.js
+++ b/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.js
@@ -40,7 +40,7 @@ export default class FocusManager extends Base {
   }
 
   static get properties() {
-    return ['direction', 'wrapSelected', 'centerInParent'];
+    return ['direction', 'wrapSelected'];
   }
 
   _construct() {


### PR DESCRIPTION
## Description

This PR updates the FocusManager declaration file to correctly extend Base per the [`@lightningjs/core` subclassable components guide](https://github.com/rdkcentral/Lightning/blob/2e4c829be45614290405c222bf102022a6219153/docs/TypeScript/Components/SubclassableComponents.md)

removes centerInParent from the properties array as this is defined in Base and exists outside the render cycle(maybe, might need to revert this).

## References

## Testing

ensure all properties are correctly documented, optionally link to a TS project and ensure all properties and methods appear both via dot syntax and in patches/templates

## Automation
n/a

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
