### PR TITLE
fix(FocusManager): provide default parameters for generic

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.d.ts
@@ -49,8 +49,8 @@ declare namespace FocusManager {
 }
 
 declare class FocusManager<
-  TemplateSpec extends FocusManager.TemplateSpec,
-  TypeConfig extends lng.Component.TypeConfig
+  TemplateSpec extends FocusManager.TemplateSpec = FocusManager.TemplateSpec,
+  TypeConfig extends lng.Component.TypeConfig = lng.Component.TypeConfig
 > extends Base<TemplateSpec, TypeConfig> {
   // Properties
 


### PR DESCRIPTION
## Description

Provide default values to `FocusManger`'s type definition to make them optional. With previous implementation TS is throwing error in `NavigationManage` type.

```ts
declare class FocusManager<
  TemplateSpec extends FocusManager.TemplateSpec = FocusManager.TemplateSpec,
  TypeConfig extends lng.Component.TypeConfig = lng.Component.TypeConfig
> extends Base<TemplateSpec, TypeConfig> {
```

## References

none

## Testing

- Open `NavigationManager`,
- `NavigationManager extends FocusManager` should not throw any errors

## Automation

none

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
