### PR TITLE
fix(NavigationManager): expose component publicly

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/index.d.ts
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright 2023 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -76,6 +76,7 @@ export {
   MetadataCardContentStyle
 } from './MetadataCardContent';
 export { default as MetadataTile, MetadataTileStyle } from './MetadataTile';
+export { default as NavigationManager } from './NavigationManager';
 export { default as ProgressBar, ProgressBarStyle } from './ProgressBar';
 export { default as Provider, ProviderStyle } from './Provider';
 export { default as Radio, RadioStyle } from './Radio';

--- a/packages/@lightningjs/ui-components/src/components/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/index.d.ts
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright 2023 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,22 +23,22 @@ export { default as Button, ButtonSmall, ButtonStyle } from './Button';
 export {
   default as Card,
   CardSection,
-  CardSectionStyle,
-  CardStyle,
   CardTitle,
+  CardStyle,
+  CardSectionStyle,
   CardTitleStyle
 } from './Card';
 export {
   default as CardContent,
   CardContentHorizontal,
   CardContentHorizontalLarge,
-  CardContentHorizontalLargeStyle,
-  CardContentHorizontalStyle,
-  CardContentStyle,
   CardContentVertical,
   CardContentVerticalSmall,
-  CardContentVerticalSmallStyle,
-  CardContentVerticalStyle
+  CardContentStyle,
+  CardContentHorizontalStyle,
+  CardContentHorizontalLargeStyle,
+  CardContentVerticalStyle,
+  CardContentVerticalSmallStyle
 } from './CardContent';
 export { default as Checkbox, CheckboxStyle } from './Checkbox';
 export { default as Column, ColumnStyle } from './Column';
@@ -53,12 +53,12 @@ export { default as Input, InputStyle } from './Input';
 export { default as Key, KeyStyle } from './Key';
 export {
   default as Keyboard,
+  KeyboardStyle,
   KeyboardEmail,
   KeyboardFullscreen,
-  KeyboardInput,
   KeyboardNumbers,
   KeyboardQwerty,
-  KeyboardStyle
+  KeyboardInput
 } from './Keyboard';
 export { default as Knob, KnobStyle } from './Knob';
 export { default as Label, LabelStyle } from './Label';
@@ -85,7 +85,7 @@ export { default as ScrollWrapper, ScrollWrapperStyle } from './ScrollWrapper';
 export { default as Shadow, ShadowStyle } from './Shadow';
 export { default as Slider, SliderStyle } from './Slider';
 export { default as Surface, SurfaceStyle } from './Surface';
-export { Tab, default as TabBar, TabBarStyle, TabStyle } from './TabBar';
+export { default as TabBar, TabBarStyle, Tab, TabStyle } from './TabBar';
 export { default as TextBox, TextBoxStyle } from './TextBox';
 export { default as Tile, TileStyle } from './Tile';
 export { default as TitleRow, TitleRowStyle } from './TitleRow';

--- a/packages/@lightningjs/ui-components/src/components/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/index.d.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Copyright 2023 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,22 +23,22 @@ export { default as Button, ButtonSmall, ButtonStyle } from './Button';
 export {
   default as Card,
   CardSection,
-  CardTitle,
-  CardStyle,
   CardSectionStyle,
+  CardStyle,
+  CardTitle,
   CardTitleStyle
 } from './Card';
 export {
   default as CardContent,
   CardContentHorizontal,
   CardContentHorizontalLarge,
+  CardContentHorizontalLargeStyle,
+  CardContentHorizontalStyle,
+  CardContentStyle,
   CardContentVertical,
   CardContentVerticalSmall,
-  CardContentStyle,
-  CardContentHorizontalStyle,
-  CardContentHorizontalLargeStyle,
-  CardContentVerticalStyle,
-  CardContentVerticalSmallStyle
+  CardContentVerticalSmallStyle,
+  CardContentVerticalStyle
 } from './CardContent';
 export { default as Checkbox, CheckboxStyle } from './Checkbox';
 export { default as Column, ColumnStyle } from './Column';
@@ -53,12 +53,12 @@ export { default as Input, InputStyle } from './Input';
 export { default as Key, KeyStyle } from './Key';
 export {
   default as Keyboard,
-  KeyboardStyle,
   KeyboardEmail,
   KeyboardFullscreen,
+  KeyboardInput,
   KeyboardNumbers,
   KeyboardQwerty,
-  KeyboardInput
+  KeyboardStyle
 } from './Keyboard';
 export { default as Knob, KnobStyle } from './Knob';
 export { default as Label, LabelStyle } from './Label';
@@ -85,7 +85,7 @@ export { default as ScrollWrapper, ScrollWrapperStyle } from './ScrollWrapper';
 export { default as Shadow, ShadowStyle } from './Shadow';
 export { default as Slider, SliderStyle } from './Slider';
 export { default as Surface, SurfaceStyle } from './Surface';
-export { default as TabBar, TabBarStyle, Tab, TabStyle } from './TabBar';
+export { Tab, default as TabBar, TabBarStyle, TabStyle } from './TabBar';
 export { default as TextBox, TextBoxStyle } from './TextBox';
 export { default as Tile, TileStyle } from './Tile';
 export { default as TitleRow, TitleRowStyle } from './TitleRow';

--- a/packages/@lightningjs/ui-components/src/components/index.js
+++ b/packages/@lightningjs/ui-components/src/components/index.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright 2023 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,9 +46,9 @@ export {
   default as Keyboard,
   KeyboardEmail,
   KeyboardFullscreen,
-  KeyboardInput,
   KeyboardNumbers,
-  KeyboardQwerty
+  KeyboardQwerty,
+  KeyboardInput
 } from './Keyboard';
 export { default as Knob } from './Knob/Knob.js';
 export { default as Label } from './Label/Label.js';
@@ -73,7 +73,7 @@ export { default as Shadow } from './Shadow/Shadow.js';
 export { default as Slider } from './Slider/Slider.js';
 export { default as SliderLarge } from './Slider/SliderLarge.js';
 export { default as Surface } from './Surface/Surface.js';
-export { Tab, default as TabBar } from './TabBar';
+export { default as TabBar, Tab } from './TabBar';
 export { default as TextBox } from './TextBox/TextBox.js';
 export { default as Tile } from './Tile/Tile.js';
 export { default as TitleRow } from './TitleRow/TitleRow.js';

--- a/packages/@lightningjs/ui-components/src/components/index.js
+++ b/packages/@lightningjs/ui-components/src/components/index.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright 2023 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -62,6 +62,7 @@ export { default as MetadataBase } from './MetadataBase/MetadataBase.js';
 export { default as MetadataCard } from './MetadataCard';
 export { default as MetadataCardContent } from './MetadataCardContent';
 export { default as MetadataTile } from './MetadataTile/MetadataTile.js';
+export { default as NavigationManager } from './NavigationManager';
 export { default as ProgressBar } from './ProgressBar/ProgressBar.js';
 export { default as Provider } from './Provider';
 export { default as Radio } from './Radio/Radio.js';

--- a/packages/@lightningjs/ui-components/src/components/index.js
+++ b/packages/@lightningjs/ui-components/src/components/index.js
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Copyright 2023 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,9 +46,9 @@ export {
   default as Keyboard,
   KeyboardEmail,
   KeyboardFullscreen,
+  KeyboardInput,
   KeyboardNumbers,
-  KeyboardQwerty,
-  KeyboardInput
+  KeyboardQwerty
 } from './Keyboard';
 export { default as Knob } from './Knob/Knob.js';
 export { default as Label } from './Label/Label.js';
@@ -73,7 +73,7 @@ export { default as Shadow } from './Shadow/Shadow.js';
 export { default as Slider } from './Slider/Slider.js';
 export { default as SliderLarge } from './Slider/SliderLarge.js';
 export { default as Surface } from './Surface/Surface.js';
-export { default as TabBar, Tab } from './TabBar';
+export { Tab, default as TabBar } from './TabBar';
 export { default as TextBox } from './TextBox/TextBox.js';
 export { default as Tile } from './Tile/Tile.js';
 export { default as TitleRow } from './TitleRow/TitleRow.js';


### PR DESCRIPTION
## Description

According to storybook's documentation I should be able to use `NavigationManager` publicly. 

## References

[storybook](https://rdkcentral.github.io/Lightning-UI-Components/?path=/story/navigation-navigationmanager--column&globals=GridOverlay-toggle-showColumns:false)

## Testing

- It should be possible to build packages and import `NavigationManager`.

## Automation

none

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
