### PR TITLE
feat(utils): add function to attach onAfterUpdate function that runs sideEffect on specific prop changes

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -270,9 +270,9 @@ export default class NavigationManager extends FocusManager {
     this.transitionDone();
   }
 
-  _withAfterUpdate(component) {
+  _withAfterUpdate(element) {
     return watchForUpdates({
-      component,
+      element,
       watchProps: [
         this._directionPropNames.crossAxis,
         'w',

--- a/packages/@lightningjs/ui-components/src/utils/index.js
+++ b/packages/@lightningjs/ui-components/src/utils/index.js
@@ -17,6 +17,7 @@
  */
 
 import lng from '@lightningjs/core';
+import logger from '../globals/context/logger';
 
 /**
  *
@@ -744,21 +745,27 @@ export function createConditionalZContext(component, zOffset) {
 }
 
 /**
- * Runs a side effect function when any values of specified properties on a component change.
- * @param {Object} options - defines the `component`, `watchProps`, and `sideEffect` options
- * @param {lng.Component} options.component - Lightning component on which property changes will watched
+ * Runs a side effect function when any values of specified properties on an element change.
+ * @param {Object} options - defines the `element`, `watchProps`, and `sideEffect` options
+ * @param {lng.Element} options.element - Lightning element on which property changes will watched
  * @param {String[]} options.watchProps - properties that when their value changes a side effect function is invoked
  * @param {Function} options.sideEffect - function to be invoked when a watched property's value changes
- * @returns {lng.Component}
+ * @returns {lng.Element}
  */
 export function watchForUpdates({
-  component = lng.Component,
+  element,
   watchProps = [],
   sideEffect = () => {}
 }) {
-  const initialOnAfterUpdate = component.__core?._onAfterUpdate;
+  if (!element?.isElement) {
+    logger.error(
+      `watchForUpdates: Expected a Lightning Element passed to element parameter, received ${typeof element}`
+    );
+  }
 
-  component.onAfterUpdate = function (element) {
+  const initialOnAfterUpdate = element.__core?._onAfterUpdate;
+
+  element.onAfterUpdate = function (element) {
     let hasChanged = false;
 
     watchProps.forEach(prop => {
@@ -779,13 +786,13 @@ export function watchForUpdates({
       sideEffect();
     }
 
-    // if a component already has an onAfterUpdate function, preserve that behavior
+    // if an element already has an onAfterUpdate function, preserve that behavior
     if (initialOnAfterUpdate) {
       initialOnAfterUpdate(element);
     }
   }.bind(this);
 
-  return component;
+  return element;
 }
 
 const utils = {


### PR DESCRIPTION
## Description
This is a follow up PR to https://github.com/rdkcentral/Lightning-UI-Components/pull/200 to abstract the `onAfterUpdate` logic used in `NavigationManager._withAfterUpdate` to a utility function that can be reused in other components.

Adds utility function, `watchForUpdates`, which adds an `onAfterUpdate` function to a component. The function will be invoked when any of the supplied `watchProps` change.
<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References
LUI-797
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
Compare stories in the following components to those on the deployed storybook instance. No visible changes between the branches should be present: 
- Row 
- Column
- Button
- Control (subclass of button)
- ControlRow (utilizes both NavigationManager and Control)
<!-- step by step instructions to review this PR's changes -->

## Automation
n/a
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
