### PR TITLE
fix(NavigationManager): update TS structure

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
@@ -122,16 +122,19 @@ declare class NavigationManager<
   autoResizeHeight?: boolean;
 
   /**
-   * If set, this is used to calculate the initial number of items to display on the first render (`lazyUpCount` + `lazyLoadUpCountBuffer`).
+   * Note: `lazyUpCount` and `lazyUpCountBuffer` work hand in hand.
+   * If defined, `lazyUpCount` enables "lazy loading" of items where only an initial number of items are displayed when the Row/Column first renders until further navigation.
+   * The initial number of items is calculated by `lazyUpCount` + `lazyLoadUpCountBuffer`.
    * The remaining items are stored as lazy items.
-   * Each time the user navigates further, the next lazy item will be added.
+   * Each time `selectNext` is invoked (moving right in Row or down in a Column), an item (that was not initially displayed) will be added to the end until all lazy items are loaded.
    */
   lazyUpCount?: number;
 
   /**
-   * If `lazyUpCount` is set, this is used to calculate the initial number of items to display on the first render (`lazyUpCount` + `lazyLoadUpCountBuffer`).
-   * The remaining items are stored as lazy items.
-   * Each time the user navigates further, the next lazy item will be added.
+   * By default `lazyUpCountBuffer` is 2.
+   * Changing this value updates the initial number of items to display on first render of Row/Column.
+   * Note: this behavior will only occur if `lazyUpCount` is defined.
+   * ex: only providing `lazyUpCountBuffer: 1` will display all items since `lazyUpCount` is not set so the “lazy loading” behavior is not enabled.
    */
   lazyUpCountBuffer?: number;
 

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
@@ -134,13 +134,6 @@ declare class NavigationManager<
   lazyUpCountBuffer?: number;
 
   // Accessors
-  // TODO: ask if necessary --> these are private accessors so do they need to be included?
-  get _directionPropNames(): DirectionProps;
-  get _canScrollBack(): boolean;
-  get _canScrollNext(): boolean;
-  get _isColumn(): boolean;
-  get _isRow(): boolean;
-
   get style(): NavigationManagerStyles;
   set style(v: StylePartial<NavigationManagerStyles>);
 

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
@@ -72,16 +72,19 @@ declare namespace NavigationManager {
     autoResizeHeight?: boolean;
 
     /**
-     * If set, this is used to calculate the initial number of items to display on the first render (`lazyUpCount` + `lazyLoadUpCountBuffer`).
+     * Note: `lazyUpCount` and `lazyUpCountBuffer` work hand in hand.
+     * If defined, `lazyUpCount` enables "lazy loading" of items where only an initial number of items are displayed when the Row/Column first renders until further navigation.
+     * The initial number of items is calculated by `lazyUpCount` + `lazyLoadUpCountBuffer`.
      * The remaining items are stored as lazy items.
-     * Each time the user navigates further, the next lazy item will be added.
+     * Each time `selectNext` is invoked (moving right in Row or down in a Column), an item (that was not initially displayed) will be added to the end until all lazy items are loaded.
      */
     lazyUpCount?: number;
 
     /**
-     * If `lazyUpCount` is set, this is used to calculate the initial number of items to display on the first render (`lazyUpCount` + `lazyLoadUpCountBuffer`).
-     * The remaining items are stored as lazy items.
-     * Each time the user navigates further, the next lazy item will be added.
+     * By default `lazyUpCountBuffer` is 2.
+     * Changing this value updates the initial number of items to display on first render of Row/Column.
+     * Note: this behavior will only occur if `lazyUpCount` is defined.
+     * ex: only providing `lazyUpCountBuffer: 1` will display all items since `lazyUpCount` is not set so the “lazy loading” behavior is not enabled.
      */
     lazyUpCountBuffer?: number;
   }

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
@@ -34,7 +34,7 @@ export type DirectionProps = {
   innerCrossDimension: string;
 };
 
-export type NavigationManagerStyles = {
+export type NavigationManagerStyle = {
   alwaysScroll: boolean;
   itemSpacing: number;
   itemTransition: TransitionObject;
@@ -134,8 +134,8 @@ declare class NavigationManager<
   lazyUpCountBuffer?: number;
 
   // Accessors
-  get style(): NavigationManagerStyles;
-  set style(v: StylePartial<NavigationManagerStyles>);
+  get style(): NavigationManagerStyle;
+  set style(v: StylePartial<NavigationManagerStyle>);
 
   // Methods
   /**

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
@@ -20,13 +20,13 @@ import lng from '@lightningjs/core';
 import type { StylePartial } from '../../types/lui';
 import FocusManager from '../FocusManager';
 
-type TransitionObject = {
+export type TransitionObject = {
   delay: number;
   duration: number;
   timingFunction: string;
 };
 
-type DirectionProps = {
+export type DirectionProps = {
   axis: string;
   crossAxis: string;
   lengthDimension: string;
@@ -42,21 +42,44 @@ export type NavigationManagerStyles = {
   scrollIndex: number;
 };
 
-export default class NavigationManager extends FocusManager {
+declare namespace NavigationManager {
+  export interface TemplateSpec extends FocusManager.TemplateSpec {
+    alwaysScroll?: boolean;
+    neverScroll?: boolean;
+    scrollIndex?: number;
+    autoResizeWidth?: boolean;
+    autoResizeHeight?: boolean;
+    lazyUpCount?: number;
+    lazyUpCountBuffer?: number;
+  }
+}
+
+declare class NavigationManager<
+  TemplateSpec extends NavigationManager.TemplateSpec = NavigationManager.TemplateSpec,
+  TypeConfig extends lng.Component.TypeConfig = lng.Component.TypeConfig
+> extends FocusManager<TemplateSpec, TypeConfig> {
+  // Properties
   alwaysScroll?: boolean;
   neverScroll?: boolean;
   scrollIndex?: number;
   autoResizeWidth?: boolean;
   autoResizeHeight?: boolean;
+  lazyUpCount?: number;
+  lazyUpCountBuffer?: number;
+
+  // Accessors
+  // TODO: ask if necessary --> these are private accessors so do they need to be included?
+  get _directionPropNames(): DirectionProps;
+  get _canScrollBack(): boolean;
+  get _canScrollNext(): boolean;
+  get _isColumn(): boolean;
+  get _isRow(): boolean;
 
   get style(): NavigationManagerStyles;
   set style(v: StylePartial<NavigationManagerStyles>);
 
-  protected _initComponentSize(): void;
-  protected _updateLayout(): void;
-
+  // Methods
   $itemChanged(): void;
-
   updatePositionOnAxis(item: lng.Component, position: number): void;
   scrollTo(index: number, duration: number): void;
   transitionDone(): void;
@@ -64,13 +87,6 @@ export default class NavigationManager extends FocusManager {
   shouldScrollRight(): boolean;
   shouldScrollUp(): boolean;
   shouldScrollDown(): boolean;
-
-  get _directionPropNames(): DirectionProps;
-  get _canScrollBack(): boolean;
-  get _canScrollNext(): boolean;
-  get _isColumn(): boolean;
-  get _isRow(): boolean;
-  protected _getAlwaysScroll: boolean;
-  protected _getNeverScroll: boolean;
-  protected _getScrollIndex: number;
 }
+
+export default NavigationManager;

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
@@ -44,12 +44,45 @@ export type NavigationManagerStyles = {
 
 declare namespace NavigationManager {
   export interface TemplateSpec extends FocusManager.TemplateSpec {
+    /**
+     * Determines whether the component will stop scrolling as it nears the end to prevent white space.
+     * If true, the component will scroll infinitely.
+     */
     alwaysScroll?: boolean;
+
+    /**
+     * If true, the component will never scroll, unless `alwaysScroll` is set to true.
+     * If false, the component will apply normal scrolling logic.
+     */
     neverScroll?: boolean;
+
+    /**
+     * Item index at which scrolling begins, provided the sum of item widths is greater than the width of the Row component.
+     */
     scrollIndex?: number;
+
+    /**
+     * Automatically sets the width of the row to be the same as the Items container inside (this will prevent scrolling).
+     */
     autoResizeWidth?: boolean;
+
+    /**
+     * Automatically sets the height of the row to be the same as the Items container inside.
+     */
     autoResizeHeight?: boolean;
+
+    /**
+     * If set, this is used to calculate the initial number of items to display on the first render (`lazyUpCount` + `lazyLoadUpCountBuffer`).
+     * The remaining items are stored as lazy items.
+     * Each time the user navigates further, the next lazy item will be added.
+     */
     lazyUpCount?: number;
+
+    /**
+     * If `lazyUpCount` is set, this is used to calculate the initial number of items to display on the first render (`lazyUpCount` + `lazyLoadUpCountBuffer`).
+     * The remaining items are stored as lazy items.
+     * Each time the user navigates further, the next lazy item will be added.
+     */
     lazyUpCountBuffer?: number;
   }
 }
@@ -59,12 +92,45 @@ declare class NavigationManager<
   TypeConfig extends lng.Component.TypeConfig = lng.Component.TypeConfig
 > extends FocusManager<TemplateSpec, TypeConfig> {
   // Properties
+  /**
+   * Determines whether the component will stop scrolling as it nears the end to prevent white space.
+   * If true, the component will scroll infinitely.
+   */
   alwaysScroll?: boolean;
+
+  /**
+   * If true, the component will never scroll, unless alwaysScroll is set to true.
+   * If false, the component will apply normal scrolling logic.
+   */
   neverScroll?: boolean;
+
+  /**
+   * Item index at which scrolling begins, provided the sum of item widths is greater than the width of the Row component.
+   */
   scrollIndex?: number;
+
+  /**
+   * Automatically sets the width of the row to be the same as the Items container inside (this will prevent scrolling).
+   */
   autoResizeWidth?: boolean;
+
+  /**
+   * Automatically sets the height of the row to be the same as the Items container inside.
+   */
   autoResizeHeight?: boolean;
+
+  /**
+   * If set, this is used to calculate the initial number of items to display on the first render (`lazyUpCount` + `lazyLoadUpCountBuffer`).
+   * The remaining items are stored as lazy items.
+   * Each time the user navigates further, the next lazy item will be added.
+   */
   lazyUpCount?: number;
+
+  /**
+   * If `lazyUpCount` is set, this is used to calculate the initial number of items to display on the first render (`lazyUpCount` + `lazyLoadUpCountBuffer`).
+   * The remaining items are stored as lazy items.
+   * Each time the user navigates further, the next lazy item will be added.
+   */
   lazyUpCountBuffer?: number;
 
   // Accessors
@@ -79,13 +145,55 @@ declare class NavigationManager<
   set style(v: StylePartial<NavigationManagerStyles>);
 
   // Methods
+  /**
+   * An event that, when triggered, calls a method that forces the component to update.
+   */
   $itemChanged(): void;
+
+  /**
+   * Updates the position of a component along the main axis of the NavigationManager component.
+   * For components where `direction` is `'row'`, it will update the `x` property on the passed in component(`item`) to the passed in value(`position`).
+   * For components where `direction` is `'column'`, it will update the `y` property on the passed in component(`item`) to the passed in value(`position`).
+   * @param item component whose property will be updated
+   * @param position value to replace either the `x` or `y` property of item
+   */
   updatePositionOnAxis(item: lng.Component, position: number): void;
+
+  /**
+   * Scrolls to the child at the supplied index at the rate of `duration` * (`this.selectedIndex` - `index`)
+   * @param index index of item to scroll to
+   * @param duration how long, in ms, it should take to scroll to the item at index
+   */
   scrollTo(index: number, duration: number): void;
+
+  /**
+   * A method that is invoked upon any transitions to the component's axis property finishing (ex. 'x' for Row, 'y' for Column).
+   * It is not set by default and can be overwritten.
+   */
   transitionDone(): void;
+
+  /**
+   * Returns a boolean for whether or not the component should scroll left
+   * based off if the component's `direction` property is `'row'`, the selected item's index is past the `scrollIndex`, and that content that is out of view can be scrolled to.
+   */
   shouldScrollLeft(): boolean;
+
+  /**
+   * Returns a boolean for whether or not the component should scroll right
+   * based off if the component's `direction` property is `'row'`, the selected item's index is past the `scrollIndex`, and that content that is out of view can be scrolled to.
+   */
   shouldScrollRight(): boolean;
+
+  /**
+   * Returns a boolean for whether or not the component should scroll up
+   * based off if the component's `direction` property is `'column'`, the selected item's index is past the `scrollIndex`, and that content that is out of view can be scrolled to.
+   */
   shouldScrollUp(): boolean;
+
+  /**
+   * Returns a boolean for whether or not the component should scroll down
+   * based off if the component's `direction` property is `'column'`, the selected item's index is past the `scrollIndex`, and that content that is out of view can be scrolled to.
+   */
   shouldScrollDown(): boolean;
 }
 

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
@@ -88,9 +88,8 @@ declare namespace NavigationManager {
 }
 
 declare class NavigationManager<
-  TemplateSpec extends NavigationManager.TemplateSpec = NavigationManager.TemplateSpec,
-  TypeConfig extends lng.Component.TypeConfig = lng.Component.TypeConfig
-> extends FocusManager<TemplateSpec, TypeConfig> {
+  TemplateSpec extends NavigationManager.TemplateSpec = NavigationManager.TemplateSpec
+> extends FocusManager<TemplateSpec> {
   // Properties
   /**
    * Determines whether the component will stop scrolling as it nears the end to prevent white space.


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Updates NavigationManager's TS declaration file to match the new TS structure ([@lightningjs/core subclassable components guide](https://github.com/rdkcentral/Lightning/blob/2e4c829be45614290405c222bf102022a6219153/docs/TypeScript/Components/SubclassableComponents.md))

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->
LUI-840

## Testing

<!-- step by step instructions to review this PR's changes -->

- Create a new component using `yarn createComponent @lightningjs/ui-components MyComponent`
- Make sure the component extends `NavigationManager` (rather than `Base`)
- Ensure the NavigationManager properties/methods show up when using the dot syntax (`...`) or patch

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
