### PR TITLE
fix(Button): remove unnecessary utils call and return calculated text width

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Button/Button.js
+++ b/packages/@lightningjs/ui-components/src/components/Button/Button.js
@@ -16,7 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { measureTextWidth } from '../../utils';
 import * as styles from './Button.styles.js';
 import Row from '../Row';
 import Surface from '../Surface';
@@ -302,11 +301,7 @@ export default class Button extends Surface {
       this._Title._Text &&
       this._Title.visible
     ) {
-      if (this.fixed) {
-        return this._Title.w;
-      } else {
-        return measureTextWidth(this._Title._Text.text);
-      }
+      return this._Title.w;
     }
     return 0;
   }


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
When dealing with fonts with custom fontStyle set, the `measureTextWidth` util method acts unexpectedly. It does not seem to actually be needed for the Button anyway.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
