### PR TITLE
fix(Column): update TS structure

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Base/Base.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Base/Base.d.ts
@@ -63,6 +63,8 @@ declare class Base<
    */
   loaded?: Promise<void>;
 
+  // TODO: flag for discussion
+  // internal stuff can be omitted --> `shouldSmooth` is internal?
   shouldSmooth?: boolean;
 
   /**
@@ -100,6 +102,7 @@ declare class Base<
    */
   isFullyOnScreen(): boolean;
 
+  // TODO: for future reference these accessors should technically be public
   /**
    * check if the component is disabled
    */

--- a/packages/@lightningjs/ui-components/src/components/Column/Column.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.d.ts
@@ -20,7 +20,6 @@ import lng from '@lightningjs/core';
 import NavigationManager from '../NavigationManager';
 
 declare namespace Column {
-  // errored until NavigationManager TS updates are merged
   export interface TemplateSpec extends NavigationManager.TemplateSpec {
     /**
      * When navigation between multiple Columns,
@@ -48,16 +47,12 @@ declare class Column<
    */
   checkSkipPlinko(prev: lng.Component, next: lng.Component): lng.Component;
 
-  // TODO: flag for discussion
-  // in the docs, there is a parameter for this function but in Column.js the function has no params
   /**
    * A callback that can be overridden to do something with the items that are currently on screen.
    * This will be called on every new render.
    */
   onScreenEffect(): void;
 
-  // TODO: flag for conversation/discussion
-  // should we include these methods?
   /**
    * Removes the passed in item from the items array and updates the selectedIndex, if necessary
    * @param item component to be removed

--- a/packages/@lightningjs/ui-components/src/components/Column/Column.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.d.ts
@@ -17,26 +17,7 @@
  */
 
 import lng from '@lightningjs/core';
-import NavigationManager, {
-  NavigationManagerStyle
-} from '../NavigationManager/NavigationManager';
-import type { StylePartial } from '../../types/lui';
-
-// TODO: ask --this is exported in NavigationManager; is this even necessary?
-export type TransitionObject = {
-  delay: number;
-  duration: number;
-  timingFunction: string;
-};
-
-// TODO: ask --all these style props are part of NavigationManager; do we need to define the props again? Or should the object just be empty?
-export type ColumnStyle = NavigationManagerStyle & {
-  itemSpacing: number;
-  scrollIndex: number;
-  alwaysScroll: boolean;
-  neverScroll: boolean;
-  itemTransition: TransitionObject;
-};
+import NavigationManager from '../NavigationManager';
 
 declare namespace Column {
   // errored until NavigationManager TS updates are merged
@@ -59,10 +40,6 @@ declare class Column<
    */
   plinko?: boolean;
 
-  // Accessors
-  get style(): ColumnStyle;
-  set style(v: StylePartial<ColumnStyle>);
-
   // Methods
   /**
    * Returns the item right before the item that has skipPlinko or before prev if no item has skipPlinko
@@ -71,13 +48,16 @@ declare class Column<
    */
   checkSkipPlinko(prev: lng.Component, next: lng.Component): lng.Component;
 
-  // TODO: check -- in the docs, there is a parameter but in Column.js the function has no params
+  // TODO: flag for discussion
+  // in the docs, there is a parameter for this function but in Column.js the function has no params
   /**
    * A callback that can be overridden to do something with the items that are currently on screen.
    * This will be called on every new render.
    */
   onScreenEffect(): void;
 
+  // TODO: flag for conversation/discussion
+  // should we include these methods?
   /**
    * Removes the passed in item from the items array and updates the selectedIndex, if necessary
    * @param item component to be removed

--- a/packages/@lightningjs/ui-components/src/components/Column/Column.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.d.ts
@@ -17,16 +17,20 @@
  */
 
 import lng from '@lightningjs/core';
-import NavigationManager from '../NavigationManager';
+import NavigationManager, {
+  NavigationManagerStyle
+} from '../NavigationManager/NavigationManager';
 import type { StylePartial } from '../../types/lui';
 
-type TransitionObject = {
+// TODO: ask --this is exported in NavigationManager; is this even necessary?
+export type TransitionObject = {
   delay: number;
   duration: number;
   timingFunction: string;
 };
 
-export type ColumnStyle = {
+// TODO: ask --all these style props are part of NavigationManager; do we need to define the props again? Or should the object just be empty?
+export type ColumnStyle = NavigationManagerStyle & {
   itemSpacing: number;
   scrollIndex: number;
   alwaysScroll: boolean;
@@ -34,16 +38,56 @@ export type ColumnStyle = {
   itemTransition: TransitionObject;
 };
 
-export default class Column extends NavigationManager {
+declare namespace Column {
+  // errored until NavigationManager TS updates are merged
+  export interface TemplateSpec extends NavigationManager.TemplateSpec {
+    /**
+     * When navigation between multiple Columns,
+     * plinko functionality enables navigation to the item in the next Column that is closest to the index of the item in the previous Column.
+     */
+    plinko?: boolean;
+  }
+}
+
+declare class Column<
+  TemplateSpec extends Column.TemplateSpec = Column.TemplateSpec
+> extends NavigationManager<TemplateSpec> {
+  // Properties
+  /**
+   * When navigation between multiple Columns,
+   * plinko functionality enables navigation to the item in the next Column that is closest to the index of the item in the previous Column.
+   */
   plinko?: boolean;
-  itemPosX?: number;
-  itemPosY?: number;
+
+  // Accessors
   get style(): ColumnStyle;
   set style(v: StylePartial<ColumnStyle>);
 
+  // Methods
+  /**
+   * Returns the item right before the item that has skipPlinko or before prev if no item has skipPlinko
+   * @param prev component existing right before the current component
+   * @param next component existing right after the current component
+   */
   checkSkipPlinko(prev: lng.Component, next: lng.Component): lng.Component;
+
+  // TODO: check -- in the docs, there is a parameter but in Column.js the function has no params
+  /**
+   * A callback that can be overridden to do something with the items that are currently on screen.
+   * This will be called on every new render.
+   */
   onScreenEffect(): void;
 
+  /**
+   * Removes the passed in item from the items array and updates the selectedIndex, if necessary
+   * @param item component to be removed
+   */
   $removeItem(item: lng.Component): void;
+
+  /**
+   * An event that, when triggered, calls a method that forces the component to update.
+   */
   $columnChanged(): void;
 }
+
+export default Column;

--- a/packages/@lightningjs/ui-components/src/components/Column/Column.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.mdx
@@ -140,16 +140,9 @@ The `Column` component will utilize the following properties on each individual 
 
 ### Methods
 
-#### onScreenEffect(onScreenItems: lng.Component[]): void
+#### onScreenEffect(): void
 
 A callback that can be overridden to do something with the items that are currently on screen. This will be called on every new render.
-
-##### Arguments
-
-| name     | type   | required | default   | description                               |
-| -------- | ------ | -------- | --------- | ----------------------------------------- |
-| index    | number | true     | undefined | index of the child component to scroll to |
-| duration | number | false    | 40        | timeout value in milliseconds             |
 
 #### appendItems(items: lng.Component[]): void
 

--- a/packages/@lightningjs/ui-components/src/components/Column/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Column/index.d.ts
@@ -16,6 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import Column, { ColumnStyle } from './Column';
+import Column from './Column';
 
-export { Column as default, ColumnStyle };
+export { Column as default };

--- a/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.d.ts
@@ -29,6 +29,7 @@ declare namespace FocusManager {
      * the navigation direction
      */
     direction?: NavigationDirectionType;
+
     /**
      * child element or elements of the FocusManager
      */
@@ -36,6 +37,7 @@ declare namespace FocusManager {
       | lng.Component.NewPatchTemplate<lng.Component.Constructor>
       | typeof lng.Component
     >;
+
     /**
      * index of currently selected item
      */
@@ -45,6 +47,16 @@ declare namespace FocusManager {
      * enables wrapping behavior, so `selectNext` selects the first item if the current item is the last on the list and vice versa
      */
     wrapSelected?: boolean;
+
+    /**
+     * x (horizontal) position value of the Row/Column (items array)
+     */
+    itemPosX?: number;
+
+    /**
+     * y (vertical) position value of the Row/Column (items array)
+     */
+    itemPosY?: number;
   }
 }
 
@@ -74,6 +86,16 @@ declare class FocusManager<
    */
   wrapSelected: boolean;
 
+  /**
+   * x (horizontal) position value of the Row/Column (items array)
+   */
+  itemPosX?: number;
+
+  /**
+   * y (vertical) position value of the Row/Column (items array)
+   */
+  itemPosY?: number;
+
   // Accessors
 
   get Items(): lng.Element;
@@ -82,6 +104,11 @@ declare class FocusManager<
    * returns the currently selected component
    */
   get selected(): lng.Component;
+
+  /**
+   * returns a list of items that are currently fully and partially on screen
+   */
+  get onScreenItems(): Array<lng.Component>;
 
   /**
    * returns an array containing the children of the FocusManager that are fully within the visible bounds of the FocusManager

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
@@ -17,7 +17,7 @@
  */
 
 import lng from '@lightningjs/core';
-import type { StylePartial, TransitionObject } from '../../types/lui';
+import type { StylePartial } from '../../types/lui';
 import FocusManager from '../FocusManager';
 
 export type DirectionProps = {
@@ -31,7 +31,7 @@ export type DirectionProps = {
 export type NavigationManagerStyle = {
   alwaysScroll: boolean;
   itemSpacing: number;
-  itemTransition: TransitionObject;
+  itemTransition: lng.types.TransitionSettings;
   neverScroll: boolean;
   scrollIndex: number;
 };

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
@@ -17,14 +17,8 @@
  */
 
 import lng from '@lightningjs/core';
-import type { StylePartial } from '../../types/lui';
+import type { StylePartial, TransitionObject } from '../../types/lui';
 import FocusManager from '../FocusManager';
-
-export type TransitionObject = {
-  delay: number;
-  duration: number;
-  timingFunction: string;
-};
 
 export type DirectionProps = {
   axis: string;

--- a/packages/@lightningjs/ui-components/src/components/Surface/Surface.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Surface/Surface.d.ts
@@ -19,10 +19,9 @@
 import lng from '@lightningjs/core';
 import Base from '../Base/Base';
 import type { Color, StylePartial } from '../../types/lui';
-import type TransitionSettings from '@lightningjs/core/dist/src/animation/TransitionSettings.d.mts';
 
 export type SurfaceStyle = {
-  animation: TransitionSettings;
+  animation: lng.types.TransitionSettings;
   backgroundColor: Color;
   radius: lng.Tools.CornerRadius;
   scale: number;

--- a/packages/@lightningjs/ui-components/src/components/Surface/Surface.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Surface/Surface.d.ts
@@ -18,10 +18,11 @@
 
 import lng from '@lightningjs/core';
 import Base from '../Base/Base';
-import type { Color, StylePartial, TransitionObject } from '../../types/lui';
+import type { Color, StylePartial } from '../../types/lui';
+import type TransitionSettings from '@lightningjs/core/dist/src/animation/TransitionSettings.d.mts';
 
 export type SurfaceStyle = {
-  animation: TransitionObject;
+  animation: TransitionSettings;
   backgroundColor: Color;
   radius: lng.Tools.CornerRadius;
   scale: number;

--- a/packages/@lightningjs/ui-components/src/components/Surface/Surface.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Surface/Surface.d.ts
@@ -18,13 +18,7 @@
 
 import lng from '@lightningjs/core';
 import Base from '../Base/Base';
-import type { Color, StylePartial } from '../../types/lui';
-
-export type TransitionObject = {
-  delay: number;
-  duration: number;
-  timingFunction: string;
-};
+import type { Color, StylePartial, TransitionObject } from '../../types/lui';
 
 export type SurfaceStyle = {
   animation: TransitionObject;

--- a/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.d.ts
@@ -18,7 +18,7 @@
 
 import lng from '@lightningjs/core';
 import Base from '../Base';
-import type { Color, StylePartial, TransitionObject } from '../../types/lui';
+import type { Color, StylePartial } from '../../types/lui';
 import type { TextBoxStyle } from '../TextBox';
 
 export type TooltipStyle = {
@@ -30,7 +30,7 @@ export type TooltipStyle = {
   pointerH: number;
   radius: lng.Tools.CornerRadius;
   textStyle: TextBoxStyle;
-  transition: TransitionObject;
+  transition: lng.types.TransitionSettings;
 };
 
 export default class Tooltip extends Base {

--- a/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.d.ts
@@ -18,14 +18,8 @@
 
 import lng from '@lightningjs/core';
 import Base from '../Base';
-import type { Color, StylePartial } from '../../types/lui';
+import type { Color, StylePartial, TransitionObject } from '../../types/lui';
 import type { TextBoxStyle } from '../TextBox';
-
-type TransitionObject = {
-  delay: number;
-  duration: number;
-  timingFunction: string;
-};
 
 export type TooltipStyle = {
   backgroundColor: Color;

--- a/packages/@lightningjs/ui-components/src/components/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/index.d.ts
@@ -41,7 +41,7 @@ export {
   CardContentVerticalSmallStyle
 } from './CardContent';
 export { default as Checkbox, CheckboxStyle } from './Checkbox';
-export { default as Column, ColumnStyle } from './Column';
+export { default as Column } from './Column';
 export { default as Control, ControlSmall, ControlStyle } from './Control';
 export { default as ControlRow, ControlRowStyle } from './ControlRow';
 export { default as FocusManager } from './FocusManager';

--- a/packages/@lightningjs/ui-components/src/types/lui.d.ts
+++ b/packages/@lightningjs/ui-components/src/types/lui.d.ts
@@ -34,11 +34,3 @@ export type StylePartial<T> = {
     : // If it is NOT an object, then just spit back the original value type.
       T[P];
 };
-
-// TODO: flag for discussion
-// more specific naming of this object
-export type TransitionObject = {
-  delay: number;
-  duration: number;
-  timingFunction: string;
-};

--- a/packages/@lightningjs/ui-components/src/types/lui.d.ts
+++ b/packages/@lightningjs/ui-components/src/types/lui.d.ts
@@ -34,3 +34,11 @@ export type StylePartial<T> = {
     : // If it is NOT an object, then just spit back the original value type.
       T[P];
 };
+
+// TODO: flag for discussion
+// more specific naming of this object
+export type TransitionObject = {
+  delay: number;
+  duration: number;
+  timingFunction: string;
+};


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Updates Column's TS declaration file to match the new TS structure ([@lightningjs/core subclassable components guide](https://github.com/rdkcentral/Lightning/blob/2e4c829be45614290405c222bf102022a6219153/docs/TypeScript/Components/SubclassableComponents.md))

Additional Updates

- Moves the `TransitionObject` to the lui.d.ts file since the object is used in multiple components
- Adds additional properties and accessors to `FocusManager`

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->
LUI-836

## Testing

<!-- step by step instructions to review this PR's changes -->

- Create a new component using `yarn createComponent @lightningjs/ui-components MyComponent`
- Make sure the component extends `Column` (rather than Base)
- Ensure the `Column` properties/methods show up when using the dot syntax or through patch

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
