### PR TITLE
docs: refactor navigation stories to run effects from user input instead of timeouts

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Column/Column.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.stories.js
@@ -25,6 +25,7 @@ import Button from '../Button';
 import { default as ColumnComponent } from '.';
 import mdx from './Column.mdx';
 import { CATEGORIES } from '../../docs/constants';
+import { SignalButton } from '../../docs/story-components';
 
 export default {
   title: `${CATEGORIES[64]}/Column`,
@@ -632,50 +633,63 @@ export const AddingItems = args =>
           scrollIndex: args.scrollIndex,
           lazyUpCount: args.lazyUpCount,
           lazyUpCountBuffer: args.lazyUpCountBuffer,
-          items: createItems(Button, 20, false, true)
+          signals: {
+            append: 'appendButton',
+            appendAt: 'appendButtonAt',
+            prepend: 'prependButton'
+          },
+          items: [
+            {
+              type: SignalButton,
+              title: 'Prepend 1 Button (prependItems)',
+              signalName: 'prepend',
+              passSignals: { prepend: true }
+            },
+            {
+              type: SignalButton,
+              title: 'Append 1 Button at index 1 (appendItemsAt)',
+              signalName: 'appendAt',
+              passSignals: { appendAt: true }
+            },
+            {
+              type: SignalButton,
+              title: 'Append 1 Button to the Row (appendItems)',
+              signalName: 'append',
+              passSignals: { append: true }
+            }
+          ]
         }
       };
     }
 
-    _init() {
-      super._init();
+    prependButton() {
+      this.tag('Column').prependItems([
+        {
+          type: Button,
+          title: 'Prepended Button'
+        }
+      ]);
+    }
 
-      setTimeout(() => {
-        this.tag('Column').appendItemsAt(
-          [
-            {
-              type: Button,
-              title: 'New Button 0'
-            },
-            {
-              type: Button,
-              title: 'New Button 1'
-            },
-            {
-              type: Button,
-              title: 'New Button 2'
-            }
-          ],
-          3
-        );
-      }, 3000);
-
-      setTimeout(() => {
-        this.tag('Column').prependItems([
+    appendButtonAt() {
+      this.tag('Column').appendItemsAt(
+        [
           {
             type: Button,
-            title: 'New Button 3'
-          },
-          {
-            type: Button,
-            title: 'New Button 4'
-          },
-          {
-            type: Button,
-            title: 'New Button 5'
+            title: 'Appended Button at index 1'
           }
-        ]);
-      }, 4000);
+        ],
+        1
+      );
+    }
+
+    appendButton() {
+      this.tag('Column').appendItems([
+        {
+          type: Button,
+          title: 'Appended Button'
+        }
+      ]);
     }
   };
 AddingItems.args = {
@@ -709,7 +723,7 @@ AddingItems.argTypes = {
 };
 AddingItems.parameters = {
   storyDetails:
-    '3 seconds after rendering, 3 new buttons are added at index 3 of the Column via Column.appendItemsAt. 4 seconds after rendering, 3 additional buttons are added at start of the Column via Column.prependItems.'
+    'The 3 buttons initially rendered in this story are configured to invoke 1 of the 3 methods available to add items to a Column (the name of the method used is in parenthesis on the button). Press enter on any of those 3 buttons to invoke that method and add a button to the Column.'
 };
 
 export const RemovingItems = args =>
@@ -720,17 +734,24 @@ export const RemovingItems = args =>
           type: ColumnComponent,
           h: 500,
           scrollIndex: args.scrollIndex,
-          items: createItems(Button, 20, false, true)
+          signals: {
+            removeAt: 'removeButton'
+          },
+          items: [
+            ...createItems(Button, 2),
+            {
+              type: SignalButton,
+              title: 'Press Enter on this button to remove it (removeItemAt)',
+              signalName: 'removeAt',
+              passSignals: { removeAt: true }
+            }
+          ]
         }
       };
     }
 
-    _init() {
-      super._init();
-      this.tag('Column').items[1].title = 'To Be Removed';
-      setTimeout(() => {
-        this.tag('Column').removeItemAt(1);
-      }, 3000);
+    removeButton() {
+      this.tag('Column').removeItemAt(2);
     }
   };
 RemovingItems.args = {
@@ -746,5 +767,5 @@ RemovingItems.argTypes = {
 };
 RemovingItems.parameters = {
   storyDetails:
-    '3 seconds after rendering, the button at index 1 in the Column is removed via Column.removeItemAt.'
+    'The third button in this column is configured to invoke removeItemAt to remove that button. Focus on that button and press Enter to invoke that method and remove the button from the column.'
 };

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Copyright 2023 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
@@ -374,23 +374,15 @@ LazyScrollIndexes.parameters = {
     'Items before the item at startLazyScrollIndex and after the item at stopLazyScrollIndex will use alwaysScroll. Items at and between startLazyScrollIndex and stopLazyScrollIndex will use lazyScroll.'
 };
 
-const actionTypes = {
-  append: 'append',
-  appendAt: 'appendAt',
-  prepend: 'prepend',
-  removeAt: 'removeAt'
-};
-
-class EditButton extends Button {
+class SignalButton extends Button {
   onEnter() {
-    const signalName = actionTypes[this.action] || 'append';
-    this.signal(signalName);
+    this.signal(this.signalName);
   }
-  set action(action) {
-    this._action = action;
+  set signalName(signalName) {
+    this._signalName = signalName;
   }
-  get action() {
-    return this._action;
+  get signalName() {
+    return this._signalName;
   }
 }
 
@@ -410,21 +402,21 @@ export const AddingItems = args =>
           },
           items: [
             {
-              type: EditButton,
+              type: SignalButton,
               title: 'Prepend 1 Button (prependItems)',
-              action: 'prepend',
+              signalName: 'prepend',
               passSignals: { prepend: true }
             },
             {
-              type: EditButton,
+              type: SignalButton,
               title: 'Append 1 Button at index 1 (appendItemsAt)',
-              action: 'appendAt',
+              signalName: 'appendAt',
               passSignals: { appendAt: true }
             },
             {
-              type: EditButton,
+              type: SignalButton,
               title: 'Append 1 Button to the Row (appendItems)',
-              action: 'append',
+              signalName: 'append',
               passSignals: { append: true }
             }
           ]

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
@@ -374,6 +374,26 @@ LazyScrollIndexes.parameters = {
     'Items before the item at startLazyScrollIndex and after the item at stopLazyScrollIndex will use alwaysScroll. Items at and between startLazyScrollIndex and stopLazyScrollIndex will use lazyScroll.'
 };
 
+const actionTypes = {
+  append: 'append',
+  appendAt: 'appendAt',
+  prepend: 'prepend',
+  removeAt: 'removeAt'
+};
+
+class EditButton extends Button {
+  onEnter() {
+    const signalName = actionTypes[this.action] || 'append';
+    this.signal(signalName);
+  }
+  set action(action) {
+    this._action = action;
+  }
+  get action() {
+    return this._action;
+  }
+}
+
 export const AddingItems = args =>
   class AddingItems extends lng.Component {
     static _template() {
@@ -383,54 +403,63 @@ export const AddingItems = args =>
           w: getWidthByUpCount(context.theme, 1), // x offset from preview.js * 2
           lazyUpCount: args.lazyUpCount,
           lazyUpCountBuffer: args.lazyUpCountBuffer,
-          items: createItems(Button, 12)
+          signals: {
+            append: 'appendButton',
+            appendAt: 'appendButtonAt',
+            prepend: 'prependButton'
+          },
+          items: [
+            {
+              type: EditButton,
+              title: 'Prepend 1 Button (prependItems)',
+              action: 'prepend',
+              passSignals: { prepend: true }
+            },
+            {
+              type: EditButton,
+              title: 'Append 1 Button at index 1 (appendItemsAt)',
+              action: 'appendAt',
+              passSignals: { appendAt: true }
+            },
+            {
+              type: EditButton,
+              title: 'Append 1 Button to the Row (appendItems)',
+              action: 'append',
+              passSignals: { append: true }
+            }
+          ]
         }
       };
     }
 
-    _init() {
-      super._init();
-      setTimeout(() => {
-        this.tag('Row').appendItemsAt(
-          [
-            {
-              type: Button,
-              title: 'New Button 0',
-              w: 150
-            },
-            {
-              type: Button,
-              title: 'New Button 1',
-              w: 150
-            },
-            {
-              type: Button,
-              title: 'New Button 2',
-              w: 150
-            }
-          ],
-          3
-        );
-      }, 3000);
-      setTimeout(() => {
-        this.tag('Row').prependItems([
+    prependButton() {
+      this.tag('Row').prependItems([
+        {
+          type: Button,
+          title: 'Prepended Button'
+        }
+      ]);
+    }
+
+    appendButtonAt() {
+      this.tag('Row').appendItemsAt(
+        [
           {
             type: Button,
-            title: 'New Button 3',
-            w: 150
-          },
-          {
-            type: Button,
-            title: 'New Button 4',
-            w: 150
-          },
-          {
-            type: Button,
-            title: 'New Button 5',
-            w: 150
+            title: 'Appended Button at index 1'
           }
-        ]);
-      }, 4000);
+        ],
+        1
+      );
+    }
+
+    appendButton() {
+      this.tag('Row').appendItems([
+        {
+          type: Button,
+          title: 'Appended Button'
+        }
+      ]);
     }
   };
 AddingItems.args = {
@@ -459,7 +488,7 @@ AddingItems.argTypes = {
 };
 AddingItems.parameters = {
   storyDetails:
-    '3 seconds after rendering, 3 new buttons are added at index 3 of the Row via Row.appendItemsAt. 4 seconds after rendering, 3 additional buttons are added at start of the Row via Row.prependItems. '
+    'The 3 buttons initially rendered in this story are configured to invoke 1 of the 3 methods available to add items to a Row (the name of the method used is in parenthesis on the button). Press enter on any of those 3 buttons to invoke that method and add a button to the Row.'
 };
 
 export const LazyUpCount = args =>
@@ -512,16 +541,24 @@ export const RemovingItems = () =>
         Row: {
           type: RowComponent,
           w: getWidthByUpCount(context.theme, 1), // x offset from preview.js * 2
-          items: createItems(Button, 5)
+          signals: {
+            removeAt: 'removeButton'
+          },
+          items: [
+            ...createItems(Button, 2),
+            {
+              type: EditButton,
+              title: 'Press Enter on this button to remove it (removeItemAt)',
+              action: 'removeAt',
+              passSignals: { removeAt: true }
+            }
+          ]
         }
       };
     }
 
-    _init() {
-      super._init();
-      setTimeout(() => {
-        this.tag('Row').removeItemAt(1);
-      }, 3000);
+    removeButton() {
+      this.tag('Row').removeItemAt(2);
     }
   };
 RemovingItems.args = {
@@ -532,5 +569,5 @@ RemovingItems.argTypes = {
 };
 RemovingItems.parameters = {
   storyDetails:
-    '3 seconds after rendering, the button at index 1 in the Row is removed via Row.removeItemAt.'
+    'The third button in this row is configured to invoke removeItemAt to remove that button. Focus on that button and press Enter to invoke that method and remove the button from the row.'
 };

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright 2023 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +24,7 @@ import mdx from './Row.mdx';
 import { context } from '../../globals';
 import { createModeControl } from '../../docs/utils';
 import { CATEGORIES } from '../../docs/constants';
+import { SignalButton } from '../../docs/story-components';
 import Button from '../Button';
 
 export default {
@@ -373,18 +374,6 @@ LazyScrollIndexes.parameters = {
   storyDetails:
     'Items before the item at startLazyScrollIndex and after the item at stopLazyScrollIndex will use alwaysScroll. Items at and between startLazyScrollIndex and stopLazyScrollIndex will use lazyScroll.'
 };
-
-class SignalButton extends Button {
-  onEnter() {
-    this.signal(this.signalName);
-  }
-  set signalName(signalName) {
-    this._signalName = signalName;
-  }
-  get signalName() {
-    return this._signalName;
-  }
-}
 
 export const AddingItems = args =>
   class AddingItems extends lng.Component {

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
@@ -528,9 +528,9 @@ export const RemovingItems = () =>
           items: [
             ...createItems(Button, 2),
             {
-              type: EditButton,
+              type: SignalButton,
               title: 'Press Enter on this button to remove it (removeItemAt)',
-              action: 'removeAt',
+              signalName: 'removeAt',
               passSignals: { removeAt: true }
             }
           ]

--- a/packages/@lightningjs/ui-components/src/docs/story-components/SignalButton.js
+++ b/packages/@lightningjs/ui-components/src/docs/story-components/SignalButton.js
@@ -1,0 +1,13 @@
+import Button from '../../components/Button/Button';
+
+export default class SignalButton extends Button {
+  onEnter() {
+    this.signal(this.signalName);
+  }
+  set signalName(signalName) {
+    this._signalName = signalName;
+  }
+  get signalName() {
+    return this._signalName;
+  }
+}

--- a/packages/@lightningjs/ui-components/src/docs/story-components/index.js
+++ b/packages/@lightningjs/ui-components/src/docs/story-components/index.js
@@ -1,0 +1,1 @@
+export { default as SignalButton } from './SignalButton'


### PR DESCRIPTION
## Description
In the Navigation section of this projects storybook instance, there stories that demonstrate adding and removing items. Previous to this change, that was demonstrated using a timer (`setTimeout`) and would run the various effects after an arbitrary amount of time. This made it more difficult to understand how/when the component was changing and posed timing issues when stories were evaluated with automated tests. 

This pull request refactors those stories to instead add or remove items from user input (pressing the Enter key while focused on an item). The descriptions above the stories outline the expected behavior from those key presses. 
The following stories in the Navigation section of our storybook instance have been updated with these changes:
- Column / Adding Items
- Column / Removing Items
- ControlRow / Adding and Removing
- Row / Adding Items
- Row / Removing Items


<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References
LUI-847
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
1. Navigate to the stories listed in this pull request's Description and follow the instructions written above each component. 
2. Call out any disparity between the description or behavior or if the description is unclear.
<!-- step by step instructions to review this PR's changes -->

## Automation
These changes impact the display and behavior of the above listed stories, so very likely will trigger failures in existing automation tests.
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
