### PR TITLE
fix(Row): update TS structure

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Row/Row.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.d.ts
@@ -71,3 +71,5 @@ declare class Row<
    */
   onScreenEffect(): void;
 }
+
+export default Row;

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.d.ts
@@ -20,8 +20,23 @@ import NavigationManager from '../NavigationManager';
 
 declare namespace Row {
   export interface TemplateSpec extends NavigationManager.TemplateSpec {
+    /**
+     * If true, will only scroll the row if the item is off screen and `alwaysScroll` and `neverScroll` are both false.
+     */
     lazyScroll?: boolean;
+
+    /**
+     * When `lazyScroll` is `true`,
+     * this is the index of item in `items`, and items thereafter, at which lazy scrolling should occur
+     * (alwaysScroll functionality will take place before this index)
+     */
     startLazyScrollIndex?: number;
+
+    /**
+     * When `lazyScroll` is `true`,
+     * this is the index of item in `items`, and items preceding, at which lazy scrolling should occur
+     * (alwaysScroll functionality will take place after this index)
+     */
     stopLazyScrollIndex?: number;
   }
 }
@@ -30,10 +45,29 @@ declare class Row<
   TemplateSpec extends Row.TemplateSpec = Row.TemplateSpec
 > extends NavigationManager<TemplateSpec> {
   // Properties
+  /**
+   * If true, will only scroll the row if the item is off screen and `alwaysScroll` and `neverScroll` are both false.
+   */
   lazyScroll?: boolean;
+
+  /**
+   * When `lazyScroll` is `true`,
+   * this is the index of item in `items`, and items thereafter, at which lazy scrolling should occur
+   * (alwaysScroll functionality will take place before this index)
+   */
   startLazyScrollIndex?: number;
+
+  /**
+   * When `lazyScroll` is `true`,
+   * this is the index of item in `items`, and items preceding, at which lazy scrolling should occur
+   * (alwaysScroll functionality will take place after this index)
+   */
   stopLazyScrollIndex?: number;
 
   // Methods
+  /**
+   * A callback that can be overridden to do something with the items that are currently on screen.
+   * This will be called on every new render.
+   */
   onScreenEffect(): void;
 }

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.d.ts
@@ -17,30 +17,23 @@
  */
 
 import NavigationManager from '../NavigationManager';
-import type { StylePartial } from '../../types/lui';
 
-type TransitionObject = {
-  delay: number;
-  duration: number;
-  timingFunction: string;
-};
+declare namespace Row {
+  export interface TemplateSpec extends NavigationManager.TemplateSpec {
+    lazyScroll?: boolean;
+    startLazyScrollIndex?: number;
+    stopLazyScrollIndex?: number;
+  }
+}
 
-export type RowStyle = {
-  itemSpacing: number;
-  scrollIndex: number;
-  alwaysScroll: boolean;
-  neverScroll: boolean;
-  itemTransition: TransitionObject;
-};
-
-export default class Row extends NavigationManager {
+declare class Row<
+  TemplateSpec extends Row.TemplateSpec = Row.TemplateSpec
+> extends NavigationManager<TemplateSpec> {
+  // Properties
   lazyScroll?: boolean;
-  itemPosX?: number;
-  itemPosY?: number;
   startLazyScrollIndex?: number;
   stopLazyScrollIndex?: number;
-  get style(): RowStyle;
-  set style(v: StylePartial<RowStyle>);
 
+  // Methods
   onScreenEffect(): void;
 }

--- a/packages/@lightningjs/ui-components/src/components/Row/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Row/index.d.ts
@@ -16,6 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import Row, { RowStyle } from './Row';
+import Row from './Row';
 
-export { Row as default, RowStyle };
+export { Row as default };

--- a/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.d.ts
@@ -22,6 +22,12 @@ import type { NavigationManagerStyles } from '../NavigationManager/NavigationMan
 import type { StylePartial } from '../../types/lui';
 import type { TextBoxStyle } from '../TextBox';
 
+// Why does `TitleRow` extend `Row` but use style props from `NavigationManager`?
+/**
+ * `Row` style props are the same as `NavigationManager` style props.
+ * We are not re-mapping properties and defining a `RowStyle` in `Row` since `Row` inherits all of `NavigationManager` style props.
+ * Hence `TitleRowStyle` uses `NavigationManagerStyle` rather than the previous `RowStyle`
+ */
 export type TitleRowStyle = NavigationManagerStyles & {
   w: number;
   titleMarginLeft: number;

--- a/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.d.ts
@@ -18,7 +18,7 @@
 
 import lng from '@lightningjs/core';
 import type Row from '../Row';
-import type { NavigationManagerStyles } from '../NavigationManager/NavigationManager';
+import type { NavigationManagerStyle } from '../NavigationManager/NavigationManager';
 import type { StylePartial } from '../../types/lui';
 import type { TextBoxStyle } from '../TextBox';
 
@@ -28,7 +28,7 @@ import type { TextBoxStyle } from '../TextBox';
  * We are not re-mapping properties and defining a `RowStyle` in `Row` since `Row` inherits all of `NavigationManager` style props.
  * Hence `TitleRowStyle` uses `NavigationManagerStyle` rather than the previous `RowStyle`
  */
-export type TitleRowStyle = NavigationManagerStyles & {
+export type TitleRowStyle = NavigationManagerStyle & {
   w: number;
   titleMarginLeft: number;
   titleTextStyle: TextBoxStyle;

--- a/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.d.ts
@@ -18,11 +18,11 @@
 
 import lng from '@lightningjs/core';
 import type Row from '../Row';
-import type { RowStyle } from '../Row';
+import type { NavigationManagerStyles } from '../NavigationManager/NavigationManager';
 import type { StylePartial } from '../../types/lui';
 import type { TextBoxStyle } from '../TextBox';
 
-export type TitleRowStyle = RowStyle & {
+export type TitleRowStyle = NavigationManagerStyles & {
   w: number;
   titleMarginLeft: number;
   titleTextStyle: TextBoxStyle;

--- a/packages/@lightningjs/ui-components/src/components/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/index.d.ts
@@ -80,7 +80,7 @@ export { default as NavigationManager } from './NavigationManager';
 export { default as ProgressBar, ProgressBarStyle } from './ProgressBar';
 export { default as Provider, ProviderStyle } from './Provider';
 export { default as Radio, RadioStyle } from './Radio';
-export { default as Row, RowStyle } from './Row';
+export { default as Row } from './Row';
 export { default as ScrollWrapper, ScrollWrapperStyle } from './ScrollWrapper';
 export { default as Shadow, ShadowStyle } from './Shadow';
 export { default as Slider, SliderStyle } from './Slider';


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Updates Row's TS declaration file to match the new TS structure ([@lightningjs/core subclassable components guide](https://github.com/rdkcentral/Lightning/blob/2e4c829be45614290405c222bf102022a6219153/docs/TypeScript/Components/SubclassableComponents.md))

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->
LUI-841

## Testing

<!-- step by step instructions to review this PR's changes -->
- Create a new component using `yarn createComponent @lightningjs/ui-components MyComponent`
- Make sure the component extends `Row` (rather than Base)
- Ensure the `Row` properties/methods show up when using the dot syntax or through patch

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
