### PR TITLE
fix(FocusManager): removes all stories except ColumnWithRows

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.mdx
+++ b/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.mdx
@@ -107,12 +107,12 @@ class FancyFocus extends FocusManager {
 
 ### Properties
 
-| name          | type                                                    | default   | description                                                    |
-| ------------- | ------------------------------------------------------- | --------- | -------------------------------------------------------------- |
-| direction     | 'column'\|'row'                                         | undefined | The navigation direction for focus ('left/right' or 'up/down') |
-| selectedIndex | number                                                  | undefined | The index of the currently selected item.                      |
-| items         | <DocsLink id="lng.Component">lng.Component[]</DocsLink> | undefined | Child element or elements of the FocusManager.                 |
-| wrapSelected  | boolean                                                 | false     | Enables wrapping behavior for focus navigation.                |
+| name          | type                                                    | default   | description                                                                                                                                                                                                                                                                                                                                            |
+| ------------- | ------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| direction     | 'column'\|'row'                                         | undefined | The navigation direction for focus ('left/right' or 'up/down')                                                                                                                                                                                                                                                                                         |
+| selectedIndex | number                                                  | undefined | The index of the currently selected item.                                                                                                                                                                                                                                                                                                              |
+| items         | <DocsLink id="lng.Component">lng.Component[]</DocsLink> | undefined | Child element or elements of the FocusManager.                                                                                                                                                                                                                                                                                                         |
+| wrapSelected  | boolean                                                 | false     | When wrapSelected is set to true, the focus will loop back to the beginning of the list after reaching the last item, and vice versa. This enables continuous navigation through the list without dead ends. If wrapSelected is set to false (the default value), the focus will stop at the first or last item, depending on the navigation direction |
 
 ### Methods
 

--- a/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.mdx
+++ b/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.mdx
@@ -54,7 +54,7 @@ class RowExample extends lng.Component {
 ```
 
 <Canvas>
-  <Story id="navigation-focusmanager--rows" />
+  <Story id="navigation-focusmanager--column-with-rows" />
 </Canvas>
 
 Set the `direction` property to `row` for left/right or `column` for up/down key handling.
@@ -67,10 +67,6 @@ Set the `direction` property to `row` for left/right or `column` for up/down key
 }
 ```
 
-<Canvas>
-  <Story id="navigation-focusmanager--columns" />
-</Canvas>
-
 To enable cycling focus between the first and last items, set the `wrapSelected` property to true.
 
 ```js
@@ -80,10 +76,6 @@ To enable cycling focus between the first and last items, set the `wrapSelected`
   children: [/* ... */]
 }
 ```
-
-<Canvas>
-  <Story id="navigation-focusmanager--wrap-selected" />
-</Canvas>
 
 ## Extending FocusManager
 
@@ -110,10 +102,6 @@ class FancyFocus extends FocusManager {
   }
 }
 ```
-
-<Canvas>
-  <Story id="navigation-focusmanager--column-with-rows" />
-</Canvas>
 
 ## API
 

--- a/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.stories.js
@@ -19,7 +19,6 @@
 import lng from '@lightningjs/core';
 import FocusManager from '.';
 import mdx from './FocusManager.mdx';
-import { withSelections } from '../../mixins';
 import { CATEGORIES } from '../../docs/constants';
 import Button from '../Button';
 

--- a/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.stories.js
@@ -91,7 +91,8 @@ ColumnWithRows.argTypes = {
   },
   wrapSelected: {
     control: 'boolean',
-    description: 'Enables wrapping behavior for focus navigation',
+    description:
+      'When set to true, the focus will loop back to the beginning of the list after reaching the last item, and vice versa. This enables continuous navigation through the list without dead ends. If wrapSelected is set to false (the default value), the focus will stop at the first or last item, depending on the navigation direction',
     table: {
       defaultValue: { summary: false }
     }

--- a/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.stories.js
@@ -32,66 +32,6 @@ export default {
   }
 };
 
-export const Rows = () =>
-  class RowExample extends lng.Component {
-    static _template() {
-      return {
-        Row: {
-          type: withSelections(FocusManager),
-          direction: 'row',
-          items: [
-            { type: ButtonFixedWidth, title: 'Left' },
-            { type: ButtonFixedWidth, title: 'Center', x: 250 },
-            { type: ButtonFixedWidth, title: 'Right', x: 500 }
-          ]
-        }
-      };
-    }
-  };
-
-export const WrapSelected = () =>
-  class WrapSelectedExample extends lng.Component {
-    static _template() {
-      return {
-        Row: {
-          y: 50,
-          type: FocusManager,
-          direction: 'row',
-          wrapSelected: true, // allows cycling through items
-          items: [
-            { type: ButtonFixedWidth, title: 'Left' },
-            { type: ButtonFixedWidth, title: 'Center', x: 250 },
-            { type: ButtonFixedWidth, title: 'Right', x: 500 }
-          ]
-        },
-        Text: {
-          y: 0,
-          text: {
-            fontSize: 20,
-            text: 'Key in one direction a bunch of times'
-          }
-        }
-      };
-    }
-  };
-
-export const Columns = () =>
-  class ColumnExample extends lng.Component {
-    static _template() {
-      return {
-        Column: {
-          type: FocusManager,
-          direction: 'column',
-          items: [
-            { type: ButtonFixedWidth, title: 'Top' },
-            { type: ButtonFixedWidth, title: 'Middle', y: 150 },
-            { type: ButtonFixedWidth, title: 'Bottom', y: 300 }
-          ]
-        }
-      };
-    }
-  };
-
 export const ColumnWithRows = () =>
   class ColumnWithRowsExample extends lng.Component {
     static _template() {
@@ -135,3 +75,26 @@ class ButtonFixedWidth extends Button {
     super._init();
   }
 }
+
+ColumnWithRows.args = {
+  direction: 'row',
+  wrapSelected: false
+};
+
+ColumnWithRows.argTypes = {
+  direction: {
+    control: 'radio',
+    options: ['row', 'column'],
+    description: 'The navigation direction for focus (left/right or up/down)',
+    table: {
+      defaultValue: { summary: 'row' }
+    }
+  },
+  wrapSelected: {
+    control: 'boolean',
+    description: 'Enables wrapping behavior for focus navigation',
+    table: {
+      defaultValue: { summary: false }
+    }
+  }
+};


### PR DESCRIPTION
## Description

This PR does the following:

- removes all stories except for ColumnWithRows
- adds two controls: direction and wrapSelected

## References

[LUI-766](https://ccp.sys.comcast.net/browse/LUI-766)

## Testing

- pull branch
- yarn start
- go to Focus Manager => Column with Rows story
- test added controls to make sure expected behavior from controls work

## Automation
The tests for Focus Manager will probably need to be updated since we removed a few stories and and added controls to the one existing story

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
