### PR TITLE
fix(Tile): re-enabled persistentMetadata and clean up transitions

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
@@ -222,7 +222,7 @@ export default class Tile extends Surface {
       ...this.badge,
       x: this.style.paddingX,
       y: this.style.paddingY,
-      alpha: !this._persistentMetadata ? 0.001 : 1
+      alpha: this.persistentMetadata ? 1 : 0.001
     };
 
     if (!this._Badge) {
@@ -259,7 +259,7 @@ export default class Tile extends Surface {
       ...this.label,
       x: this._w - this.style.paddingX,
       y: this.style.paddingY,
-      alpha: !this._persistentMetadata ? 0.001 : 1
+      alpha: this.persistentMetadata ? 1 : 0.001
     };
 
     if (!this._Label) {
@@ -293,14 +293,15 @@ export default class Tile extends Surface {
   // Badge and Label should animate in with the same values
   get _shouldShowBadgeLabel() {
     return (
-      this._persistentMetadata || (this._isFocusedMode && !this._isCircleLayout)
+      this.persistentMetadata || (this._isFocusedMode && !this._isCircleLayout)
     );
   }
+
   get _badgeLabelTransitions() {
     return {
       y: [
         this._shouldShowBadgeLabel ? this.style.paddingY : 0,
-        this.__shouldShowBadgeLabel
+        this._shouldShowBadgeLabel
           ? this.style.animationEntrance
           : this.style.animationExit
       ],
@@ -444,9 +445,12 @@ export default class Tile extends Surface {
   // all the logic on whether the metaData should show
   get _shouldShowMetadata() {
     return (
-      (this._persistentMetadata && !this._isInsetMetadata) ||
-      (this._isFocusedMode && !this._isInsetMetadata) ||
-      (this._isFocusedMode && this._isInsetMetadata && !this._isCircleLayout)
+      this._hasMetadata &&
+      ((this.persistentMetadata && !this._isInsetMetadata) ||
+        (this._isFocusedMode && !this._isInsetMetadata) ||
+        ((this.persistentMetadata || this._isFocusedMode) &&
+          this._isInsetMetadata &&
+          !this._isCircleLayout))
     );
   }
 
@@ -465,7 +469,7 @@ export default class Tile extends Surface {
           : this.style.animationExit
       ],
       alpha: [
-        this._shouldShowMetadata ? 1 : 0.001,
+        this._metadataAlpha,
         this._shouldShowMetadata
           ? this.style.animationEntrance
           : this.style.animationExit
@@ -487,17 +491,23 @@ export default class Tile extends Surface {
       : this._h + this.style.paddingY;
   }
 
+  get _metadataAlpha() {
+    return this._shouldShowMetadata ? 1 : 0.001;
+  }
+
   get _metadataPatch() {
     return {
-      alpha: this._hasMetadata ? 1 : 0.001,
+      alpha: this._metadataAlpha,
       mountX: 0.5,
       mountY: this._isInsetMetadata ? 1 : 0,
       marquee: this._isFocusedMode,
       w: this._w - this.style.paddingX * 2,
       x: this._w / 2,
-      y: !(this._isInsetMetadata && this._isFocusedMode)
-        ? this._metadataY
-        : this._h + this.style.paddingY,
+      y:
+        this.persistentMetadata ||
+        !(this._isInsetMetadata && this._isFocusedMode)
+          ? this._metadataY
+          : this._h + this.style.paddingY,
       ...(this.metadata || {})
     };
   }
@@ -514,15 +524,6 @@ export default class Tile extends Surface {
   }
 
   _updateMetadata() {
-    if (!this._hasMetadata || (this._isCircleLayout && this._isInsetMetadata)) {
-      return;
-    }
-
-    if (!this._persistentMetadata && !this._isFocusedMode) {
-      this._animateMetadata();
-      return;
-    }
-
     if (!this._Metadata) {
       // Patch in Metadata for the first time
       this._Content.patch({
@@ -544,7 +545,10 @@ export default class Tile extends Surface {
   }
 
   _animateMetadata() {
-    if (!this._Metadata) return;
+    if (!this._Metadata) {
+      return;
+    }
+
     this.applySmooth(
       this._Metadata,
       this._metadataPatch,
@@ -558,7 +562,10 @@ export default class Tile extends Surface {
 
   _metadataLoaded() {
     this._animateMetadata();
-    if (this.metadataLocation !== 'inset') this.fireAncestors('$itemChanged'); // Send event to columns/rows that the height has been updated since metadata will be displayed below the Tile
+    // Send event to columns/rows that the height has been updated since metadata will be displayed below the Tile
+    if (this.metadataLocation !== 'inset') {
+      this.fireAncestors('$itemChanged');
+    }
   }
 
   /* ------------------------------ Marquee  ------------------------------ */

--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
@@ -524,7 +524,12 @@ export default class Tile extends Surface {
   }
 
   _updateMetadata() {
-    if (!this._Metadata) {
+    if (!this._hasMetadata) {
+      this._Content.patch({ Metadata: undefined });
+      return;
+    }
+
+    if (!this._Metadata && this._hasMetadata) {
       // Patch in Metadata for the first time
       this._Content.patch({
         Metadata: {

--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.test.js
@@ -433,19 +433,16 @@ describe('Tile', () => {
     expect(tile._ProgressBar).toBeUndefined();
   });
 
-  it('should update metadata and remove if no longer needed if metadataLocation is inset', async () => {
+  it('should update metadata and remove if no longer needed', async () => {
     expect(tile.metadata).toBeUndefined();
+
     tile.metadata = { title: 'test' };
-    tile.metadataLocation = 'inset';
     await tile.__updateMetadataSpyPromise;
     expect(tile.metadata).not.toBeUndefined();
+
     tile.metadata = undefined;
     await tile.__updateMetadataSpyPromise;
     expect(tile._Metadata).toBeUndefined();
-    tile.shouldSmooth = false;
-    tile.metadata = { title: 'test2' };
-    await tile.__updateMetadataSpyPromise;
-    expect(tile.metadata).not.toBeUndefined();
   });
 
   it('should reset the marquee animation when unfocused', async () => {

--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.test.js
@@ -439,6 +439,7 @@ describe('Tile', () => {
     tile.metadata = { title: 'test' };
     await tile.__updateMetadataSpyPromise;
     expect(tile.metadata).not.toBeUndefined();
+    expect(tile._Metadata).not.toBeUndefined();
 
     tile.metadata = undefined;
     await tile.__updateMetadataSpyPromise;


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
The inset persistent metadata was broken and after putting it back, the animation on/off the tile was happening on focus/unfocus even if the metadata should stay visible.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
1. Go to Tile
2. In standard metadata position, test that it appears/disappears on focus/unfocus appropriately.
3. Repeat inset.
2. In standard metadata position, turn on persistentMetadata and test that it is visible in all modes.
3. Repeat with inset.
4. Repeat all of the above in the circle mode. The inset metadata should never be visible (regardless of persistency).
5. Reset back to the original args, turn on persistent metadata and confirm that in both the standard and inset positions, if you remove all of the text in title and description, they are not visible on the tile (this was an issue with the short circuit return in updateMetadata not actually alpha-ing anything out).

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
