### PR TITLE
fix(Template): update TS template to reflect new structure

### DIFF
--- a/bin/templates/component.template.js
+++ b/bin/templates/component.template.js
@@ -17,8 +17,25 @@
  */
 
 module.exports = name => {
-  return `import Base from '../Base';
+  return `/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
+import Base from '../Base';
 import * as styles from './${name}.styles.js';
 
 export default class ${name} extends Base {
@@ -52,6 +69,5 @@ export default class ${name} extends Base {
      * Styles can be accessed by this.style.myStyle
      */
   }
-}`;
-};
-  
+}
+`};

--- a/bin/templates/docs.template.js
+++ b/bin/templates/docs.template.js
@@ -18,7 +18,24 @@
 
 const urlBase = 'https://github.com/rdkcentral/Lightning-UI-Components/tree/develop/packages/%40lightningjs/ui-components/src/components/';
 
-module.exports = (name, dir) => `
+module.exports = (name, dir) => `<!--
+  Copyright 2023 Comcast Cable Communications Management, LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
 import { Canvas, Story } from '@storybook/addon-docs';
 import ${name} from '.';
 

--- a/bin/templates/export-typescript-definitions.template.js
+++ b/bin/templates/export-typescript-definitions.template.js
@@ -17,7 +17,25 @@
  */
 
 module.exports = name => {
-    return `import ${name}, { ${name}Style } from './${name}';
+  return `/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import ${name}, { ${name}Style } from './${name}';
 
 export { ${name} as default, ${name}Style };
 `}

--- a/bin/templates/export.template.js
+++ b/bin/templates/export.template.js
@@ -17,6 +17,24 @@
  */
 
 module.exports = name => {
-    return `export { default } from './${name}';
+  return `/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { default as default } from './${name}';
 `
 }

--- a/bin/templates/story.template.js
+++ b/bin/templates/story.template.js
@@ -38,7 +38,7 @@ module.exports = (name) => {
 import lng from '@lightningjs/core';
 import ${name} from '.';
 import mdx from './${name}.mdx';
-import { CATEGORIES } from '../../../docs/constants';
+import { CATEGORIES } from '../../docs/constants';
 
 export default {
   // TODO: replace categoryIndex with key for which category this component's story should be nested in. See CATEGORIES object in packages/apps/lightning-ui-docs/index.js

--- a/bin/templates/story.template.js
+++ b/bin/templates/story.template.js
@@ -17,9 +17,25 @@
  */
 
 module.exports = (name) => {
+  return `/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
-  return `import lng from '@lightningjs/core';
-
+import lng from '@lightningjs/core';
 import ${name} from '.';
 import mdx from './${name}.mdx';
 import { CATEGORIES } from '../../../docs/constants';

--- a/bin/templates/style.template.js
+++ b/bin/templates/style.template.js
@@ -17,12 +17,28 @@
  */
 
 module.exports = () => {
-  return `
+  return `/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 export const base = theme => ({
   
 });
-  
+
 export const mode = theme => ({
   unfocused: {
 
@@ -33,8 +49,8 @@ export const mode = theme => ({
   disabled: {
     
   }
-  });
-  
+});
+
 export const tone = theme => ({
   neutral: {
 
@@ -45,5 +61,5 @@ export const tone = theme => ({
   brand: {
     
   }
-  });
-  `}
+});
+`}

--- a/bin/templates/test.template.js
+++ b/bin/templates/test.template.js
@@ -18,7 +18,25 @@
 
 module.exports = name => {
   const camelCaseName = name.charAt(0).toLowerCase() + name.slice(1);;
-  return `import { makeCreateComponent } from '@lightningjs/ui-components-test-utils';
+  return `/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { makeCreateComponent } from '@lightningjs/ui-components-test-utils';
 import ${name} from '.';
 
 const createComponent = makeCreateComponent(${name});

--- a/bin/templates/typescript-definitions.template.js
+++ b/bin/templates/typescript-definitions.template.js
@@ -17,20 +17,50 @@
  */
 
 module.exports = name => {
-  return `import type { Base, StylePartial } from '../../types/lui';
+  return `/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
-export type ${name}Style = {
+import lng from '@lightningjs/core';
+import Base from '../Base/Base'; // TODO: remove this comment or replace import with appropriate parent component import
+import type { StylePartial } from '../../types/lui';
 
-};
+export type ${name}Style = {};
 
-export default class ${name} extends Base {
-  //add public class methods here
+declare namespace ${name} {
+  export interface TemplateSpec extends Base.TemplateSpec {
+    // include properties from the below class declaration and anything that can be patched to the component
+  }
+}
+
+declare class ${name}<
+  TemplateSpec extends ${name}.TemplateSpec = ${name}.TemplateSpec,
+  TypeConfig extends lng.Component.TypeConfig = lng.Component.TypeConfig
+> extends Base<TemplateSpec, TypeConfig> {
+  // Properties
+
+  // Accessors
   get style(): ${name}Style;
   set style(v: StylePartial<${name}Style>);
 
+  // Methods
 
-  //add all component tags here
+  // Tags
 }
+
+export default ${name};
 `}
-
-


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
This PR updates the template files for when new components are created.

- Ensures the TypeScript template is updated to reflect the new structure ([@lightningjs/core subclassable components guide](https://github.com/rdkcentral/Lightning/blob/2e4c829be45614290405c222bf102022a6219153/docs/TypeScript/Components/SubclassableComponents.md))
- Adds License and Copyright to all template files so that new components will automatically have it

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->
LUI-828

## Testing

<!-- step by step instructions to review this PR's changes -->

- Create a new component using the yarn createComponent command in the terminal (for example `yarn createComponent @lightningjs/ui-components Test`)
- Ensure all files in the new Test component have a License and Copyright comment at the top of the file
- Confirm Test.d.ts (TS file) follows the new TS structure (should have namespace and a class declaration)
- Run a local server and confirm Storybook does build with the new component

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
