### PR TITLE
fix(ProgressBar): update Base theme default brand tone barColor to neutral

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/ProgressBar/ProgressBar.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/ProgressBar/ProgressBar.styles.js
@@ -32,7 +32,7 @@ export const tone = theme => ({
     progressColor: theme.color.fillInverse
   },
   brand: {
-    barColor: theme.color.fillBrandTertiary,
+    barColor: theme.color.fillNeutralTertiary,
     progressColor: theme.color.fillBrand
   }
 });


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Per the weekly component reviews with design, we are updating the default barColor for the brand tone to use a neetral color to better match the industry standard (brand color is only used on the foreground progress bar).

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
In the ProgressBar story, observe that when in the brand tone, the brand color is only applied to the progress color, and the bar color uses the neutral color.

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
