### PR TITLE
fix: Base theme radii

### DIFF
--- a/packages/@lightningjs/ui-components-theme-base/theme.js
+++ b/packages/@lightningjs/ui-components-theme-base/theme.js
@@ -134,6 +134,10 @@ export default {
     textInverseSecondary: ['#181819', 0.7],
     textInverseTertiary: ['#181819', 0.1],
     textInverseDisabled: ['#181819', 0.5],
+    textBrand: ['#93a9fd', 1],
+    textBrandSecondary: ['#93a9fd', 0.7],
+    textBrandTertiary: ['#93a9fd', 0.1],
+    textBrandDisabled: ['#93a9fd', 0.5],
     textPositive: ['#2Ecc71', 1],
     textNegative: ['#e74c3c', 1],
     textInfo: ['#93a9fd', 1],
@@ -208,7 +212,7 @@ export default {
     gutterY: { xs: 20, sm: 40, md: 60, lg: 80, xl: 100 },
     focusScale: 1.2
   },
-  radius: { none: 0, xs: 0, sm: 0, md: 0, lg: 0, xl: 0 },
+  radius: { none: 0, xs: 2, sm: 4, md: 8, lg: 16, xl: 24 },
   spacer: { xxs: 2, xs: 4, sm: 8, md: 10, lg: 20, xl: 30, xxl: 40, xxxl: 50 },
   stroke: { sm: 2, md: 4, lg: 6, xl: 8 },
   typography: {
@@ -216,7 +220,7 @@ export default {
       fontFamily: 'Arial',
       fontSize: 75,
       lineHeight: 85,
-      fontWeight: 500,
+      fontStyle: '500',
       verticalAlign: 'middle',
       textBaseline: 'bottom'
     },
@@ -224,14 +228,14 @@ export default {
       fontFamily: 'Arial',
       fontSize: 50,
       lineHeight: 60,
-      fontWeight: 500,
+      fontStyle: '500',
       verticalAlign: 'middle',
       textBaseline: 'bottom'
     },
     headline1: {
       fontFamily: 'Arial',
       fontSize: 35,
-      fontWeight: 500,
+      fontStyle: '500',
       lineHeight: 48,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
@@ -239,7 +243,7 @@ export default {
     headline2: {
       fontFamily: 'Arial',
       fontSize: 30,
-      fontWeight: 500,
+      fontStyle: '500',
       lineHeight: 40,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
@@ -247,7 +251,7 @@ export default {
     headline3: {
       fontFamily: 'Arial',
       fontSize: 25,
-      fontWeight: 500,
+      fontStyle: '500',
       lineHeight: 36,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
@@ -255,7 +259,7 @@ export default {
     body1: {
       fontFamily: 'Arial',
       fontSize: 25,
-      fontWeight: 300,
+      fontStyle: '300',
       lineHeight: 40,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
@@ -263,7 +267,7 @@ export default {
     body2: {
       fontFamily: 'Arial',
       fontSize: 22,
-      fontWeight: 300,
+      fontStyle: '300',
       lineHeight: 32,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
@@ -271,7 +275,7 @@ export default {
     body3: {
       fontFamily: 'Arial',
       fontSize: 20,
-      fontWeight: 300,
+      fontStyle: '300',
       lineHeight: 32,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
@@ -279,7 +283,7 @@ export default {
     button1: {
       fontFamily: 'Arial',
       fontSize: 25,
-      fontWeight: 500,
+      fontStyle: '500',
       letterSpacing: -0.2,
       lineHeight: 32,
       verticalAlign: 'middle',
@@ -288,7 +292,7 @@ export default {
     button2: {
       fontFamily: 'Arial',
       fontSize: 20,
-      fontWeight: 500,
+      fontStyle: '500',
       lineHeight: 32,
       verticalAlign: 'middle',
       textBaseline: 'bottom'
@@ -296,7 +300,7 @@ export default {
     callout1: {
       fontFamily: 'Arial',
       fontSize: 20,
-      fontWeight: 500,
+      fontStyle: '500',
       letterSpacing: 1,
       lineHeight: 32,
       verticalAlign: 'middle',
@@ -305,7 +309,7 @@ export default {
     caption1: {
       fontFamily: 'Arial',
       fontSize: 15,
-      fontWeight: 500,
+      fontStyle: '500',
       lineHeight: 24,
       verticalAlign: 'middle',
       textBaseline: 'bottom'

--- a/packages/@lightningjs/ui-components/src/components/Badge/__snapshots__/Badge.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/Badge/__snapshots__/Badge.test.js.snap
@@ -73,6 +73,7 @@ exports[`Badge renders 1`] = `
       "texture": {
         "fontFace": "Arial",
         "fontSize": 15,
+        "fontStyle": "500",
         "lineHeight": 24,
         "precision": 0.6666666666666666,
         "textAlign": "center",
@@ -168,6 +169,7 @@ exports[`Badge renders icon and text side by side 1`] = `
       "texture": {
         "fontFace": "Arial",
         "fontSize": 15,
+        "fontStyle": "500",
         "lineHeight": 24,
         "precision": 0.6666666666666666,
         "text": "HD",
@@ -264,6 +266,7 @@ exports[`Badge renders icon only 1`] = `
       "texture": {
         "fontFace": "Arial",
         "fontSize": 15,
+        "fontStyle": "500",
         "lineHeight": 24,
         "precision": 0.6666666666666666,
         "textAlign": "center",

--- a/packages/@lightningjs/ui-components/src/components/Control/ControlSmall.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Control/ControlSmall.test.js
@@ -75,7 +75,7 @@ describe('ControlSmall', () => {
 
   it('renders the correct logo radius', async () => {
     expect(controlSmall.style.logoStyle.radius).toBe(
-      Math.max(controlSmall.style.radius - controlSmall.theme.spacer.xl / 2, 0)
+      Math.max(controlSmall.style.radius - controlSmall.style.paddingX / 2, 0)
     );
   });
 });

--- a/packages/@lightningjs/ui-components/src/components/ControlRow/__snapshots__/ControlRow.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/ControlRow/__snapshots__/ControlRow.test.js.snap
@@ -650,6 +650,7 @@ exports[`ControlRow renders 1`] = `
           "texture": {
             "fontFace": "Arial",
             "fontSize": 35,
+            "fontStyle": "500",
             "lineHeight": 48,
             "precision": 0.6666666666666666,
             "text": "Title",

--- a/packages/@lightningjs/ui-components/src/components/Key/__snapshots__/Key.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/Key/__snapshots__/Key.test.js.snap
@@ -91,6 +91,7 @@ exports[`Key should render 1`] = `
                   "texture": {
                     "fontFace": "Arial",
                     "fontSize": 30,
+                    "fontStyle": "500",
                     "letterSpacing": -0.2,
                     "lineHeight": 40,
                     "maxLines": 1,

--- a/packages/@lightningjs/ui-components/src/components/Keyboard/__snapshots__/Keyboard.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/__snapshots__/Keyboard.test.js.snap
@@ -121,6 +121,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -359,6 +360,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -597,6 +599,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -835,6 +838,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -1073,6 +1077,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -1311,6 +1316,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -1549,6 +1555,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -1787,6 +1794,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -2025,6 +2033,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -2263,6 +2272,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -2501,6 +2511,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -2813,6 +2824,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -3051,6 +3063,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -3289,6 +3302,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -3601,6 +3615,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -3839,6 +3854,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -4077,6 +4093,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -4315,6 +4332,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -4553,6 +4571,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -4791,6 +4810,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -5029,6 +5049,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -5267,6 +5288,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -5505,6 +5527,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -5743,6 +5766,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -5981,6 +6005,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -6293,6 +6318,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -6531,6 +6557,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -6769,6 +6796,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -7007,6 +7035,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -7245,6 +7274,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -7483,6 +7513,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -7721,6 +7752,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -7959,6 +7991,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -8197,6 +8230,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -8698,6 +8732,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -9010,6 +9045,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -9248,6 +9284,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -9486,6 +9523,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -9724,6 +9762,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -9962,6 +10001,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -10200,6 +10240,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -10438,6 +10479,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -10676,6 +10718,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -10914,6 +10957,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -11152,6 +11196,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -11390,6 +11435,7 @@ exports[`Keyboard renders 1`] = `
                                       "texture": {
                                         "fontFace": "Arial",
                                         "fontSize": 30,
+                                        "fontStyle": "500",
                                         "letterSpacing": -0.2,
                                         "lineHeight": 40,
                                         "maxLines": 1,
@@ -12106,6 +12152,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -12344,6 +12391,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -12582,6 +12630,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -12820,6 +12869,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -13058,6 +13108,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -13296,6 +13347,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -13534,6 +13586,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -13772,6 +13825,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -14010,6 +14064,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -14248,6 +14303,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -14823,6 +14879,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -15061,6 +15118,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -15299,6 +15357,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -15537,6 +15596,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -15775,6 +15835,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -16013,6 +16074,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -16251,6 +16313,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -16489,6 +16552,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -16727,6 +16791,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -16965,6 +17030,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -17203,6 +17269,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -17515,6 +17582,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -17753,6 +17821,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -17991,6 +18060,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -18229,6 +18299,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -18467,6 +18538,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -18705,6 +18777,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -18943,6 +19016,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -19181,6 +19255,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -19419,6 +19494,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -19657,6 +19733,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -19895,6 +19972,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -20207,6 +20285,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -20445,6 +20524,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -20683,6 +20763,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -20921,6 +21002,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -21159,6 +21241,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -21397,6 +21480,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -21635,6 +21719,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -21873,6 +21958,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -22111,6 +22197,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -22349,6 +22436,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -22587,6 +22675,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -22899,6 +22988,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -23137,6 +23227,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,
@@ -23375,6 +23466,7 @@ exports[`KeyboardInput renders 1`] = `
                                                   "texture": {
                                                     "fontFace": "Arial",
                                                     "fontSize": 30,
+                                                    "fontStyle": "500",
                                                     "letterSpacing": -0.2,
                                                     "lineHeight": 40,
                                                     "maxLines": 1,

--- a/packages/@lightningjs/ui-components/src/components/Label/__snapshots__/Label.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/Label/__snapshots__/Label.test.js.snap
@@ -73,6 +73,7 @@ exports[`Label renders 1`] = `
       "texture": {
         "fontFace": "Arial",
         "fontSize": 15,
+        "fontStyle": "500",
         "lineHeight": 24,
         "precision": 0.6666666666666666,
         "text": "undefined",

--- a/packages/@lightningjs/ui-components/src/components/ListItem/__snapshots__/ListItem.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/__snapshots__/ListItem.test.js.snap
@@ -91,6 +91,7 @@ exports[`ListItem renders 1`] = `
                   "texture": {
                     "fontFace": "Arial",
                     "fontSize": 20,
+                    "fontStyle": "300",
                     "lineHeight": 32,
                     "maxLines": 1,
                     "precision": 0.6666666666666666,
@@ -178,6 +179,7 @@ exports[`ListItem renders 1`] = `
                   "texture": {
                     "fontFace": "Arial",
                     "fontSize": 25,
+                    "fontStyle": "500",
                     "letterSpacing": -0.2,
                     "lineHeight": 32,
                     "maxLines": 1,

--- a/packages/@lightningjs/ui-components/src/components/ListItem/__snapshots__/ListItemPicker.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/__snapshots__/ListItemPicker.test.js.snap
@@ -91,6 +91,7 @@ exports[`ListItemPicker renders 1`] = `
                   "texture": {
                     "fontFace": "Arial",
                     "fontSize": 20,
+                    "fontStyle": "300",
                     "lineHeight": 32,
                     "maxLines": 1,
                     "precision": 0.6666666666666666,
@@ -253,6 +254,7 @@ exports[`ListItemPicker renders 1`] = `
                   "texture": {
                     "fontFace": "Arial",
                     "fontSize": 25,
+                    "fontStyle": "500",
                     "letterSpacing": -0.2,
                     "lineHeight": 32,
                     "maxLines": 1,

--- a/packages/@lightningjs/ui-components/src/components/ListItem/__snapshots__/ListItemSlider.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/__snapshots__/ListItemSlider.test.js.snap
@@ -443,6 +443,7 @@ exports[`ListItemSlider renders 1`] = `
                   "texture": {
                     "fontFace": "Arial",
                     "fontSize": 25,
+                    "fontStyle": "500",
                     "letterSpacing": -0.2,
                     "lineHeight": 32,
                     "maxLines": 1,
@@ -532,6 +533,7 @@ exports[`ListItemSlider renders 1`] = `
                   "texture": {
                     "fontFace": "Arial",
                     "fontSize": 25,
+                    "fontStyle": "500",
                     "lineHeight": 36,
                     "maxLines": 1,
                     "precision": 0.6666666666666666,

--- a/packages/@lightningjs/ui-components/src/components/Marquee/__snapshots__/Marquee.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/Marquee/__snapshots__/Marquee.test.js.snap
@@ -47,6 +47,7 @@ exports[`Marquee #color updates the text color 1`] = `
               "texture": {
                 "fontFace": "Arial",
                 "fontSize": 25,
+                "fontStyle": "300",
                 "lineHeight": 50,
                 "maxLines": 1,
                 "precision": 0.6666666666666666,
@@ -209,6 +210,7 @@ exports[`Marquee renders 1`] = `
               "texture": {
                 "fontFace": "Arial",
                 "fontSize": 25,
+                "fontStyle": "300",
                 "lineHeight": 50,
                 "maxLines": 1,
                 "precision": 0.6666666666666666,

--- a/packages/@lightningjs/ui-components/src/components/MetadataCardContent/__snapshots__/MetadataCardContent.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/MetadataCardContent/__snapshots__/MetadataCardContent.test.js.snap
@@ -289,6 +289,7 @@ exports[`MetadataCardContent renders 1`] = `
                               "texture": {
                                 "fontFace": "Arial",
                                 "fontSize": 25,
+                                "fontStyle": "500",
                                 "lineHeight": 36,
                                 "precision": 0.6666666666666666,
                                 "text": "+7",

--- a/packages/@lightningjs/ui-components/src/components/Provider/Provider.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Provider/Provider.test.js
@@ -105,6 +105,7 @@ describe('Provider', () => {
       providers: Array(20).fill(iconSquare)
     });
     provider.disableRadius = true;
+    testRenderer.forceAllUpdates();
     expect(provider._Row.items[2].radius).toEqual(0);
   });
 

--- a/packages/@lightningjs/ui-components/src/components/Provider/__snapshots__/Provider.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/Provider/__snapshots__/Provider.test.js.snap
@@ -214,6 +214,7 @@ exports[`Provider renders 1`] = `
                       "texture": {
                         "fontFace": "Arial",
                         "fontSize": 25,
+                        "fontStyle": "500",
                         "lineHeight": 36,
                         "precision": 0.6666666666666666,
                         "text": "+1",

--- a/packages/@lightningjs/ui-components/src/components/ScrollWrapper/__snapshots__/ScrollWrapper.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/ScrollWrapper/__snapshots__/ScrollWrapper.test.js.snap
@@ -485,6 +485,7 @@ exports[`ScrollWrapper renders 1`] = `
                   "texture": {
                     "fontFace": "Arial",
                     "fontSize": 22,
+                    "fontStyle": "300",
                     "lineHeight": 32,
                     "precision": 0.6666666666666666,
                     "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin eu aliquam libero. Sed ipsum ligula, egestas et sollicitudin eget, pulvinar et neque. Curabitur commodo nisi sit amet ligula ultrices, a sodales ante consequat. Ut ullamcorper odio et erat sagittis volutpat. Cras consequat dolor in nisi sagittis, quis volutpat mi tempor. Praesent condimentum quis purus eget sodales. Praesent tempus suscipit felis, quis gravida massa tempor ut.",
@@ -652,6 +653,7 @@ exports[`ScrollWrapper renders a content array 1`] = `
                   "texture": {
                     "fontFace": "Arial",
                     "fontSize": 22,
+                    "fontStyle": "300",
                     "lineHeight": 32,
                     "precision": 0.6666666666666666,
                     "text": "Heading!",
@@ -738,6 +740,7 @@ exports[`ScrollWrapper renders a content array 1`] = `
                   "texture": {
                     "fontFace": "Arial",
                     "fontSize": "30",
+                    "fontStyle": "300",
                     "lineHeight": 32,
                     "precision": 0.6666666666666666,
                     "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin eu aliquam libero. Sed ipsum ligula, egestas et sollicitudin eget, pulvinar et neque. Curabitur commodo nisi sit amet ligula ultrices, a sodales ante consequat. Ut ullamcorper odio et erat sagittis volutpat. Cras consequat dolor in nisi sagittis, quis volutpat mi tempor. Praesent condimentum quis purus eget sodales. Praesent tempus suscipit felis, quis gravida massa tempor ut.",
@@ -1296,6 +1299,7 @@ exports[`ScrollWrapper renders a content string 1`] = `
                   "texture": {
                     "fontFace": "Arial",
                     "fontSize": 22,
+                    "fontStyle": "300",
                     "lineHeight": 32,
                     "precision": 0.6666666666666666,
                     "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin eu aliquam libero. Sed ipsum ligula, egestas et sollicitudin eget, pulvinar et neque. Curabitur commodo nisi sit amet ligula ultrices, a sodales ante consequat. Ut ullamcorper odio et erat sagittis volutpat. Cras consequat dolor in nisi sagittis, quis volutpat mi tempor. Praesent condimentum quis purus eget sodales. Praesent tempus suscipit felis, quis gravida massa tempor ut.",

--- a/packages/@lightningjs/ui-components/src/components/TabBar/__snapshots__/Tab.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/__snapshots__/Tab.test.js.snap
@@ -127,6 +127,7 @@ exports[`Tab renders 1`] = `
               "texture": {
                 "fontFace": "Arial",
                 "fontSize": 25,
+                "fontStyle": "500",
                 "lineHeight": 36,
                 "precision": 0.6666666666666666,
                 "text": "Tab",

--- a/packages/@lightningjs/ui-components/src/components/TabBar/__snapshots__/TabBar.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/__snapshots__/TabBar.test.js.snap
@@ -325,6 +325,7 @@ exports[`TabBar renders 1`] = `
                           "texture": {
                             "fontFace": "Arial",
                             "fontSize": 25,
+                            "fontStyle": "500",
                             "lineHeight": 36,
                             "precision": 0.6666666666666666,
                             "text": "Tab 1",
@@ -523,6 +524,7 @@ exports[`TabBar renders 1`] = `
                           "texture": {
                             "fontFace": "Arial",
                             "fontSize": 25,
+                            "fontStyle": "500",
                             "lineHeight": 36,
                             "precision": 0.6666666666666666,
                             "text": "Tab 2",

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.test.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.test.js
@@ -180,7 +180,6 @@ describe('TextBox', () => {
       };
       const lightningDefaultValues = {
         fontSize: 40,
-        fontStyle: 'normal',
         textAlign: 'left',
         verticalAlign: 'top',
         wordWrap: true,
@@ -198,9 +197,6 @@ describe('TextBox', () => {
       expect(textBox._Text.text.fontSize).toBe(baseTheme.fontSize);
       expect(textBox._Text.text.maxLinesSuffix).toBe(
         lightningDefaultValues.maxLinesSuffix
-      );
-      expect(textBox._Text.text.fontStyle).toBe(
-        lightningDefaultValues.fontStyle
       );
     });
   });

--- a/packages/@lightningjs/ui-components/src/components/TitleRow/__snapshots__/TitleRow.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/TitleRow/__snapshots__/TitleRow.test.js.snap
@@ -323,6 +323,7 @@ exports[`TitleRow renders 1`] = `
           "texture": {
             "fontFace": "Arial",
             "fontSize": 35,
+            "fontStyle": "500",
             "lineHeight": 48,
             "precision": 0.6666666666666666,
             "text": "Title",

--- a/packages/@lightningjs/ui-components/src/components/Tooltip/__snapshots__/Tooltip.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/Tooltip/__snapshots__/Tooltip.test.js.snap
@@ -47,6 +47,7 @@ exports[`Tooltip renders 1`] = `
               "texture": {
                 "fontFace": "Arial",
                 "fontSize": 15,
+                "fontStyle": "500",
                 "lineHeight": 24,
                 "precision": 0.6666666666666666,
                 "text": "Tooltip",

--- a/packages/@lightningjs/ui-components/src/mixins/withEditItems/__snapshots__/withEditItems.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/mixins/withEditItems/__snapshots__/withEditItems.test.js.snap
@@ -103,6 +103,7 @@ exports[`withEditItems renders 1`] = `
                           "texture": {
                             "fontFace": "Arial",
                             "fontSize": 25,
+                            "fontStyle": "500",
                             "letterSpacing": -0.2,
                             "lineHeight": 32,
                             "maxLines": 1,
@@ -341,6 +342,7 @@ exports[`withEditItems renders 1`] = `
                           "texture": {
                             "fontFace": "Arial",
                             "fontSize": 25,
+                            "fontStyle": "500",
                             "letterSpacing": -0.2,
                             "lineHeight": 32,
                             "maxLines": 1,
@@ -579,6 +581,7 @@ exports[`withEditItems renders 1`] = `
                           "texture": {
                             "fontFace": "Arial",
                             "fontSize": 25,
+                            "fontStyle": "500",
                             "letterSpacing": -0.2,
                             "lineHeight": 32,
                             "maxLines": 1,
@@ -817,6 +820,7 @@ exports[`withEditItems renders 1`] = `
                           "texture": {
                             "fontFace": "Arial",
                             "fontSize": 25,
+                            "fontStyle": "500",
                             "letterSpacing": -0.2,
                             "lineHeight": 32,
                             "maxLines": 1,
@@ -1055,6 +1059,7 @@ exports[`withEditItems renders 1`] = `
                           "texture": {
                             "fontFace": "Arial",
                             "fontSize": 25,
+                            "fontStyle": "500",
                             "letterSpacing": -0.2,
                             "lineHeight": 32,
                             "maxLines": 1,
@@ -1293,6 +1298,7 @@ exports[`withEditItems renders 1`] = `
                           "texture": {
                             "fontFace": "Arial",
                             "fontSize": 25,
+                            "fontStyle": "500",
                             "letterSpacing": -0.2,
                             "lineHeight": 32,
                             "maxLines": 1,


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Update corner radii of Base theme to be non-zero and adjust snapshots and tests accordingly.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
Check out the Theming Tokens story and confirm that the corner radius icons at the right now have values. Components like the Tile and Button should also be more rounded now.

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
