### PR TITLE
fix(TitleRow): update TS structure

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.d.ts
@@ -35,11 +35,30 @@ export type TitleRowStyle = NavigationManagerStyle & {
   rowMarginTop: number;
 };
 
-export default class TitleRow extends Row {
+declare namespace TitleRow {
+  export interface TemplateSpec extends Row.TemplateSpec {
+    /**
+     * Title text to be displayed above the `Row` items
+     */
+    title?: string;
+  }
+}
+
+declare class TitleRow<
+  TemplateSpec extends TitleRow.TemplateSpec = TitleRow.TemplateSpec
+> extends Row<TemplateSpec> {
+  // Properties
+  /**
+   * Title text to be displayed above the `Row` items
+   */
   title?: string;
+
+  // Accessors
   get style(): TitleRowStyle;
   set style(v: StylePartial<TitleRowStyle>);
 
-  // tags
+  // Tags
   get _Title(): lng.Component;
 }
+
+export default TitleRow;


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Updates `TitleRow`'s TS declaration file to match the new TS structure ([@lightningjs/core subclassable components guide](https://github.com/rdkcentral/Lightning/blob/2e4c829be45614290405c222bf102022a6219153/docs/TypeScript/Components/SubclassableComponents.md))

This PR branches off the Row TS updates (#241) since `TitleRow` extends `Row`.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->
LUI-842

## Testing

<!-- step by step instructions to review this PR's changes -->
- Create a new component using `yarn createComponent @lightningjs/ui-components MyComponent`
- Make sure the component extends `TitleRow` (rather than `Base`)
- Ensure the `TitleRow` properties/methods show up when using the dot syntax or through patch

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
