### PR TITLE
fix(Slider): removes canvas tags from docs

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Slider/Slider.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Slider/Slider.mdx
@@ -44,10 +44,6 @@ class Example extends lng.Component {
 }
 ```
 
-<Canvas>
-  <Story id="utilities-slider--basic" />
-</Canvas>
-
 The `Slider` can be initialized with a `min`, `max` and current `value`. The `min` and `max` properties determine the bounds of the `Slider`. The `value` prop should be greater than or equal to `min` and less than or equal to `max`.
 
 ```js
@@ -85,10 +81,6 @@ class Example extends lng.Component {
 ### Signal handling
 
 React to changes to the `Slider` value using the `onChange` signal.
-
-<Canvas>
-  <Story id="utilities-slider--signal-handling" />
-</Canvas>
 
 ## API
 


### PR DESCRIPTION
## Description
The Slider story docs has an error in the <Canvas>  element. More than likely this is related to `useArgs`. For now the fix will be to remove both the <Canvas> elements in the docs for this story.

## References
LUI-887

## Testing

clone branch
got to Slider Story => Docs tab
Canvas elements should not be there and setState error should no be showing

## Automation


## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
