### PR TITLE
feat: add TypeScript definitions for @lightningjs/ui-components-test-utils exports

### DIFF
--- a/packages/@lightningjs/ui-components-test-utils/index.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/index.d.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './src/lightning-test-renderer';
+export * from './src/lightning-test-utils';
+export * from './src/lng-test-env';

--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-renderer.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-renderer.d.ts
@@ -1,0 +1,49 @@
+import lng from '@lightningjs/core';
+
+export type JSONTreeProperties = any; // TODO
+export type JSONTree = Record<string, JSONTreeProperties>;
+
+export type testRenderer = {
+  toJSON: (children?: number) => JSONTree;
+  update: () => void;
+  forceAllUpdates: () => void;
+  focus: () => void;
+  unfocus: () => void;
+  getContext: () => any; // TODO: Context does not have a TS def
+
+  // TODO: I don't think this is correct, lng.Element.ElementChildList is readonly so can't access from lng
+  getInstance: () => lng.Element;
+
+  getFocused: () => lng.Component<
+    lng.Component.TemplateSpecLoose,
+    lng.Component.TypeConfig
+  >;
+  getApp: () => lng.Application;
+  keyPress: (key: string | Record<'key', string>) => void;
+  keyRelease: (key: string | Record<'key', string>) => void;
+  destroy: () => void;
+  focusPath: () => string[];
+};
+
+export type createOptions = {
+  applicationW: number;
+  applicationH: number;
+  [key: string]: any;
+};
+
+declare function create(
+  Component: lng.Component,
+  options?: createOptions
+): testRenderer;
+
+export type toJSON = (
+  element: lng.Element,
+  options?: { children: number }
+) => JSONTree;
+
+declare namespace _default {
+  export { create };
+  export { toJSON };
+}
+
+export default _default;

--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import lng from '@lightningjs/core';
+import { jest } from '@jest/globals';
+import type {
+  default as TestRenderer,
+  testRenderer
+} from './lightning-test-renderer.d.ts';
+
+export function nextTick(wait?: number): Promise<undefined>;
+
+export function fastForward(elements: lng.Element[]): void;
+
+type makeCreateComponentConfig = Record<string, any>;
+interface makeCreateComponentDefaultOptions {
+  applicationW?: number;
+  applicationH?: number;
+  [key: string]: any;
+}
+interface makeCreateComponentOptions extends makeCreateComponentDefaultOptions {
+  spyOnMethods?: string[];
+}
+type createComponent = (
+  config: makeCreateComponentConfig,
+  options: makeCreateComponentOptions
+) => [lng.Element, testRenderer];
+export function makeCreateComponent(
+  type: lng.Component,
+  defaultConfig?: makeCreateComponentConfig,
+  defaultOptions?: makeCreateComponentDefaultOptions
+): createComponent;
+
+export function completeAnimation(
+  element: lng.Element,
+  transitionProperties?: string | string[]
+): Promise<undefined>;
+
+import { Mock } from 'jest-mock';
+
+export function mockContext(
+  context: any, // TODO: no TS def for Context available
+  mockKeyMetricsHandler?: jest.Mock<any>
+): any;
+
+export function resetContext(): void;
+
+export { TestRenderer };
+
+declare namespace _default {
+  export { fastForward };
+  export { makeCreateComponent };
+  export { nextTick };
+  export { completeAnimation };
+}
+export default _default;

--- a/packages/@lightningjs/ui-components-test-utils/src/lng-test-env.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/src/lng-test-env.d.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TestEnvironment } from 'jest-environment-jsdom';
+
+export default class MyTestEnvironment extends TestEnvironment {
+  setup(): Promise<void>;
+}


### PR DESCRIPTION
## Description

- adds TypeScript definition files for all exports from the `@lightningjs/ui-components-test-utils` package

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References
LUI-872
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->

## Automation
n/a
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
