### PR TITLE
feat: add TypeScript definitions for @lightningjs/ui-components-test-utils exports

### DIFF
--- a/packages/@lightningjs/ui-components-test-utils/index.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/index.d.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './src/lightning-test-renderer';
+export * from './src/lightning-test-utils';
+export * from './src/lng-test-env';

--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-renderer.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-renderer.d.ts
@@ -18,8 +18,51 @@
 
 import lng from '@lightningjs/core';
 
-export type JSONTreeProperties = any; // TODO
-export type JSONTree = Record<string, JSONTreeProperties>;
+export interface JSONTree {
+  alpha: lng.Component['alpha'];
+  active: lng.Component['active'];
+  attached: lng.Component['attached'];
+  boundsMargin: lng.Component['attached'];
+  color: lng.Component['color'];
+  clipping: lng.Component['clipping'];
+  enabled: lng.Component['enabled'];
+  h: lng.Component['h'];
+  isComponent: boolean;
+  mount: lng.Component['mount'];
+  mountY: lng.Component['mountY'];
+  mountX: lng.Component['mountX'];
+  pivot: lng.Component['pivot'];
+  pivotX: lng.Component['pivotX'];
+  pivotY: lng.Component['pivotY'];
+  ref: lng.Component['ref'];
+  renderOfScreen?: unknown;
+  renderToTexture: lng.Component['renderToTexture'];
+  scale: lng.Component['scale'];
+  scaleX: lng.Component['scaleX'];
+  scaleY: lng.Component['scaleY'];
+  state: lng.Component['state'];
+  tag: lng.Component['tag'];
+  visible: lng.Component['visible'];
+  w: lng.Component['w'];
+  x: lng.Component['x'];
+  y: lng.Component['y'];
+  zIndex: lng.Component['zIndex'];
+  /**
+   * @remarks
+   * This does not return the flex object property on the Lightning Element.
+   * It returns a boolean of whether or not that property exists on the Element.
+   */
+  flex: boolean; // returns
+  /**
+   * @remarks
+   * This does not return the flexItem object property on the Lightning Element.
+   * It returns a boolean of whether or not that property exists on the Element.
+   */
+  flexItem: boolean;
+  hasFocus?: boolean;
+  hasFinalFocus?: boolean;
+  [key: string]: any;
+}
 
 export type testRenderer = {
   toJSON: (children?: number) => JSONTree;
@@ -28,10 +71,7 @@ export type testRenderer = {
   focus: () => void;
   unfocus: () => void;
   getContext: () => any; // TODO: Context does not have a TS def
-
-  // TODO: I don't think this is correct, lng.Element.ElementChildList is readonly so can't access from lng
   getInstance: () => lng.Element;
-
   getFocused: () => lng.Component<
     lng.Component.TemplateSpecLoose,
     lng.Component.TypeConfig
@@ -49,19 +89,12 @@ export type createOptions = {
   [key: string]: any;
 };
 
-declare function create(
+export declare function create(
   Component: lng.Component,
   options?: createOptions
 ): testRenderer;
 
-export type toJSON = (
+export declare function toJSON(
   element: lng.Element,
   options?: { children: number }
-) => JSONTree;
-
-declare namespace _default {
-  export { create };
-  export { toJSON };
-}
-
-export default _default;
+): JSONTree;

--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-renderer.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-renderer.d.ts
@@ -61,8 +61,11 @@ export interface JSONTree {
   flexItem: boolean;
   hasFocus?: boolean;
   hasFinalFocus?: boolean;
-  [key: string]: any;
+  [key: string]: unknown;
 }
+
+// TODO: no TS def for Context available
+type context = Record<string, unknown>;
 
 export type testRenderer = {
   toJSON: (children?: number) => JSONTree;
@@ -70,7 +73,7 @@ export type testRenderer = {
   forceAllUpdates: () => void;
   focus: () => void;
   unfocus: () => void;
-  getContext: () => any; // TODO: Context does not have a TS def
+  getContext: () => context;
   getInstance: () => lng.Element;
   getFocused: () => lng.Component<
     lng.Component.TemplateSpecLoose,
@@ -86,7 +89,7 @@ export type testRenderer = {
 export type createOptions = {
   applicationW: number;
   applicationH: number;
-  [key: string]: any;
+  [key: string]: unknown;
 };
 
 export declare function create(

--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-renderer.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-renderer.d.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import lng from '@lightningjs/core';
 
 export type JSONTreeProperties = any; // TODO

--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-renderer.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-renderer.d.ts
@@ -1,0 +1,49 @@
+import lng from '@lightningjs/core';
+
+export type JSONTreeProperties = any; // TODO
+export type JSONTree = Record<string, JSONTreeProperties>;
+
+export type testRenderer = {
+  toJSON: (children?: number) => JSONTree;
+  update: () => void;
+  forceAllUpdates: () => void;
+  focus: () => void;
+  unfocus: () => void;
+  getContext: () => any; // TODO: Context does not have a TS def
+
+  // TODO: I don't think this is correct, lng.Element.ElementChildList is readonly so can't access from lng
+  getInstance: () => lng.Element;
+
+  getFocused: () => lng.Component<
+    lng.Component.TemplateSpecLoose,
+    lng.Component.TypeConfig
+  >;
+  getApp: () => lng.Application;
+  keyPress: (key: string | Record<'key', string>) => void;
+  keyRelease: (key: string | Record<'key', string>) => void;
+  destroy: () => void;
+  focusPath: () => string[];
+};
+
+export type createOptions = {
+  applicationW: number;
+  applicationH: number;
+  [key: string]: any;
+};
+
+declare function create(
+  Component: lng.Component,
+  options?: createOptions
+): testRenderer;
+
+export type toJSON = (
+  element: lng.Element,
+  options?: { children: number }
+) => JSONTree;
+
+declare namespace _default {
+  export { create };
+  export { toJSON };
+}
+
+export default _default;

--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-renderer.js
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-renderer.js
@@ -212,15 +212,21 @@ function getProperties(element) {
     const getBoolean = /^!{2}/;
     const isFunction = /\(\)$/;
 
+    // output a different value of certain properties in the list array if matched
     if (getBoolean.test(key)) {
+      // contains !! --> output value as boolean of if is truthy/falsey
       key = key.substring(2, key.length);
       props[key] = !!element[key];
     } else if (isFunction.test(key)) {
+      // contains ()
+      // if that function exists on the element, invoke it and output the return value
+      // else omit that key from the output
       key = key.substring(0, key.length - 2);
       if (typeof element[key] === 'function') {
         props[key] = element[key]();
       }
     } else {
+      // doesn't match either Regex --> output the actual value of that property on the element
       props[key] = element[key];
     }
   }

--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
@@ -44,7 +44,7 @@ type createComponent = (
 ) => [lng.Element, testRenderer];
 
 export function makeCreateComponent(
-  type: Base.TemplateSpec, // TODO: this throws TS error when used
+  type: lng.Component.Constructor,
   defaultConfig?: makeCreateComponentConfig,
   defaultOptions?: makeCreateComponentDefaultOptions
 ): createComponent;

--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
@@ -17,10 +17,10 @@
  */
 import lng from '@lightningjs/core';
 import { jest } from '@jest/globals';
-import type {
+import {
   default as TestRenderer,
   testRenderer
-} from './lightning-test-renderer.d.ts';
+} from './lightning-test-renderer';
 
 /**
  * nextTick
@@ -91,7 +91,7 @@ export function completeAnimation(
  * mockContext
  */
 // TODO: no TS def for Context available
-type context = Record<string, unknown>;
+export type context = Record<string, unknown>;
 
 export function mockContext(
   context: context,

--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import lng from '@lightningjs/core';
+import { jest } from '@jest/globals';
+import type {
+  default as TestRenderer,
+  testRenderer
+} from './lightning-test-renderer.d.ts';
+
+export function nextTick(wait?: number): Promise<undefined>;
+
+export function fastForward(elements: lng.Element[]): void;
+
+type makeCreateComponentConfig = Record<string, any>;
+interface makeCreateComponentDefaultOptions {
+  applicationW?: number;
+  applicationH?: number;
+  [key: string]: any;
+}
+interface makeCreateComponentOptions extends makeCreateComponentDefaultOptions {
+  spyOnMethods?: string[];
+}
+type createComponent = (
+  config: makeCreateComponentConfig,
+  options: makeCreateComponentOptions
+) => [lng.Element, testRenderer];
+export function makeCreateComponent(
+  type: lng.Component,
+  defaultConfig?: makeCreateComponentConfig,
+  defaultOptions?: makeCreateComponentDefaultOptions
+): createComponent;
+
+export function completeAnimation(
+  element: lng.Element,
+  transitionProperties?: string | string[]
+): Promise<undefined>;
+
+import { Mock } from 'jest-mock';
+
+export function mockContext(
+  context: any, // TODO: no TS def for Context available
+  mockKeyMetricsHandler?: jest.Mock<any>
+): any;
+
+export function resetContext(): void;
+
+export { TestRenderer };
+
+declare namespace _default {
+  export { fastForward };
+  export { makeCreateComponent };
+  export { nextTick };
+  export { completeAnimation };
+}
+export default _default;

--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
@@ -35,44 +35,49 @@ export function fastForward(elements: lng.Element[]): void;
 /**
  * makeCreateComponent
  */
-interface MakeCreateComponentDefaultOptions
-  extends Partial<lng.Application.Options> {
-  focused?: boolean;
-  applicationW?: number;
-  applicationH?: number;
-  stage?: Partial<lng.Application.Options['stage']>; // TODO: test if this is the correct type
+declare namespace makeCreateComponent {
+  export type Config = lng.Element.PatchTemplate;
+  export interface DefaultOptions extends Partial<lng.Application.Options> {
+    focused?: boolean;
+    applicationW?: number;
+    applicationH?: number;
+    stage?: Partial<lng.Application.Options['stage']>;
+  }
+
+  export namespace createComponent {
+    interface Options extends DefaultOptions {
+      spyOnMethods?: string[];
+    }
+
+    type SpyOnMethodsPromises<T extends string[]> = {
+      [K in T[number] as `_${K}SpyPromise`]: Promise<void>;
+    };
+
+    type SpyOnMethodsResolvers<T extends string[]> = {
+      [K in T[number] as `_${K}SpyResolve`]: () => void;
+    };
+
+    type ComponentInstance<T extends string[]> = {
+      [key: string]: unknown;
+    } & lng.Component &
+      SpyOnMethodsPromises<T> &
+      SpyOnMethodsResolvers<T>;
+
+    export type CreateComponent = (
+      config: Config,
+      options?: Options
+    ) => [
+      ComponentInstance<NonNullable<(typeof options)['spyOnMethods']>>,
+      testRenderer
+    ];
+  }
 }
-
-interface MakeCreateComponentOptions extends MakeCreateComponentDefaultOptions {
-  spyOnMethods?: string[];
-}
-
-type SpyOnMethodPromises<T extends string[]> = {
-  [K in T[number] as `_${K}SpyPromise`]: Promise<void>;
-};
-type SpyOnMethodResolvers<T extends string[]> = {
-  [K in T[number] as `_${K}SpyResolve`]: () => void;
-};
-
-type TestRendererComponentInstance<T extends string[]> = {
-  [key: string]: unknown;
-} & lng.Component &
-  SpyOnMethodPromises<T> &
-  SpyOnMethodResolvers<T>;
-
-export type createComponent = (
-  config: lng.Element.PatchTemplate,
-  options?: MakeCreateComponentOptions
-) => [
-  TestRendererComponentInstance<NonNullable<(typeof options)['spyOnMethods']>>,
-  testRenderer
-];
 
 export function makeCreateComponent(
   type: lng.Component.Constructor,
-  defaultConfig?: lng.Element.PatchTemplate,
-  defaultOptions?: MakeCreateComponentDefaultOptions
-): createComponent;
+  defaultConfig?: makeCreateComponent.Config,
+  defaultOptions?: makeCreateComponent.DefaultOptions
+): makeCreateComponent.createComponent.CreateComponent;
 
 /**
  * completeAnimation

--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
@@ -26,11 +26,11 @@ export function nextTick(wait?: number): Promise<void>;
 
 export function fastForward(elements: lng.Element[]): void;
 
-type makeCreateComponentConfig = Record<string, any>;
+type makeCreateComponentConfig = Record<string, unknown>;
 interface makeCreateComponentDefaultOptions {
   applicationW?: number;
   applicationH?: number;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 interface makeCreateComponentOptions extends makeCreateComponentDefaultOptions {
   spyOnMethods?: string[];
@@ -52,10 +52,13 @@ export function completeAnimation(
 
 import { Mock } from 'jest-mock';
 
+// TODO: no TS def for Context available
+type context = Record<string, unknown>;
+
 export function mockContext(
-  context: any, // TODO: no TS def for Context available
-  mockKeyMetricsHandler?: jest.Mock<any>
-): any;
+  context: context,
+  mockKeyMetricsHandler: jest.Mock | ((...args: unknown[]) => unknown)
+): context;
 
 export function resetContext(): void;
 

--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
@@ -23,12 +23,19 @@ import type {
 } from './lightning-test-renderer.d.ts';
 import { Base } from '@lightningjs/ui-components';
 
+/**
+ * nextTick
+ */
 export function nextTick(wait?: number): Promise<void>;
 
+/**
+ * fastForward
+ */
 export function fastForward(elements: lng.Element[]): void;
 
-type makeCreateComponentConfig = Record<string, unknown>;
-interface makeCreateComponentDefaultOptions {
+/**
+ * makeCreateComponent
+ */
   applicationW?: number;
   applicationH?: number;
   [key: string]: unknown;
@@ -49,11 +56,17 @@ export function makeCreateComponent(
   defaultOptions?: makeCreateComponentDefaultOptions
 ): createComponent;
 
+/**
+ * completeAnimation
+ */
 export function completeAnimation(
   element: lng.Element,
   transitionProperties?: string | string[]
 ): Promise<void>;
 
+/**
+ * mockContext
+ */
 // TODO: no TS def for Context available
 type context = Record<string, unknown>;
 
@@ -62,8 +75,14 @@ export function mockContext(
   mockKeyMetricsHandler: jest.Mock | ((...args: unknown[]) => unknown)
 ): context;
 
+/**
+ * resetContext
+ */
 export function resetContext(): void;
 
+/**
+ * exports
+ */
 export { TestRenderer };
 
 declare namespace _default {

--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
@@ -50,8 +50,6 @@ export function completeAnimation(
   transitionProperties?: string | string[]
 ): Promise<void>;
 
-import { Mock } from 'jest-mock';
-
 // TODO: no TS def for Context available
 type context = Record<string, unknown>;
 

--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
@@ -22,7 +22,7 @@ import type {
   testRenderer
 } from './lightning-test-renderer.d.ts';
 
-export function nextTick(wait?: number): Promise<undefined>;
+export function nextTick(wait?: number): Promise<void>;
 
 export function fastForward(elements: lng.Element[]): void;
 
@@ -48,7 +48,7 @@ export function makeCreateComponent(
 export function completeAnimation(
   element: lng.Element,
   transitionProperties?: string | string[]
-): Promise<undefined>;
+): Promise<void>;
 
 import { Mock } from 'jest-mock';
 

--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
@@ -21,6 +21,7 @@ import type {
   default as TestRenderer,
   testRenderer
 } from './lightning-test-renderer.d.ts';
+import { Base } from '@lightningjs/ui-components';
 
 export function nextTick(wait?: number): Promise<void>;
 
@@ -35,12 +36,15 @@ interface makeCreateComponentDefaultOptions {
 interface makeCreateComponentOptions extends makeCreateComponentDefaultOptions {
   spyOnMethods?: string[];
 }
+
+// TODO: the component instance needs to optionally add __${methodName}PromiseSpy
 type createComponent = (
-  config: makeCreateComponentConfig,
-  options: makeCreateComponentOptions
+  config?: makeCreateComponentConfig,
+  options?: makeCreateComponentOptions
 ) => [lng.Element, testRenderer];
+
 export function makeCreateComponent(
-  type: lng.Component,
+  type: Base.TemplateSpec, // TODO: this throws TS error when used
   defaultConfig?: makeCreateComponentConfig,
   defaultOptions?: makeCreateComponentDefaultOptions
 ): createComponent;

--- a/packages/@lightningjs/ui-components-test-utils/src/lng-test-env.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/src/lng-test-env.d.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TestEnvironment } from 'jest-environment-jsdom';
+
+export default class MyTestEnvironment extends TestEnvironment {
+  setup(): Promise<void>;
+}


### PR DESCRIPTION
## Description

- adds TypeScript definition files for all exports from the `@lightningjs/ui-components-test-utils` package

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References
LUI-872
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->

## Automation
n/a
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
