### PR TITLE
fix: update alpha handling in InlineContent Truncation Logic

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
@@ -61,12 +61,12 @@ export default class InlineContent extends Base {
   }
 
   _updateContent() {
-    this.childList.clear();
+   this.childList.clear();
 
     // if wrapping with max lines, hide content until it has rerendered with maxLines and truncation calculated
-if (this._shouldTruncate) {
+     if (this._shouldTruncate) {
       this.alpha = 0.001;
-    }
+    }      
 
     if (this._parsedContent && this._parsedContent.length) {
       this.patch({

--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
@@ -64,7 +64,9 @@ export default class InlineContent extends Base {
     this.childList.clear();
 
     // if wrapping with max lines, hide content until it has rerendered with maxLines and truncation calculated
-    this.alpha = this._shouldTruncate ? 0.001 : 1;
+if (this._shouldTruncate) {
+      this.alpha = 0.001;
+    }
 
     if (this._parsedContent && this._parsedContent.length) {
       this.patch({

--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
@@ -61,13 +61,11 @@ export default class InlineContent extends Base {
   }
 
   _updateContent() {
-   this.childList.clear();
-
+    this.childList.clear();
     // if wrapping with max lines, hide content until it has rerendered with maxLines and truncation calculated
-     if (this._shouldTruncate) {
+    if (this._shouldTruncate) {
       this.alpha = 0.001;
-    }      
-
+    }
     if (this._parsedContent && this._parsedContent.length) {
       this.patch({
         flex: {


### PR DESCRIPTION
## Description

In this PR, this change ensures the alpha value is changed only when truncation is required, so won’t affect Marquee setting its own alpha on InlineContent.

## References

Part of LUI-889

## Testing

Verify inlineContent stories haven't effected and marquee sub story centeredText should work as expected.
