### PR TITLE
fix(Base): add better docs for shouldSmooth and applySmooth

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Base/Base.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Base/Base.d.ts
@@ -63,17 +63,20 @@ declare class Base<
    */
   loaded?: Promise<void>;
 
-  // TODO: flag for discussion
-  // internal stuff can be omitted --> `shouldSmooth` is internal?
-  shouldSmooth?: boolean;
-
   /**
    * when true, plinko will use the previous item to determine the horizontal index of the next focused item
    */
   skipPlinko: boolean;
 
   /**
+   * used by `applySmooth` to track if a component should have values transitioned in, or patched without an animation
+   */
+  get shouldSmooth(): boolean;
+
+  /**
    * conditionally transitions in values based on the state of `shouldSmooth`
+   * if `true`, values will be applied using the [lng.Element.smooth](@link https://github.com/rdkcentral/Lightning/blob/8378d0e69752f476abedecc85568a27dbb63cbb0/src/tree/Element.d.mts#L1823C4-L1823C4)
+   * if `false`, values will be applied using [lng.Element.patch](@link https://github.com/rdkcentral/Lightning/blob/8378d0e69752f476abedecc85568a27dbb63cbb0/src/tree/Element.d.mts#L1746)
    */
   // TODO took a stab at these types, could probably make this type-safe
   applySmooth(


### PR DESCRIPTION
## Description

This PR updates the comments on the `shouldSmooth` property and `applySmooth` method on Base

## References

Spun out of the [Column update PR](https://github.com/rdkcentral/Lightning-UI-Components/pull/238/files#r1223159763)

## Testing

<!-- step by step instructions to review this PR's changes -->

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
