### PR TITLE
test(Artwork): unskipped and rewrote failing Artwork test

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.test.js
@@ -18,8 +18,7 @@
 
 import {
   makeCreateComponent,
-  fastForward,
-  pathToDataURI
+  fastForward
 } from '@lightningjs/ui-components-test-utils';
 import { jest } from '@jest/globals';
 import Artwork from '.';

--- a/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.test.js
@@ -716,14 +716,11 @@ describe('Artwork', () => {
     expect(artwork._Gradient).not.toBeUndefined();
   });
 
-  // TODO: Need to figure out why this test fails. Something with Jest and image loading. Right now, received is undefined.
-  it.skip('should update the Image element with the value of src, and remove the texture if no longer required', async () => {
+  it('should update the Image element with the value of src, and remove the texture if no longer required', async () => {
     expect(artwork._Image.texture).not.toBeNull();
-    artwork.src = undefined;
+    artwork.src = './src/assets/images/circle.svg';
     await artwork.__updateImageSpyPromise;
-    expect(artwork._Image.texture.src).toBe(
-      pathToDataURI('./src/assets/images/default_background.png')
-    );
+    expect(artwork._Image.texture.src).toBe('./src/assets/images/circle.svg');
     expect(artwork._Image).not.toBeUndefined();
   });
 


### PR DESCRIPTION
## Description

In this PR, addressed skipped test in the Artwork.test.js file, removed the skip flag and rewrote the test to pass.

## References

LUI-700

## Testing

Run the artwork test suite and verify there are no skipped tests present.
