### PR TITLE
fix(TextBox): add x value in the stories file for the InlineContentString

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.stories.js
@@ -137,6 +137,7 @@ export const WithInlineContentString = () =>
       return {
         TextBox: {
           type: TextBox,
+          x: 400,
           w: 400,
           content:
             'This is an example of using custom markup {ICON:settings|https://upload.wikimedia.org/wikipedia/commons/b/b6/Tomato-Torrent-Icon.png} with a linebreak{NEWLINE}{BADGE:HD} that includes all available types like {TEXT:styled text|italic}.',


### PR DESCRIPTION
## Description

With this fix, the InlineContentString will now appear properly in storybook UI.

## References

LUI-901