### PR TITLE
fix(TestRenderer): import jest from jest globals

### DIFF
--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-renderer.js
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-renderer.js
@@ -18,7 +18,7 @@
 
 import lng from '@lightningjs/core';
 import { updateManager, context } from '@lightningjs/ui-components';
-import jest from 'jest-mock';
+import { jest } from '@jest/globals';
 import BaseTheme from '@lightningjs/ui-components-theme-base';
 
 context.setTheme({

--- a/packages/@lightningjs/ui-components-test-utils/src/lng-test-env.js
+++ b/packages/@lightningjs/ui-components-test-utils/src/lng-test-env.js
@@ -17,7 +17,7 @@
  */
 
 import { TestEnvironment as JSDOMEnvironment } from 'jest-environment-jsdom';
-import jest from 'jest-mock';
+import { jest } from '@jest/globals';
 
 // Helper function to extract the width and height dimensions from a src string
 const extractWidthHeight = src => {

--- a/packages/@lightningjs/ui-components-test-utils/src/lng-test-env.js
+++ b/packages/@lightningjs/ui-components-test-utils/src/lng-test-env.js
@@ -17,7 +17,6 @@
  */
 
 import { TestEnvironment as JSDOMEnvironment } from 'jest-environment-jsdom';
-import { jest } from '@jest/globals';
 
 // Helper function to extract the width and height dimensions from a src string
 const extractWidthHeight = src => {
@@ -36,7 +35,7 @@ export default class LightningUIEnvironment extends JSDOMEnvironment {
     if (process.env.CI) {
       this.global.console = {
         ...this.global.console,
-        error: jest.fn()
+        error: () => {}
       };
     }
 


### PR DESCRIPTION
## Description
- Updates import of the `jest` object to be from the `@jest/globals` package (which gets installed along with `jest`). This is recommended by jest in their [v27 to v28 migration guide](https://jestjs.io/docs/28.x/upgrading-to-jest28#typescript) for resolving potential issues in TypeScript projects.
- remove import of `jest` object in `lng-test-env.js`. Updating that import to be from `@jest/globals` throws the following error: `Do not import `@jest/globals` outside of the Jest test environment`. It looks like `jest` was being imported to assign `jest.fn()` to `console.error`, but don't see anywhere in tests that rely on this. I changed it to be an empty arrow function so that it still removes error messages from CI builds like the existing comment suggests.
<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References
Reported in LUI5 support channel
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
I'm not aware of a way to run into the initial error, but all our tests should still run after this change.
<!-- step by step instructions to review this PR's changes -->

## Automation
n/a
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
