### PR TITLE
fix(Tile): properly set metadataLocation for style object (no nested object setters)

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
@@ -120,7 +120,7 @@ export default class Tile extends Surface {
   }
 
   get h() {
-    return this.metadataLocation !== 'inset'
+    return !this._isInsetMetadata
       ? super.h + ((this._Metadata && this._Metadata.h) || 0)
       : super.h;
   }
@@ -455,7 +455,7 @@ export default class Tile extends Surface {
   }
 
   get _isInsetMetadata() {
-    return this._metadataLocation === 'inset';
+    return this.metadataLocation === 'inset';
   }
 
   get _metadataTransitions() {
@@ -516,11 +516,11 @@ export default class Tile extends Surface {
     return this.style.metadataLocation ?? this._metadataLocation;
   }
 
-  _setMetadataLocation(newMetadataLocation) {
-    if (newMetadataLocation) {
-      this.style.metadataLocation = newMetadataLocation;
+  _setMetadataLocation(metadataLocation) {
+    if (metadataLocation) {
+      this.style = { metadataLocation };
     }
-    return newMetadataLocation;
+    return metadataLocation;
   }
 
   _updateMetadata() {
@@ -568,7 +568,7 @@ export default class Tile extends Surface {
   _metadataLoaded() {
     this._animateMetadata();
     // Send event to columns/rows that the height has been updated since metadata will be displayed below the Tile
-    if (this.metadataLocation !== 'inset') {
+    if (!this._isInsetMetadata) {
       this.fireAncestors('$itemChanged');
     }
   }


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Both of these PRs seemed fine in isolation, but once merged together, the Tile's inset metadata location was not being honored on focus/unfocused if the persistentMetadata flag was true. This resolves that issue.
- https://github.com/rdkcentral/Lightning-UI-Components/pull/246
- https://github.com/rdkcentral/Lightning-UI-Components/pull/245

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
1. Nav to Tile
2. Set metadataLocation to "inset"
3. Set persistentMetadata to true
4. Change mode between focused and unfocused and observe the metadata is in the correct location.

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
