### PR TITLE
feat: alias support for class properties and style properties

### DIFF
--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
@@ -148,13 +148,13 @@ export default function withThemeStyles(Base, mixinStyle) {
     }
 
     get _modeStyle() {
-      return this.replaceAliasValues(
+      return this._replaceAliasValues(
         this._componentStyleSource?.mode?.[this.mode] || {}
       );
     }
 
     get _toneStyle() {
-      return this.replaceAliasValues(
+      return this._replaceAliasValues(
         this._componentStyleSource?.tone?.[this.tone] || {}
       );
     }
@@ -164,7 +164,7 @@ export default function withThemeStyles(Base, mixinStyle) {
      * @return {object}
      */
     get _themeLevelStyle() {
-      return this.replaceAliasValues(this._componentConfig?.style || {});
+      return this._replaceAliasValues(this._componentConfig?.style || {});
     }
 
     /**
@@ -172,7 +172,7 @@ export default function withThemeStyles(Base, mixinStyle) {
      * @return {object}
      */
     get _componentLevelStyle() {
-      return this.replaceAliasValues(this._componentLevelStyleSource || {});
+      return this._replaceAliasValues(this._componentLevelStyleSource || {});
     }
 
     /**
@@ -460,7 +460,7 @@ export default function withThemeStyles(Base, mixinStyle) {
       this.queueThemeUpdate();
     }
 
-    replaceAliasValues(value) {
+    _replaceAliasValues(value) {
       const styleObj = clone(value, {});
       const aliasProps = [
         { prev: 'height', curr: 'h', skipWarn: true },

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
@@ -476,7 +476,7 @@ export default function withThemeStyles(Base, mixinStyle) {
         ) {
           !alias.skipWarn &&
             console.warn(
-              `The style property "${alias.prev}" is deprecated. Please use "${alias.curr}" instead.`
+              `The style property "${alias.prev}" is deprecated and may be removed in a future release. Please use "${alias.curr}" instead.`
             );
           Object.defineProperty(
             styleObj,

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
@@ -476,7 +476,7 @@ export default function withThemeStyles(Base, mixinStyle) {
         ) {
           !alias.skipWarn &&
             console.warn(
-              `The style property "${alias.prev}" is deprecated and may be removed in a future release. Please use "${alias.curr}" instead.`
+              `The style property "${alias.prev}" is deprecated and will be removed in a future release. Please use "${alias.curr}" instead.`
             );
           Object.defineProperty(
             styleObj,

--- a/packages/@lightningjs/ui-components/src/mixins/withUpdates/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withUpdates/index.js
@@ -86,9 +86,18 @@ export default function withUpdates(Base) {
         // the props in the properties array (and use the getters/setters defined above)
         const aliasProps = this.constructor.aliasProperties || [];
         aliasProps.forEach(alias => {
-          const descriptor = getAliasPropertyDescriptor(alias.prev, alias.curr);
-          if (descriptor !== undefined) {
-            Object.defineProperty(prototype, alias.prev, descriptor);
+          if (
+            alias &&
+            typeof alias.prev === 'string' &&
+            typeof alias.curr === 'string'
+          ) {
+            const descriptor = getAliasPropertyDescriptor(
+              alias.prev,
+              alias.curr
+            );
+            if (descriptor !== undefined) {
+              Object.defineProperty(prototype, alias.prev, descriptor);
+            }
           }
         });
 

--- a/packages/@lightningjs/ui-components/src/mixins/withUpdates/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withUpdates/index.js
@@ -49,6 +49,20 @@ function getPropertyDescriptor(name, key) {
   };
 }
 
+function getAliasPropertyDescriptor(prev, curr) {
+  const deprecationWarning = `The property "${prev}" is deprecated. Please use "${curr}" instead.`;
+  return {
+    get() {
+      console.warn(deprecationWarning);
+      return this[curr];
+    },
+    set(value) {
+      console.warn(deprecationWarning);
+      this[curr] = value;
+    }
+  };
+}
+
 export default function withUpdates(Base) {
   return class extends Base {
     static get name() {
@@ -58,6 +72,7 @@ export default function withUpdates(Base) {
     _construct() {
       const prototype = Object.getPrototypeOf(this);
       if (!prototype._withUpdatesInitialized) {
+        // create custom accessors and mutators for the props in the properties array
         const props = this.constructor.properties || [];
         props.forEach(name => {
           const key = '_' + name;
@@ -66,6 +81,17 @@ export default function withUpdates(Base) {
             Object.defineProperty(prototype, name, descriptor);
           }
         });
+
+        // create custom accessors and mutators that map the props in the alias array to
+        // the props in the properties array (and use the getters/setters defined above)
+        const aliasProps = this.constructor.aliasProperties || [];
+        aliasProps.forEach(alias => {
+          const descriptor = getAliasPropertyDescriptor(alias.prev, alias.curr);
+          if (descriptor !== undefined) {
+            Object.defineProperty(prototype, alias.prev, descriptor);
+          }
+        });
+
         prototype._withUpdatesInitialized = true;
       }
 

--- a/packages/@lightningjs/ui-components/src/mixins/withUpdates/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withUpdates/index.js
@@ -50,7 +50,7 @@ function getPropertyDescriptor(name, key) {
 }
 
 function getAliasPropertyDescriptor(prev, curr) {
-  const deprecationWarning = `The property "${prev}" is deprecated. Please use "${curr}" instead.`;
+  const deprecationWarning = `The property "${prev}" is deprecated and may be removed in a future release. Please use "${curr}" instead.`;
   return {
     get() {
       console.warn(deprecationWarning);

--- a/packages/@lightningjs/ui-components/src/mixins/withUpdates/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withUpdates/index.js
@@ -50,7 +50,7 @@ function getPropertyDescriptor(name, key) {
 }
 
 function getAliasPropertyDescriptor(prev, curr) {
-  const deprecationWarning = `The property "${prev}" is deprecated and may be removed in a future release. Please use "${curr}" instead.`;
+  const deprecationWarning = `The property "${prev}" is deprecated and will be removed in a future release. Please use "${curr}" instead.`;
   return {
     get() {
       console.warn(deprecationWarning);


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
These updates add aliasing support to withUpdates and withThemeStyles so that we can update property names and throw deprecation warnings without creating breaking changes. This also adds support for `height` and `width` to be accepted as `h` and `w` in the styles file.

Once this is vetted and merged, I will be going through each component to scrub for abbreviated properties like "iconW" and replacing them with the expanded string version ("iconWidth") using this new alias feature, both in the component properties and component style properties.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
1. Add "value" as a deprecated property in ProgressBar
    - In Progress.d.ts's class declaration (note that these "strings" need to be changed to "number" when we scrub the components):
      ```ts
      progress: string;
      /** @deprecated */
      value: string;
      ```
    - In Progress.js:
      ```js
      static get aliasProperties() {
        return [{ prev: 'value', curr: 'progress' }];
      }
      ```
2. Add "foregroundColor" as a deprecated style property in ProgressBar
    - In Progress.d.ts's ProgressBarStyle declaration:
      ```ts
      progressColor: Color;
      /** @deprecated */
      foregroundColor: Color;
      ```
    - In Progress.js
      ```js
      static get aliasStyles() {
        return [{ prev: 'foregroundColor', curr: 'progressColor' }];
      }
      ```
3. Add instructions to ProgressBar story to test out the aliasing:
    - In ProgressBar.stories.js, under the template method, add something like this:
      ```js
      _init() {
        setTimeout(() => {
          this.tag('ProgressBar').value = 50;
          this.tag('ProgressBar').style = { foregroundColor: 0xff5b16e5 };
        }, 3000);
      }
      ```
4. Navigate to the ProgressBar story in the browser and open the console. Observe that after 3 seconds, the progress bar value (progress) is changed along with the progress bar color (progressColor) and there are warnings in the console for both the "value" and "foregroundColor" properties, like below:
    <img width="506" alt="Screen Shot 2023-07-07 at 4 03 34 PM" src="https://github.com/rdkcentral/Lightning-UI-Components/assets/15019089/c5d5920a-20e6-4167-8d5e-438185a68904">

5. If able to test in a TS file, you will notice that setting the deprecated properties will display a strikethrough and warning on hover:
    <img width="719" alt="Screen Shot 2023-07-07 at 2 46 16 PM" src="https://github.com/rdkcentral/Lightning-UI-Components/assets/15019089/20c85077-0f72-49cc-8dbd-c1ccbaf1f44e">


## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
