### PR TITLE
fix(Tile): pass Tile's mode to nested components

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
@@ -182,6 +182,7 @@ export default class Tile extends Surface {
     // but that if src is undefined in both the setter and artwork object,
     // we don't incorrectly pass "src: undefined" to the Artwork component)
     this._Artwork.patch({
+      mode: this.mode,
       h: this._h,
       w: this._w,
       x: this._w / 2,
@@ -220,6 +221,7 @@ export default class Tile extends Surface {
 
     const badgePatch = {
       ...this.badge,
+      mode: this.mode,
       x: this.style.paddingX,
       y: this.style.paddingY,
       alpha: this.persistentMetadata ? 1 : 0.001
@@ -257,6 +259,7 @@ export default class Tile extends Surface {
     }
     const labelPatch = {
       ...this.label,
+      mode: this.mode,
       x: this._w - this.style.paddingX,
       y: this.style.paddingY,
       alpha: this.persistentMetadata ? 1 : 0.001
@@ -332,6 +335,7 @@ export default class Tile extends Surface {
 
     const checkboxPatch = {
       ...this.checkbox,
+      mode: this.mode,
       x: this._w - this.style.paddingX,
       y: this._h - this.style.paddingY
     };
@@ -392,6 +396,7 @@ export default class Tile extends Surface {
     if (this.progressBar.progress > 0) {
       const progressPatch = {
         ...this.progressBar,
+        mode: this.mode,
         w: this._w - this.style.paddingX * 2,
         x: this._w / 2,
         y: this._h - this.style.paddingYProgress
@@ -497,6 +502,7 @@ export default class Tile extends Surface {
 
   get _metadataPatch() {
     return {
+      mode: this.mode,
       alpha: this._metadataAlpha,
       mountX: 0.5,
       mountY: this._isInsetMetadata ? 1 : 0,


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
This passes the mode from the Tile into nested components like Metadata and ProgressBar. This is needed in order to change things like the Metadata font styles on focus and unfocus (requirement for Sky theme)

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
