### PR TITLE
docs: update Row and Column docs

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Column/Column.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.mdx
@@ -140,7 +140,7 @@ The `Column` component will utilize the following properties on each individual 
 
 ### Methods
 
-The Column component inherits few methods from its parent component, NavigationManager, which in turn extends the focusManager component. These shared methods are already documented in the focusManager component. For a detailed description of these methods, please refer to the methods section in the focusManager component documentation.
+The Column component inherits few methods from its parent component, NavigationManager, which in turn extends the focusManager component. These shared methods are already documented in the focusManager component. For a detailed description of these methods, please refer to the methods section in the [FocusManager component](?path=/docs/navigation-focusmanager--focusmanager)
 
 #### onScreenEffect(): void
 

--- a/packages/@lightningjs/ui-components/src/components/Column/Column.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.mdx
@@ -122,7 +122,7 @@ If both of those properties are enabled, `alwaysScroll` will take precedence ove
 
 ### Style Properties
 
-The Column component shares a few of the same style properties as the ones listed in NavigationManager. For a detailed description, please refer to style properties section in the [NavigationManager component](?path=/docs/navigation-navigationmanager--navigationmanager)
+The Column component shares a few of the same style properties as the ones listed in NavigationManager. For a detailed description, please refer to style properties section in the [NavigationManager component](?path=/docs/navigation-navigationmanager--row)
 
 scrollIndex: number
 itemSpacing: number

--- a/packages/@lightningjs/ui-components/src/components/Column/Column.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.mdx
@@ -122,7 +122,7 @@ If both of those properties are enabled, `alwaysScroll` will take precedence ove
 
 ### Style Properties
 
-The Column component shares few same style properties as the one's listed in NavigationManager. For a detailed description, please refer to style properties section in the [NavigationManager component](?path=/docs/navigation-navigationmanager--navigationmanager)
+The Column component shares a few of the same style properties as the ones listed in NavigationManager. For a detailed description, please refer to style properties section in the [NavigationManager component](?path=/docs/navigation-navigationmanager--navigationmanager)
 
 scrollIndex: number
 itemSpacing: number
@@ -140,42 +140,11 @@ The `Column` component will utilize the following properties on each individual 
 
 ### Methods
 
+The Column component inherits few methods from its parent component, NavigationManager, which in turn extends the focusManager component. These shared methods are already documented in the focusManager component. For a detailed description of these methods, please refer to the methods section in the focusManager component documentation.
+
 #### onScreenEffect(): void
 
 A callback that can be overridden to do something with the items that are currently on screen. This will be called on every new render.
-
-#### appendItems(items: lng.Component[]): void
-
-Adds items to the end of the child list
-
-#### appendItemsAt(items: lng.Component[], index: number): void
-
-Adds items at a specified index of the child list
-
-#### prependItems(items: lng.Component[]): void
-
-Adds items to the start of the child list
-
-#### removeItemAt(index: number): void
-
-Removes an item (by index) from the row
-
-##### Arguments
-
-| name  | type                                                    | required | default | description             |
-| ----- | ------------------------------------------------------- | -------- | ------- | ----------------------- |
-| items | <DocsLink id="lng.Component">lng.Component[]</DocsLink> | false    | []      | list of items to append |
-
-#### render(selected: lng.Component, previous: lng.Component): void
-
-Called when item focus changes. Render is responsible for the scroll behavior
-
-##### Arguments
-
-| name     | type                                                    | required | default | description                                                          |
-| -------- | ------------------------------------------------------- | -------- | ------- | -------------------------------------------------------------------- |
-| selected | <DocsLink id="lng.Component">lng.Component[]</DocsLink> | false    | -       | The items to be selected. Required only if this.plinko is true.      |
-| previous | <DocsLink id="lng.Component">lng.Component[]</DocsLink> | false    | -       | The previously selected items. Required only if this.plinko is true. |
 
 ### Events
 

--- a/packages/@lightningjs/ui-components/src/components/Column/Column.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.mdx
@@ -140,7 +140,7 @@ The `Column` component will utilize the following properties on each individual 
 
 ### Methods
 
-The Column component inherits few methods from its parent component, NavigationManager, which in turn extends the focusManager component. These shared methods are already documented in the focusManager component. For a detailed description of these methods, please refer to the methods section in the [FocusManager component](?path=/docs/navigation-focusmanager--focusmanager)
+The Column component is a subclass of NavigationManager and FocusManager, so inherits all methods from those parent components. These shared methods are already documented in the NavigationManager and FocusManager documentation. For detailed descriptions of these methods, please refer to the methods section in the [NavigationManager](/?path=/docs/navigation-navigationmanager--row) and [FocusManager](/docs/navigation-focusmanager--column-with-rows) documentation.
 
 #### onScreenEffect(): void
 

--- a/packages/@lightningjs/ui-components/src/components/Column/Column.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.mdx
@@ -144,6 +144,10 @@ The `Column` component will utilize the following properties on each individual 
 
 A callback that can be overridden to do something with the items that are currently on screen. This will be called on every new render.
 
+#### appendItems(items: lng.Component[]): void
+
+Adds items to the end of the child list
+
 #### appendItemsAt(items: lng.Component[], index: number): void
 
 Adds items at a specified index of the child list

--- a/packages/@lightningjs/ui-components/src/components/Column/Column.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.mdx
@@ -122,11 +122,11 @@ If both of those properties are enabled, `alwaysScroll` will take precedence ove
 
 ### Style Properties
 
-| name           | type                             | description                            |
-| -------------- | -------------------------------- | -------------------------------------- |
-| itemSpacing    | number                           | spacing between items                  |
-| scrollIndex    | number                           | index of currently selected item       |
-| itemTransition | <DocsLink id="lng.Transition" /> | transition to apply to items on render |
+The Column component shares few same style properties as the one's listed in NavigationManager. For a detailed description, please refer to style properties section in the [NavigationManager component](?path=/docs/navigation-navigationmanager--navigationmanager)
+
+scrollIndex: number
+itemSpacing: number
+itemTransition: <DocsLink id="lng.Transition" />
 
 ### Child Item Properties
 
@@ -143,10 +143,6 @@ The `Column` component will utilize the following properties on each individual 
 #### onScreenEffect(): void
 
 A callback that can be overridden to do something with the items that are currently on screen. This will be called on every new render.
-
-#### appendItems(items: lng.Component[]): void
-
-Adds items to the end of the child list
 
 #### appendItemsAt(items: lng.Component[], index: number): void
 

--- a/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.mdx
+++ b/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.mdx
@@ -151,7 +151,7 @@ Returns the transition value for the x coordinate of the FocusManager's items.
 
 Returns the transition value for the y coordinate of the FocusManager's items.
 
-#### \_render(): void
+#### _render(): void
 
 A no-op function that is called when `selectedIndex` is set. Can be overridden by classes that extend `FocusManager` for custom render behavior.
 

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.mdx
@@ -76,7 +76,7 @@ If multiple of these properties are enabled, the order of precedence from highes
 
 ### Style Properties
 
-The Row component shares the same style properties as the one's listed in NavigationManager.. For a detailed description, please refer to style properties section in the [NavigationManager component](?path=/docs/navigation-navigationmanager--navigationmanager)
+The Row component shares the same style properties as the ones listed in NavigationManager. For a detailed description, please refer to style properties section in the [NavigationManager component](?path=/docs/navigation-navigationmanager--navigationmanager)
 
 ### Child Item Properties
 
@@ -89,32 +89,9 @@ The `Row` component will utilize the following properties on each individual ele
 
 ### Methods
 
+The Column component inherits few methods from its parent component, NavigationManager, which in turn extends the focusManager component. These shared methods are already documented in the focusManager component. For a detailed description of these methods, please refer to the methods section in the [FocusManager component](?path=/docs/navigation-focusmanager--focusmanager)
+
 #### onScreenEffect(onScreenItems: lng.Component[]): void
 
 A callback that can be overridden to do something with the items that are currently on screen. This will be called on every new render.
 
-#### appendItems(items: lng.Component[]): void
-
-Adds items to the end of the child list
-
-#### appendItemsAt(items: lng.Component[], index: number): void
-
-Adds items at a specified index of the child list
-
-#### prependItems(items: lng.Component[]): void
-
-Adds items to the start of the child list
-
-#### removeItemAt(index: number): void
-
-Removes an item (by index) from the row
-
-##### Arguments
-
-| name  | type                                                    | required | default | description             |
-| ----- | ------------------------------------------------------- | -------- | ------- | ----------------------- |
-| items | <DocsLink id="lng.Component">lng.Component[]</DocsLink> | false    | []      | list of items to append |
-
-#### render(): void
-
-Called when item focus changes. Render is responsible for the scroll behavior

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.mdx
@@ -76,7 +76,7 @@ If multiple of these properties are enabled, the order of precedence from highes
 
 ### Style Properties
 
-The Row component shares the same style properties as the ones listed in NavigationManager. For a detailed description, please refer to style properties section in the [NavigationManager component](?path=/docs/navigation-navigationmanager--navigationmanager)
+The Row component shares the same style properties as the ones listed in NavigationManager. For a detailed description, please refer to style properties section in the [NavigationManager component](?path=/docs/navigation-navigationmanager--row)
 
 ### Child Item Properties
 

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.mdx
@@ -76,13 +76,7 @@ If multiple of these properties are enabled, the order of precedence from highes
 
 ### Style Properties
 
-| name           | type                             | description                                                                                                                         |
-| -------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| alwaysScroll   | boolean                          | when true, the row will stop scrolling as it nears the right edge to prevent white space                                            |
-| neverScroll    | boolean                          | when true, the row will never scroll, unless alwaysScroll is set to true, and if false, the row will apply normal scrolling logic', |
-| scrollIndex    | number                           | index of currently selected item                                                                                                    |
-| itemSpacing    | number                           | spacing between items                                                                                                               |
-| itemTransition | <DocsLink id="lng.Transition" /> | transition to apply to items on render                                                                                              |
+The Row component shares the same style properties as the NavigationManager component. For a detailed description, please refer to style properties section in the [NavigationManager component](?path=/docs/navigation-navigationmanager--navigationmanager)
 
 ### Child Item Properties
 

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.mdx
@@ -76,7 +76,7 @@ If multiple of these properties are enabled, the order of precedence from highes
 
 ### Style Properties
 
-The Row component shares the same style properties as the NavigationManager component. For a detailed description, please refer to style properties section in the [NavigationManager component](?path=/docs/navigation-navigationmanager--navigationmanager)
+The Row component shares the same style properties as the one's listed in NavigationManager.. For a detailed description, please refer to style properties section in the [NavigationManager component](?path=/docs/navigation-navigationmanager--navigationmanager)
 
 ### Child Item Properties
 

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.mdx
@@ -89,7 +89,7 @@ The `Row` component will utilize the following properties on each individual ele
 
 ### Methods
 
-The Column component inherits few methods from its parent component, NavigationManager, which in turn extends the focusManager component. These shared methods are already documented in the focusManager component. For a detailed description of these methods, please refer to the methods section in the [FocusManager component](?path=/docs/navigation-focusmanager--focusmanager)
+The Row component inherits few methods from its parent component, NavigationManager, which in turn extends the focusManager component. These shared methods are already documented in the focusManager component. For a detailed description of these methods, please refer to the methods section in the [FocusManager component](?path=/docs/navigation-focusmanager--focusmanager)
 
 #### onScreenEffect(onScreenItems: lng.Component[]): void
 

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.mdx
@@ -89,7 +89,7 @@ The `Row` component will utilize the following properties on each individual ele
 
 ### Methods
 
-The Row component inherits few methods from its parent component, NavigationManager, which in turn extends the focusManager component. These shared methods are already documented in the focusManager component. For a detailed description of these methods, please refer to the methods section in the [FocusManager component](?path=/docs/navigation-focusmanager--focusmanager)
+The Row component is a subclass of NavigationManager and FocusManager, so inherits all methods from those parent components. These shared methods are already documented in the NavigationManager and FocusManager documentation. For detailed descriptions of these methods, please refer to the methods section in the [NavigationManager](/?path=/docs/navigation-navigationmanager--row) and [FocusManager](/docs/navigation-focusmanager--column-with-rows) documentation.
 
 #### onScreenEffect(onScreenItems: lng.Component[]): void
 


### PR DESCRIPTION
## Description

Removed the style properties from the Column and Row docs and instead referred to the properties in the NavigationManager component as they have the same style properties

## References

LUI-867
