### PR TITLE
feat(TestUtils): include TypeScript definitions in package

### DIFF
--- a/packages/@lightningjs/ui-components-test-utils/package.json
+++ b/packages/@lightningjs/ui-components-test-utils/package.json
@@ -8,7 +8,14 @@
   },
   "homepage": "https://rdkcentral.github.io/Lightning-UI-Components/",
   "type": "module",
-  "exports": "./index.js",
+  "exports": {
+    ".": {
+      "import": "./index.js",
+      "types": "./index.d.ts"
+    }
+  },
+  "main": "./index.js",
+  "types": "./index.d.ts",
   "files": [
     "index.js",
     "src/**"


### PR DESCRIPTION
## Description
This adds the TypeScript definition files for TestRenderer and TestUtils to be included in the published `@lightningjs/ui-components-test-utils` package.

This does **not** include minifying the JS code in the package nor any generated CommonJS files for the package. There were a lot of issues between Jest and Rollup when attempting to do that, so will be a separate future effort.
<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References
LUI-926
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
I'm not aware of a way to test these changes other than publishing and seeing if the d.ts files were included or not.
<!-- step by step instructions to review this PR's changes -->

## Automation
n/a
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax

