### PR TITLE
fix(InlineContent): default InlineContent alignment should be flex-start

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.test.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.test.js
@@ -156,7 +156,7 @@ describe('InlineContent', () => {
   });
 
   it('should update flexbox justification', () => {
-    const justify = 'flex-start';
+    const justify = 'flex-end';
     inlineContent.justify = justify;
     expect(inlineContent.justify).toBe(justify);
   });

--- a/packages/@lightningjs/ui-components/src/components/Marquee/Marquee.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Marquee/Marquee.stories.js
@@ -120,7 +120,6 @@ export const CenteredText = () =>
           type: InlineContent,
           x: 200,
           alpha: 0.001,
-          justify: 'flex-start',
           content: [
             'Centered',
             {

--- a/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.js
@@ -188,8 +188,7 @@ class MetadataBase extends Base {
   _updateSubtitle() {
     this._Subtitle.patch({
       content: this.subtitle,
-      style: { textStyle: this.style.subtitleTextStyle },
-      justify: 'flex-start'
+      style: { textStyle: this.style.subtitleTextStyle }
     });
     if (this._Subtitle.finalW > this._textW()) {
       this._SubtitleWrapper.patch({

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
@@ -156,6 +156,11 @@ export default class TextBox extends Base {
     if (this._textStyleSet.maxLinesSuffix) {
       inlineContentPatch.maxLinesSuffix = this._textStyleSet.maxLinesSuffix;
     }
+    if (this._textStyleSet.textAlign) {
+      inlineContentPatch.justify = utils.convertTextAlignToFlexJustify(
+        this._textStyleSet.textAlign
+      );
+    }
 
     this.patch({
       alpha: 1,

--- a/packages/@lightningjs/ui-components/src/utils/index.js
+++ b/packages/@lightningjs/ui-components/src/utils/index.js
@@ -802,6 +802,30 @@ export function watchForUpdates({
   return element;
 }
 
+/**
+ * Given a Lightning text alignment option (left, right, center),
+ * return the Lightning flexbox equivalent.
+ *
+ * @param {string} align
+ * @returns {string}
+ */
+export function convertTextAlignToFlexJustify(align) {
+  switch (align) {
+    case 'left':
+      return 'flex-start';
+    case 'center':
+      return 'center';
+    case 'right':
+      return 'flex-end';
+    default:
+      // if there is no alignment passed in, the Lightning Text default is "left"
+      console.warn(
+        `Expected "textAlign" values are "left," "center," and "right," but instead, ${align} was received and will fall back to "left."`
+      );
+      return 'flex-start';
+  }
+}
+
 const utils = {
   isMarkupString,
   capitalizeFirstLetter,
@@ -828,7 +852,8 @@ const utils = {
   getDimensions,
   getWidthByColumnSpan,
   createConditionalZContext,
-  watchForUpdates
+  watchForUpdates,
+  convertTextAlignToFlexJustify
 };
 
 export default utils;


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Updating the default flexbox alignment of the InlineContent component to be "flex-start" instead of "center" in order to better match how Lightning Text's default `textAlign` property works (default to left). Then in the TextBox component, I added a function from `utils` called `convertTextAlignToFlexJustify` that maps the left, center, and right text alignment to flex-start, center, and flex-end. I also removed the hard-coded "flex-start" assignments in Marquee and MetadataBase since they should no longer be needed and now can be overwritten as needed by the user via styles.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
Check TextBox, InlineContent, MetadataBase, MetadataCardContent, and Marquee to confirm everything is still working as expected.

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
