### PR TITLE
docs(Gradient): switched description for gradientColor and gradientTop

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Gradient/Gradient.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Gradient/Gradient.mdx
@@ -57,6 +57,6 @@ class Example extends lng.Component {
 
 | name          | type   | description                             |
 | ------------- | ------ | --------------------------------------- |
-| gradientColor | number | default starting color for the gradient |
-| gradientTop   | number | default color the gradient fades to     |
+| gradientColor | number | default color the gradient fades to     |
+| gradientTop   | number | default starting color for the gradient |
 | radius        | number | default gradient corner radius          |


### PR DESCRIPTION
## Description

Switch of 'gradientColor' and 'gradientTop' descriptions within the styles table of the docs

## References

LUI- 913

## Testing

Go to the Gradient component of storybook, migrate to the docs, scroll to see the style table containing 'gradientColor' and 'gradientTop'


## Automation

None

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
