### PR TITLE
chore: move all exports to the same line in d.ts template

### DIFF
--- a/bin/templates/typescript-definitions.template.js
+++ b/bin/templates/typescript-definitions.template.js
@@ -37,9 +37,9 @@ module.exports = name => {
 
 import lng from '@lightningjs/core';
 import Base from '../Base/Base'; // TODO: remove this comment or replace import with appropriate parent component import
-import type { StylePartial } from '../../types/lui';
+import { StylePartial } from '../../types/lui';
 
-export type ${name}Style = {};
+type ${name}Style = {};
 
 declare namespace ${name} {
   export interface TemplateSpec extends Base.TemplateSpec {
@@ -62,5 +62,5 @@ declare class ${name}<
   // Tags
 }
 
-export default ${name};
+export { ${name} as default, ${name}Style };
 `}


### PR DESCRIPTION
## Description

Updates our d.ts template to export all declared types from the same line

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
