### PR TITLE
fix(InlineContent): removes stage.update call from component

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
@@ -138,7 +138,6 @@ export default class InlineContent extends Base {
     // TODO: FIX --figure out an alternative to using setTimeout
     // perhaps have to wait until Lightning Flexboxes can emit a signal (like textures) when they've finished loading
     if (this.children.length) {
-      this.stage.update();
       setTimeout(() => {
         this.multiLineHeight = this.finalH;
         if (

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -300,7 +300,6 @@ export default class NavigationManager extends FocusManager {
 
   _appendLazyItem(item) {
     this._appendItem(item);
-    this.stage.update();
     this.queueRequestUpdate();
     this._refocus();
   }


### PR DESCRIPTION
## Description

This PR removes stage.update() call in InlineContent and Navigation Manager

## References

LUI-848

## Testing

- clone branch
- start Storybook
- check InlineContent and Navigation Manager work as expected
- run jest tests, all tests should pass

## Automation

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
