### PR TITLE
docs(Card):  Scrub Card

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Card/Card.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Card/Card.d.ts
@@ -22,9 +22,7 @@ import { TextBoxStyle } from '../TextBox';
 import type { Color, StylePartial } from '../../types/lui';
 
 export type CardStyle = SurfaceStyle & {
-  backgroundColorDisabled: Color;
-  backgroundColorFocused: Color;
-  backgroundColorUnfocused: Color;
+  backgroundColor: Color;
   paddingHorizontal: number;
   paddingVertical: number;
   radius: lng.Tools.CornerRadius;

--- a/packages/@lightningjs/ui-components/src/components/Card/Card.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Card/Card.d.ts
@@ -20,6 +20,7 @@ import type lng from '@lightningjs/core';
 import Surface, { SurfaceStyle } from '../Surface';
 import { TextBoxStyle } from '../TextBox';
 import type { Color, StylePartial } from '../../types/lui';
+import type { TextContent } from '../InlineContent/InlineContent';
 
 export type CardStyle = SurfaceStyle & {
   backgroundColor: Color;
@@ -30,7 +31,7 @@ export type CardStyle = SurfaceStyle & {
 };
 
 export default class Card extends Surface {
-  title?: string;
+  title?: string | TextContent[];
   get style(): CardStyle;
   set style(v: StylePartial<CardStyle>);
 

--- a/packages/@lightningjs/ui-components/src/components/Card/Card.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Card/Card.mdx
@@ -62,9 +62,7 @@ class Basic extends lng.Component {
 
 | name                     | type             | description                                                                  |
 | ------------------------ | ---------------- | ---------------------------------------------------------------------------- |
-| backgroundColorDisabled  | string           | color of the card when disabled                                              |
-| backgroundColorFocused   | string           | color of the card when not disabled and when focused                         |
-| backgroundColorUnfocused | string           | color of the card when unfocused and not disabled                            |
+| backgroundColor          | string           | color of the card                                                            |
 | paddingHorizontal        | number           | padding on the x-axis between the right and left of the card and its content |
 | paddingVertical          | number           | padding on the y-axis between the top and bottom of the card and its content |
 | radius                   | number \| array  | corner radius of card                                                        |

--- a/packages/@lightningjs/ui-components/src/components/Card/Card.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Card/Card.mdx
@@ -54,9 +54,9 @@ class Basic extends lng.Component {
 
 ### Properties
 
-| name  | type   | required | default   | description             |
-| ----- | ------ | -------- | --------- | ----------------------- |
-| title | string | false    | undefined | headline of the content |
+| name  | type             | required | default   | description             |
+| ----- | ---------------- | -------- | --------- | ----------------------- |
+| title | string \| object | false    | undefined | headline of the content |
 
 ### Style Properties
 

--- a/packages/@lightningjs/ui-components/src/components/Card/CardRadio.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Card/CardRadio.mdx
@@ -58,10 +58,10 @@ class Basic extends lng.Component {
 
 ### Properties
 
-| name     | type   | required | default   | description                                                                                              |
-| -------- | ------ | -------- | --------- | -------------------------------------------------------------------------------------------------------- |
-| radio    | object | false    | undefined | Object containing all properties supported in the [Radio component](?path=/docs/components-radio--radio) |
-| subtitle | string | false    | undefined | The text to be displayed in the subtitle section of the card.                                            |
+| name     | type             | required | default   | description                                                                                              |
+| -------- | ---------------- | -------- | --------- | -------------------------------------------------------------------------------------------------------- |
+| radio    | object           | false    | undefined | Object containing all properties supported in the [Radio component](?path=/docs/components-radio--radio) |
+| subtitle | string \| object | false    | undefined | The text to be displayed in the subtitle section of the card.                                            |
 
 ### Style Properties
 

--- a/packages/@lightningjs/ui-components/src/components/Card/CardSection.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Card/CardSection.d.ts
@@ -19,10 +19,12 @@
 import lng from '@lightningjs/core';
 import Card, { CardStyle } from './Card';
 import type { StylePartial } from '../../types/lui';
+import { TextBoxStyle } from '../TextBox';
 
 export type CardSectionStyle = CardStyle & {
   iconHeight: number;
   iconWidth: number;
+  titleTextStyle: TextBoxStyle;
 };
 
 export default class CardSection extends Card {

--- a/packages/@lightningjs/ui-components/src/components/Card/CardTitle.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Card/CardTitle.d.ts
@@ -19,14 +19,17 @@
 import lng from '@lightningjs/core';
 import Card, { CardStyle } from './Card';
 import { TextBoxStyle } from '../TextBox';
+import type { TextContent } from '../InlineContent/InlineContent';
 import type { StylePartial } from '../../types/lui';
 
 export type CardTitleStyle = CardStyle & {
-  descriptionTextStyle: TextBoxStyle;
+  descriptionTextProperties: TextBoxStyle;
+  detailsTextProperties: TextBoxStyle;
 };
 
 export default class CardTitle extends Card {
-  description?: string;
+  description?: string | TextContent[];
+  details?: string | TextContent[];
   get style(): CardTitleStyle;
   set style(v: StylePartial<CardTitleStyle>);
 

--- a/packages/@lightningjs/ui-components/src/components/Card/CardTitle.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Card/CardTitle.mdx
@@ -57,10 +57,10 @@ class Basic extends lng.Component {
 
 ### Properties
 
-| name        | type   | required | default   | description |
-| ----------- | ------ | -------- | --------- | ----------- |
-| description | string | false    | undefined | description |
-| details     | string | false    | undefined | details     |
+| name        | type             | required | default   | description |
+| ----------- | ---------------- | -------- | --------- | ----------- |
+| description | string \| object | false    | undefined | description |
+| details     | string \| object | false    | undefined | details     |
 
 ### Style Properties
 


### PR DESCRIPTION
## Description

Scrub Card TS files and .mdx files. Changes the backgroundColorDisabled, backgroundColorFocused, and backgroundColorUnfocused to just backgroundColor where necessary. Updates 'string' to 'string | TextContent []' for titles and descriptions. Makes style properties consistent in both the TS and .mdx.

## References

LUI-890

## Testing

Parse through the Card docs to see the removal of the backgroundColor variants, the single remaining backgroundColor, and the addition of the TextContent array type for specific fields. Can also check the Card Style in TS and .mdx files to see consistency.

## Automation

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
