### PR TITLE
fix(CardContent): change cardContent doc backgroundColor

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.mdx
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.mdx
@@ -66,9 +66,7 @@ class Basic extends lng.Component {
 
 | name                     | type             | description                                                                    |
 | ------------------------ | ---------------- | ------------------------------------------------------------------------------ |
-| backgroundColorDisabled  | string           | color of the card when disabled                                                |
-| backgroundColorFocused   | string           | color of the card when not disabled and when focused                           |
-| backgroundColorUnfocused | string           | color of the card when unfocused and not disabled                              |
+| backgroundColor          | string           | color of the card                                                              |
 | expandedW                | number           | the desired width of the card when in the fully expanded (not collapsed) mode  |
 | expandedH                | number           | the desired height of the card when in the fully expanded (not collapsed) mode |
 | imageSize                | {w, h}           | the desired width and height the image in the card                             |


### PR DESCRIPTION
## Description

change cardContent doc to reflect having only backgroundColor style property without other variants as in Card Component. Removal of backgroundColorDisabled, backgroundColorFocused, and backgroundColorUnfocused.

## References

LUI-891

## Testing

Go to CardComponent Documentation and view backgroundColor under the Style Properties

## Automation

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
