### PR TITLE
fix(FocusManager): add SignalMap to TypeConfig, update child components

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Column/Column.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.d.ts
@@ -17,6 +17,7 @@
  */
 
 import lng from '@lightningjs/core';
+import FocusManager from '../FocusManager/FocusManager';
 import NavigationManager from '../NavigationManager';
 
 declare namespace Column {
@@ -30,8 +31,9 @@ declare namespace Column {
 }
 
 declare class Column<
-  TemplateSpec extends Column.TemplateSpec = Column.TemplateSpec
-> extends NavigationManager<TemplateSpec> {
+  TemplateSpec extends Column.TemplateSpec = Column.TemplateSpec,
+  TypeConfig extends FocusManager.TypeConfig = FocusManager.TypeConfig
+> extends NavigationManager<TemplateSpec, TypeConfig> {
   // Properties
   /**
    * When navigation between multiple Columns,

--- a/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.d.ts
@@ -20,9 +20,11 @@ import lng from '@lightningjs/core';
 import Base from '../Base';
 
 export type NavigationDirectionType = 'none' | 'column' | 'row';
+
 export type FocusItemsType = Array<
   lng.Component.NewPatchTemplate<lng.Component.Constructor> | lng.Component
 >;
+
 declare namespace FocusManager {
   export interface TemplateSpec extends Base.TemplateSpec {
     /**
@@ -40,6 +42,7 @@ declare namespace FocusManager {
 
     /**
      * index of currently selected item
+     * updating value emits the `selectedChange` signal
      */
     selectedIndex?: number;
 
@@ -58,11 +61,23 @@ declare namespace FocusManager {
      */
     itemPosY?: number;
   }
+  export interface TypeConfig extends lng.Component.TypeConfig {
+    SignalMapType: SignalMap;
+  }
+
+  export type SignalMap = {
+    /**
+     * emitted whenever the currently selected item changes
+     * @param selected the currently selected component
+     * @param prevSelected the previous selected component
+     */
+    selectedChange(selected: lng.Component, prevSelected: lng.Component): void;
+  };
 }
 
 declare class FocusManager<
   TemplateSpec extends FocusManager.TemplateSpec = FocusManager.TemplateSpec,
-  TypeConfig extends lng.Component.TypeConfig = lng.Component.TypeConfig
+  TypeConfig extends FocusManager.TypeConfig = FocusManager.TypeConfig
 > extends Base<TemplateSpec, TypeConfig> {
   // Properties
 
@@ -78,6 +93,7 @@ declare class FocusManager<
 
   /**
    * index of currently selected item
+   * updating value emits the `selectedChange` signal
    */
   selectedIndex: number;
 
@@ -158,14 +174,16 @@ declare class FocusManager<
   _render(): void;
 
   /**
-   * Selects previous item. If this.wrapSelected=true, will select the last element in the list if focus is currently on the first item.
-   */
-  selectPrevious(): void;
-
-  /**
    * Selects next item. If this.wrapSelected=true, will select the first element in the list if focus is currently on the last item.
+   * emits the `selectedChange` signal
    */
   selectNext(): void;
+
+  /**
+   * Selects previous item. If this.wrapSelected=true, will select the last element in the list if focus is currently on the first item.
+   * emits the `selectedChange` signal
+   */
+  selectPrevious(): void;
 
   // tags
   get _Items(): lng.Component;

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
@@ -85,8 +85,9 @@ declare namespace NavigationManager {
 }
 
 declare class NavigationManager<
-  TemplateSpec extends NavigationManager.TemplateSpec = NavigationManager.TemplateSpec
-> extends FocusManager<TemplateSpec> {
+  TemplateSpec extends NavigationManager.TemplateSpec = NavigationManager.TemplateSpec,
+  TypeConfig extends FocusManager.TypeConfig = FocusManager.TypeConfig
+> extends FocusManager<TemplateSpec, TypeConfig> {
   // Properties
   /**
    * Determines whether the component will stop scrolling as it nears the end to prevent white space.

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.d.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import FocusManager from '../FocusManager';
 import NavigationManager from '../NavigationManager';
 
 declare namespace Row {
@@ -42,8 +43,9 @@ declare namespace Row {
 }
 
 declare class Row<
-  TemplateSpec extends Row.TemplateSpec = Row.TemplateSpec
-> extends NavigationManager<TemplateSpec> {
+  TemplateSpec extends Row.TemplateSpec = Row.TemplateSpec,
+  TypeConfig extends FocusManager.TypeConfig = FocusManager.TypeConfig
+> extends NavigationManager<TemplateSpec, TypeConfig> {
   // Properties
   /**
    * If true, will only scroll the row if the item is off screen and `alwaysScroll` and `neverScroll` are both false.


### PR DESCRIPTION
## Description

This PR updates the FocusManager interfaces to include a SignalMap that defines the `selectedChange` signal that's emitted when the value of the `selectedItem` property changes. It also updates the child components(NavigationManager, Column, Row) to extend the FocusManager TypeConfig instead of lng.Component.TypeConfig

## Testing

n/a

## Automation

n/a

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
