### PR TITLE
feat(TextBox): add support for Marquee properties in TextBox

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
@@ -61,7 +61,13 @@ export default class TextBox extends Base {
   }
 
   static get properties() {
-    return ['content', 'fixed', 'marquee', ...InlineContent.properties];
+    return [
+      'content',
+      'fixed',
+      'marquee',
+      ...InlineContent.properties,
+      'marqueProps'
+    ];
   }
 
   _setDimensions(w, h) {
@@ -156,11 +162,6 @@ export default class TextBox extends Base {
     if (this._textStyleSet.maxLinesSuffix) {
       inlineContentPatch.maxLinesSuffix = this._textStyleSet.maxLinesSuffix;
     }
-    if (this._textStyleSet.textAlign) {
-      inlineContentPatch.justify = utils.convertTextAlignToFlexJustify(
-        this._textStyleSet.textAlign
-      );
-    }
 
     this.patch({
       alpha: 1,
@@ -233,6 +234,7 @@ export default class TextBox extends Base {
         h: this.h,
         y: this.style.offsetY,
         x: this.style.offsetX,
+        ...this._marqueProps,
         signals: {
           marqueeContentLoaded: '_loadedMarqueeContent'
         }
@@ -269,6 +271,10 @@ export default class TextBox extends Base {
         this._toggleMarquee(contentTag);
       }
     }
+  }
+
+  get _marqueeProps() {
+    return this.marquePorps ?? {};
   }
 
   get _textStyleSet() {

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
@@ -277,10 +277,6 @@ export default class TextBox extends Base {
     return this._marqueeProps ?? {};
   }
 
-  _setMarqueeProps(props) {
-    this._marqueeProps = props;
-  }
-
   get _textStyleSet() {
     const fontStyle = {
       ...this.theme.typography.body1,

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
@@ -62,10 +62,10 @@ export default class TextBox extends Base {
 
   static get properties() {
     return [
+      ...InlineContent.properties,
       'content',
       'fixed',
       'marquee',
-      ...InlineContent.properties,
       'marqueeProps'
     ];
   }
@@ -230,11 +230,11 @@ export default class TextBox extends Base {
     if (this.marquee) {
       this._resetMarqueePromise();
       const marqueePatch = {
+        ...this.marqueeProps,
         w: this._textStyleSet.wordWrapWidth || this.w,
         h: this.h,
         y: this.style.offsetY,
         x: this.style.offsetX,
-        ...this.marqueeProps,
         signals: {
           marqueeContentLoaded: '_loadedMarqueeContent'
         }
@@ -273,11 +273,11 @@ export default class TextBox extends Base {
     }
   }
 
-  get marqueeProps() {
+  _getMarqueeProps() {
     return this._marqueeProps ?? {};
   }
 
-  set marqueeProps(props) {
+  _setMarqueeProps(props) {
     this._marqueeProps = props;
   }
 

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
@@ -66,7 +66,7 @@ export default class TextBox extends Base {
       'fixed',
       'marquee',
       ...InlineContent.properties,
-      'marqueProps'
+      'marqueeProps'
     ];
   }
 
@@ -234,7 +234,7 @@ export default class TextBox extends Base {
         h: this.h,
         y: this.style.offsetY,
         x: this.style.offsetX,
-        ...this._marqueProps,
+        ...this.marqueeProps,
         signals: {
           marqueeContentLoaded: '_loadedMarqueeContent'
         }
@@ -273,8 +273,12 @@ export default class TextBox extends Base {
     }
   }
 
-  get _marqueeProps() {
-    return this.marquePorps ?? {};
+  get marqueeProps() {
+    return this._marqueeProps ?? {};
+  }
+
+  set marqueeProps(props) {
+    this._marqueeProps = props;
   }
 
   get _textStyleSet() {


### PR DESCRIPTION
## Description

This PR adds support for the Marquee component in the TextBox. Now, when the 'marquee' prop is set in the TextBox, it will render the Marquee component with properties to control its behavior, such as 'repeat'.

## References

LUI-814

## Testing

1. Navigate to any component that uses the TextBox type.
2. Try adding the following properties to the TextBox:
```
type: TextBox,
marquee: true,
marqueeProps: {
repeat: 2
},
```
3. Verify that the TextBox content correctly scrolls based on the specified repeat time.

## Automation


## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
