### PR TITLE
fix(TestUtils): provide require export for Jest

### DIFF
--- a/packages/@lightningjs/ui-components-test-utils/index.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/index.d.ts
@@ -18,4 +18,4 @@
 
 export * from './src/lightning-test-renderer';
 export * from './src/lightning-test-utils';
-export * from './src/lng-test-env';
+export * as LightningTestEnvironment from './src/lng-test-env';

--- a/packages/@lightningjs/ui-components-test-utils/index.js
+++ b/packages/@lightningjs/ui-components-test-utils/index.js
@@ -18,4 +18,4 @@
 
 export * from './src/lightning-test-renderer';
 export * from './src/lightning-test-utils';
-export * from './src/lng-test-env';
+export * as LightningTestEnvironment from './src/lng-test-env';

--- a/packages/@lightningjs/ui-components-test-utils/package.json
+++ b/packages/@lightningjs/ui-components-test-utils/package.json
@@ -11,6 +11,7 @@
   "exports": {
     ".": {
       "import": "./index.js",
+      "require": "./index.js",
       "types": "./index.d.ts"
     }
   },

--- a/packages/@lightningjs/ui-components-test-utils/src/docs/Overview.stories.mdx
+++ b/packages/@lightningjs/ui-components-test-utils/src/docs/Overview.stories.mdx
@@ -31,3 +31,25 @@ The `@lightningjs/ui-components-test-utils` package provides 2 artifacts to assi
   - [completeAnimation](/story/docs-unit-testing-test-utils-completeanimation--page): Returns a Promise that resolves once all animating properties have updated to their target value(s).
   - [fastForward](/story/docs-unit-testing-test-utils-fastforward--page): Force all running Lightning Transitions on one or more Lightning Elements to finish and update the transitioning property to its target value immediately.
   - [nextTick](/story/docs-unit-testing-test-utils-nexttick--page): Creates a Promise that resolves after a defined amount of time. If no amount of time is specified, the Promise will resolve immediately.
+
+
+## Getting Started
+All artifacts within `@lightningjs/ui-components-test-utils` are currently only available using ES Module syntax. This differs from the CommonJS syntax Jest is written in.
+Due to this, the `@lightningjs/ui-components-test-utils` must be converted to CommonJS via the Jest config setting [transformIgnorePatterns](https://jestjs.io/docs/configuration#transformignorepatterns-arraystring).
+
+By default, the Jest jsdom environment does not provide mocks for canvas and WebGL. A recommended solution for this is to add [jest-webgl-canvas-mock](https://www.npmjs.com/package/jest-webgl-canvas-mock) to the [setupFiles](https://jestjs.io/docs/configuration#setupfiles-array) option in your Jest config. 
+
+```js
+// jest.config.js
+
+const config = {
+  // ...other Jest config properties
+  setupFiles: ["jest-webgl-canvas-mock"],
+  transformIgnorePatterns: [
+    "/node_modules/(?!(@lightningjs/ui-components-test-utils)/)",
+  ]
+  // ...other Jest config properties
+}
+
+export default config
+```

--- a/packages/@lightningjs/ui-components-test-utils/src/docs/TestRenderer/create.stories.mdx
+++ b/packages/@lightningjs/ui-components-test-utils/src/docs/TestRenderer/create.stories.mdx
@@ -67,7 +67,7 @@ const stage = {
 
 ```js
 import lng from '@lightningjs/core';
-import { create } from '@lightningjs/ui-components-test-utils';
+import { TestRenderer } from '@lightningjs/ui-components-test-utils';
 
 it('should render the component with text', () => {
   const testRenderer = TestRenderer.create({

--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-renderer.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-renderer.d.ts
@@ -17,6 +17,7 @@
  */
 
 import lng from '@lightningjs/core';
+import type { context } from './lightning-test-utils';
 
 export interface JSONTree {
   alpha: lng.Component['alpha'];
@@ -64,9 +65,6 @@ export interface JSONTree {
   [key: string]: unknown;
 }
 
-// TODO: no TS def for Context available
-type context = Record<string, unknown>;
-
 export type testRenderer = {
   toJSON: (children?: number) => JSONTree;
   update: () => void;
@@ -99,7 +97,7 @@ export type createOptions = {
  * @returns {object} A testRenderer object. {@link testRenderer}
  */
 export declare function create(
-  Component: lng.Component,
+  Component: lng.Element.PatchTemplate,
   options?: createOptions
 ): testRenderer;
 

--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-utils.d.ts
@@ -64,7 +64,7 @@ declare namespace makeCreateComponent {
       SpyOnMethodsResolvers<T>;
 
     export type CreateComponent = (
-      config: Config,
+      config?: Config,
       options?: Options
     ) => [
       ComponentInstance<NonNullable<(typeof options)['spyOnMethods']>>,


### PR DESCRIPTION
## Description
Jest is written in CommonJS, so requires packages to be available in that format. All source code in `@lightningjs/ui-components-test-utils` utilizes ESModules. There are various challenges that currently prevent us from transforming `@lightningjs/ui-components-test-utils` to CommonJS when all the packages in the monorepo are transformed/bundled, primarily due to accessing the `jest` global object outside of a jest environment. 

To get around the issue of not transforming to CommonJS when bundling the package, 2 changes are needed:
- the [conditional export](https://nodejs.org/api/packages.html#conditional-exports) for CommonJS's `require` will map to the same file path utilized by ESM's `export`, `index.js`
- in the Jest config of the application consuming `@lightningjs/ui-components-test-utils`, add a pattern to the [transformIgnorePatterns](https://jestjs.io/docs/configuration#transformignorepatterns-arraystring) option that will result in `@lightningjs/ui-components-test-utils` being transformed to CommonJS when the Jest test environment is stood up
This method allows `@lightningjs/ui-components-test-utils` to both access the `jest` global object _and _ be transformed to a format Jest "understands."

- added conditional export for `require` statements so Jest can access the package in its testing environment
- added documentation to set up a Jest config to transform the `@lightningjs/ui-components-test-utils` package

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References
LUI-943
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
1. pull and checkout this branch on your local repo of this project. run `yarn` and `yarn build` to build install and build the packages
3. In a Lighting/TypeScript project ([like this one on the unit-testing branch!](https://github.com/agallo864_comcast/lng-ts-test/tree/unit-testing)), install your local version of `@lightningjs/ui-components-test-utils` (which included this PR's changes) as a devDependency with this command:
```zsh
npm i -D ../path/to/your/local/@lightningjs/ui-components-test-utils/
// ex. for me, this is npm i -D ../../os/Lightning-UI-Components/packages/@lightningjs/ui-components-test-utils/
```
4. Run unit tests in the TypeScript project. The testing suite should run without errors.

## Automation
n/a
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
