### PR TITLE
fix(ControlRow): lazy scroll

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.js
+++ b/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.js
@@ -144,7 +144,7 @@ export default class ControlRow extends TitleRow {
     }
 
     this.patch({
-      stopLazyScrollIndex: addIndex + itemsToAdd.length - 1
+      stopLazyScrollIndex: this.leftControls.length + this.contentItems.length - 1
     });
   }
 
@@ -162,7 +162,7 @@ export default class ControlRow extends TitleRow {
       }
 
       this.patch({
-        stopLazyScrollIndex: this._lastItemIndex + itemsToAdd.length
+        stopLazyScrollIndex: this.leftControls.length + this.contentItems.length - 1
       });
     }
   }
@@ -177,8 +177,8 @@ export default class ControlRow extends TitleRow {
     }
 
     this.patch({
-      stopLazyScrollIndex:
-        this.leftControls.length + this.contentItems.length - 1
+      startLazyScrollIndex: this.leftControls.length,
+      stopLazyScrollIndex: this.leftControls.length + this.contentItems.length - 1
     });
   }
 
@@ -194,7 +194,8 @@ export default class ControlRow extends TitleRow {
     }
 
     this.patch({
-      startLazyScrollIndex: addIndex + itemsToAdd.length
+      startLazyScrollIndex: this.leftControls.length,
+      stopLazyScrollIndex: this.leftControls.length + this.contentItems.length - 1
     });
   }
 
@@ -211,9 +212,8 @@ export default class ControlRow extends TitleRow {
       }
 
       this.patch({
-        startLazyScrollIndex: this._lastLeftControlIndex
-          ? this._lastLeftControlIndex + 1
-          : controls.length
+        startLazyScrollIndex: this.leftControls.length,
+        stopLazyScrollIndex: this.leftControls.length + this.contentItems.length - 1
       });
     }
   }
@@ -227,8 +227,10 @@ export default class ControlRow extends TitleRow {
       this._leftControls.splice(index, 1);
     }
 
-    this.stopLazyScrollIndex =
-      this.leftControls.length + this.contentItems.length - 1;
+    this.patch({
+      startLazyScrollIndex: this.leftControls.length,
+      stopLazyScrollIndex: this.leftControls.length + this.contentItems.length - 1
+    });
   }
 
   addRightControls(controls) {

--- a/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.js
+++ b/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.js
@@ -144,7 +144,8 @@ export default class ControlRow extends TitleRow {
     }
 
     this.patch({
-      stopLazyScrollIndex: this.leftControls.length + this.contentItems.length - 1
+      stopLazyScrollIndex:
+        this.leftControls.length + this.contentItems.length - 1
     });
   }
 
@@ -162,7 +163,8 @@ export default class ControlRow extends TitleRow {
       }
 
       this.patch({
-        stopLazyScrollIndex: this.leftControls.length + this.contentItems.length - 1
+        stopLazyScrollIndex:
+          this.leftControls.length + this.contentItems.length - 1
       });
     }
   }
@@ -178,7 +180,8 @@ export default class ControlRow extends TitleRow {
 
     this.patch({
       startLazyScrollIndex: this.leftControls.length,
-      stopLazyScrollIndex: this.leftControls.length + this.contentItems.length - 1
+      stopLazyScrollIndex:
+        this.leftControls.length + this.contentItems.length - 1
     });
   }
 
@@ -195,7 +198,8 @@ export default class ControlRow extends TitleRow {
 
     this.patch({
       startLazyScrollIndex: this.leftControls.length,
-      stopLazyScrollIndex: this.leftControls.length + this.contentItems.length - 1
+      stopLazyScrollIndex:
+        this.leftControls.length + this.contentItems.length - 1
     });
   }
 
@@ -213,7 +217,8 @@ export default class ControlRow extends TitleRow {
 
       this.patch({
         startLazyScrollIndex: this.leftControls.length,
-        stopLazyScrollIndex: this.leftControls.length + this.contentItems.length - 1
+        stopLazyScrollIndex:
+          this.leftControls.length + this.contentItems.length - 1
       });
     }
   }
@@ -229,7 +234,8 @@ export default class ControlRow extends TitleRow {
 
     this.patch({
       startLazyScrollIndex: this.leftControls.length,
-      stopLazyScrollIndex: this.leftControls.length + this.contentItems.length - 1
+      stopLazyScrollIndex:
+        this.leftControls.length + this.contentItems.length - 1
     });
   }
 

--- a/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.stories.js
@@ -177,7 +177,7 @@ export const AddingAndRemoving = () =>
             createSignal('addLeftControl')
           ),
           contentItems: createItems(
-            3,
+            5,
             undefined,
             createSignal('addContentItem')
           ),

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.js
@@ -137,17 +137,18 @@ export default class Row extends NavigationManager {
       // otherwise, no start/stop indexes, perform normal lazy scroll
       let itemsContainerX;
       const prevIndex = this.Items.childList.getIndex(prev);
-      const selectedX = this.selected.transition('x')
+      /** const selectedX = this.selected.transition('x')
         ? this.selected.transition('x').targetValue
         : this.selected.x;
       if (prevIndex === -1) {
         // No matches found in childList, start set x to 0
         return;
-      }
-      if (prevIndex > this.selectedIndex) {
-        itemsContainerX = -selectedX;
-      } else if (prevIndex < this.selectedIndex) {
-        itemsContainerX = this.w - selectedX - this.selected.w;
+      }*/
+      debugger
+      if (prevIndex && prevIndex > this.selectedIndex && this._currentItemsContainerX) {
+        itemsContainerX = this._currentItemsContainerX + this.selected.w;
+      } else if ( prevIndex && prevIndex < this.selectedIndex && this._currentItemsContainerX) {
+        itemsContainerX = this._currentItemsContainerX - this.selected.w;
       }
 
       return itemsContainerX;
@@ -193,6 +194,7 @@ export default class Row extends NavigationManager {
           : this._getScrollX();
     }
     if (itemsContainerX !== undefined) {
+      this._currentItemsContainerX = itemsContainerX;
       this.updatePositionOnAxis(this.Items, itemsContainerX);
     }
 

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.js
@@ -122,7 +122,6 @@ export default class Row extends NavigationManager {
       this.selectedIndex >= this.stopLazyScrollIndex &&
       this.selectedIndex < prevIndex
     ) {
-
       const currItemsX = this.Items.x;
 
       return (

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.js
@@ -74,15 +74,18 @@ export default class Row extends NavigationManager {
 
   _shouldScroll() {
     const prevIndex = this.Items.childList.getIndex(this.prevSelected);
-      
+
     if (
-        this.lazyScroll &&
-        ( (this.selectedIndex < this.startLazyScrollIndex || this.selectedIndex > this.stopLazyScrollIndex || 
-          (prevIndex < this.startLazyScrollIndex && this.selectedIndex === this.startLazyScrollIndex) ||
-            (prevIndex > this.stopLazyScrollIndex && this.selectedIndex === this.stopLazyScrollIndex)))
-      ) {
-        // if lazy scroll is true and we are navigating to to the left of start index, the right of stop index, 
-        // from the left to the start, or from the right to the start 
+      this.lazyScroll &&
+      (this.selectedIndex < this.startLazyScrollIndex ||
+        this.selectedIndex > this.stopLazyScrollIndex ||
+        (prevIndex < this.startLazyScrollIndex &&
+          this.selectedIndex === this.startLazyScrollIndex) ||
+        (prevIndex > this.stopLazyScrollIndex &&
+          this.selectedIndex === this.stopLazyScrollIndex))
+    ) {
+      // if lazy scroll is true and we are navigating to to the left of start index, the right of stop index,
+      // from the left to the start, or from the right to the start
       return true;
     }
 
@@ -144,10 +147,18 @@ export default class Row extends NavigationManager {
         // No matches found in childList, start set x to 0
         return;
       }*/
-      debugger
-      if (prevIndex && prevIndex > this.selectedIndex && this._currentItemsContainerX) {
+
+      if (
+        prevIndex &&
+        prevIndex > this.selectedIndex &&
+        this._currentItemsContainerX
+      ) {
         itemsContainerX = this._currentItemsContainerX + this.selected.w;
-      } else if ( prevIndex && prevIndex < this.selectedIndex && this._currentItemsContainerX) {
+      } else if (
+        prevIndex &&
+        prevIndex < this.selectedIndex &&
+        this._currentItemsContainerX
+      ) {
         itemsContainerX = this._currentItemsContainerX - this.selected.w;
       }
 

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.js
@@ -140,26 +140,23 @@ export default class Row extends NavigationManager {
       // otherwise, no start/stop indexes, perform normal lazy scroll
       let itemsContainerX;
       const prevIndex = this.Items.childList.getIndex(prev);
-      /** const selectedX = this.selected.transition('x')
-        ? this.selected.transition('x').targetValue
-        : this.selected.x;
-      if (prevIndex === -1) {
-        // No matches found in childList, start set x to 0
-        return;
-      }*/
 
       if (
         prevIndex &&
         prevIndex > this.selectedIndex &&
         this._currentItemsContainerX
       ) {
-        itemsContainerX = this._currentItemsContainerX + this.selected.w;
+        //navigating left
+        itemsContainerX = this._currentItemsContainerX + this.selected.w + this.style.itemSpacing +
+        (this.selected.extraItemSpacing || 0);;
       } else if (
         prevIndex &&
         prevIndex < this.selectedIndex &&
         this._currentItemsContainerX
       ) {
-        itemsContainerX = this._currentItemsContainerX - this.selected.w;
+        //navigating right
+        itemsContainerX = this._currentItemsContainerX - this.selected.w + this.style.itemSpacing +
+        (this.selected.extraItemSpacing || 0);
       }
 
       return itemsContainerX;

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.js
@@ -74,7 +74,6 @@ export default class Row extends NavigationManager {
 
   _shouldScroll() {
     const prevIndex = this.Items.childList.getIndex(this.prevSelected);
-
     if (
       this.lazyScroll &&
       (this.selectedIndex < this.startLazyScrollIndex ||
@@ -84,8 +83,6 @@ export default class Row extends NavigationManager {
         (prevIndex > this.stopLazyScrollIndex &&
           this.selectedIndex === this.stopLazyScrollIndex))
     ) {
-      // if lazy scroll is true and we are navigating to to the left of start index, the right of stop index,
-      // from the left to the start, or from the right to the start
       return true;
     }
 
@@ -125,10 +122,8 @@ export default class Row extends NavigationManager {
       this.selectedIndex >= this.stopLazyScrollIndex &&
       this.selectedIndex < prevIndex
     ) {
-      // if navigating left on items after stop lazy scroll index, only shift by size of prev item
-      const currItemsX = this.Items.transition('x')
-        ? this.Items.transition('x').targetValue
-        : this.Items.x;
+
+      const currItemsX = this.Items.x;
 
       return (
         currItemsX +
@@ -141,28 +136,16 @@ export default class Row extends NavigationManager {
       let itemsContainerX;
       const prevIndex = this.Items.childList.getIndex(prev);
 
-      if (
-        prevIndex &&
-        prevIndex > this.selectedIndex &&
-        this._currentItemsContainerX
-      ) {
-        //navigating left
-        itemsContainerX =
-          this._currentItemsContainerX +
-          this.selected.w +
-          this.style.itemSpacing +
-          (this.selected.extraItemSpacing || 0);
-      } else if (
-        prevIndex &&
-        prevIndex < this.selectedIndex &&
-        this._currentItemsContainerX
-      ) {
-        //navigating right
-        itemsContainerX =
-          this._currentItemsContainerX -
-          this.selected.w +
-          this.style.itemSpacing +
-          (this.selected.extraItemSpacing || 0);
+      const selectedX = this.selected.x;
+
+      if (prevIndex === -1) {
+        // No matches found in childList, start set x to 0
+        return;
+      }
+      if (prevIndex > this.selectedIndex) {
+        itemsContainerX = -selectedX;
+      } else if (prevIndex < this.selectedIndex) {
+        itemsContainerX = this.w - selectedX - this.selected.w;
       }
 
       return itemsContainerX;
@@ -208,7 +191,6 @@ export default class Row extends NavigationManager {
           : this._getScrollX();
     }
     if (itemsContainerX !== undefined) {
-      this._currentItemsContainerX = itemsContainerX;
       this.updatePositionOnAxis(this.Items, itemsContainerX);
     }
 

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.js
@@ -73,11 +73,16 @@ export default class Row extends NavigationManager {
   }
 
   _shouldScroll() {
+    const prevIndex = this.Items.childList.getIndex(this.prevSelected);
+      
     if (
-      this.lazyScroll &&
-      (this.selectedIndex <= this.startLazyScrollIndex ||
-        this.selectedIndex >= this.stopLazyScrollIndex)
-    ) {
+        this.lazyScroll &&
+        ( (this.selectedIndex < this.startLazyScrollIndex || this.selectedIndex > this.stopLazyScrollIndex || 
+          (prevIndex < this.startLazyScrollIndex && this.selectedIndex === this.startLazyScrollIndex) ||
+            (prevIndex > this.stopLazyScrollIndex && this.selectedIndex === this.stopLazyScrollIndex)))
+      ) {
+        // if lazy scroll is true and we are navigating to to the left of start index, the right of stop index, 
+        // from the left to the start, or from the right to the start 
       return true;
     }
 

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.js
@@ -147,16 +147,22 @@ export default class Row extends NavigationManager {
         this._currentItemsContainerX
       ) {
         //navigating left
-        itemsContainerX = this._currentItemsContainerX + this.selected.w + this.style.itemSpacing +
-        (this.selected.extraItemSpacing || 0);;
+        itemsContainerX =
+          this._currentItemsContainerX +
+          this.selected.w +
+          this.style.itemSpacing +
+          (this.selected.extraItemSpacing || 0);
       } else if (
         prevIndex &&
         prevIndex < this.selectedIndex &&
         this._currentItemsContainerX
       ) {
         //navigating right
-        itemsContainerX = this._currentItemsContainerX - this.selected.w + this.style.itemSpacing +
-        (this.selected.extraItemSpacing || 0);
+        itemsContainerX =
+          this._currentItemsContainerX -
+          this.selected.w +
+          this.style.itemSpacing +
+          (this.selected.extraItemSpacing || 0);
       }
 
       return itemsContainerX;


### PR DESCRIPTION
## Description

allowing the lazy scroll to work appropriately. Added a variable to keep track of the current position of the row and adjusting by the width of selected item rather than the transition value

## References

LUI-903

## Testing

Navigate to control row, then to adding and removing items. Set Lazy Scroll to true and observe the scrolling when on each item

## Automation


## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
