### PR TITLE
fix(Toggle): do not manually set height since Container uses this.h and style sets default h

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Toggle/Toggle.js
+++ b/packages/@lightningjs/ui-components/src/components/Toggle/Toggle.js
@@ -67,7 +67,6 @@ export default class Toggle extends Base {
     this._updateContainer();
     this._updateStroke();
     this._updateKnob();
-    this._updateTotalHeight();
     if (this._checkedChanged) {
       this.fireAncestors('$announce', this.announce);
       this._checkedChanged = false;
@@ -129,10 +128,6 @@ export default class Toggle extends Base {
         false
       )
     });
-  }
-  _updateTotalHeight() {
-    this.h = this._Container.h;
-    this.fireAncestors('$itemChanged');
   }
 
   _updateStroke() {


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Manually setting the Toggle's height causes the "hSetByUser" flag to be set to true in withThemeStyles, preventing a theme update from updating to the new height set in styles. Because the Container references `this.h`, which will pull from the style mappings, this isn't necessary anyway. In the future, we may want to consider automatically emitting "itemChanged" events from withThemeStyles when the theme updates h/w anyway, but TBD.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
Should resolve the failing Toggle test here: https://lui-tests.devplat.comcast.com/prValidateSanity/Aug-14-2023-Mon-11-44-46-EDT/index.html

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
