### PR TITLE
fix(Column): scrollIndex takes presedence over alwaysScroll

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Column/Column.js
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.js
@@ -43,6 +43,11 @@ export default class Column extends NavigationManager {
       shouldScroll =
         lastChild && (this.shouldScrollUp() || this.shouldScrollDown());
     }
+
+    if (this.selectedIndex < this.scrollIndex ) {
+      shouldScroll = false;
+    }
+    
     return shouldScroll;
   }
 

--- a/packages/@lightningjs/ui-components/src/components/Column/Column.js
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.js
@@ -44,10 +44,10 @@ export default class Column extends NavigationManager {
         lastChild && (this.shouldScrollUp() || this.shouldScrollDown());
     }
 
-    if (this.selectedIndex < this.scrollIndex ) {
+    if (this.selectedIndex < this.scrollIndex) {
       shouldScroll = false;
     }
-    
+
     return shouldScroll;
   }
 


### PR DESCRIPTION
## Description

Add a check comparing selectedIndex to scrollIndex to see if should scroll

## References

LUI-902

## Testing

In Column, set scrollIndex to greater than 1 with alwaysScroll True. See functionality.

## Automation


## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
