### PR TITLE
fix(NavigationManager): do not set h/w on items if they are already defined on the components

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -288,13 +288,18 @@ export default class NavigationManager extends FocusManager {
   _performRender() {}
 
   _appendItem(item) {
-    const { crossDimension } = this._directionPropNames;
-    const itemCrossSize = this._isRow ? this.renderHeight : this.renderWidth;
     this.shouldSmooth = false;
-
     item.parentFocus = this.hasFocus();
     item = this.Items.childList.a(item);
-    item[crossDimension] = item[crossDimension] || itemCrossSize;
+
+    const { crossDimension } = this._directionPropNames;
+    // do not set a h/w if the item already has one defined
+    // as this will trigger withThemeStyles's dimension "setByUser" flag
+    if (!item[crossDimension]) {
+      const itemCrossSize = this._isRow ? this.renderHeight : this.renderWidth;
+      item[crossDimension] = item[crossDimension] || itemCrossSize;
+    }
+
     item = this._withAfterUpdate(item);
   }
 
@@ -340,14 +345,17 @@ export default class NavigationManager extends FocusManager {
     this._totalAddedLength = 0;
 
     items.forEach((item, itemIdx) => {
-      this.Items.childList.addAt(
-        {
-          ...this._withAfterUpdate(item),
-          parentFocus: this.hasFocus(),
-          [crossDimension]: item[crossDimension] || this.Items[crossDimension]
-        },
-        addIndex + itemIdx
-      );
+      const newItem = {
+        ...this._withAfterUpdate(item),
+        parentFocus: this.hasFocus()
+      };
+      // do not set a h/w if the item already has one defined
+      // as this will trigger withThemeStyles's dimension "setByUser" flag
+      if (!item[crossDimension]) {
+        newItem[crossDimension] =
+          item[crossDimension] || this.Items[crossDimension];
+      }
+      this.Items.childList.addAt(newItem, addIndex + itemIdx);
       const itemLength =
         item[lengthDimension] || item[innerLengthDimension] || 0;
       const extraItemSpacing = item.extraItemSpacing || 0;


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
If there is already a width or height set on a component being added to a NavigationManager, don't force its size to use the container. This will flip the `wSetByUser` and `hSetByUser` flags in withThemeStyles unnecessarily, preventing the theme swapping from applying a new h/w.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
Run through all Column/Row stories and check everything is running as expected.

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
