### PR TITLE
docs(withThemeStyles): add info about exposure of  methods

### DIFF
--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/withThemeStyles.mdx
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/withThemeStyles.mdx
@@ -141,4 +141,21 @@ class NewComponent extends lng.Component {
 
 In both cases, you'll notice that there is a `__componentName` getter in our `Box` class. This name is what is used to reference our component for any overrides and extension assignments that might exist in our theme's `componentConfig`.
 
+### Mode Changes
+
+Instead of extending a component to access the focus or unfocus methods of a component, or to add any custom functionality for a specific mode, you can tap into "on" methods for mode changes. Similarly to the `on[KeyName]` methods exposed via the [withHandleKey](?path=/docs/utilities-withhandlekey--with-handle-key) mixin, all mode changes are linked to `on[ModeName]` methods, which are triggered when the `mode` of the component is set to a new value.
+
+For example, if a component has an `unfocused`, `focused`, and `disabled` mode, the `onUnfocused`, `onFocused`, and `onDisabled` methods will be called on change to the associated mode. Any custom modes beyond these three will also be added to the method list. When using a component, all of those methods can be accessed and set like other component properties, like this:
+
+```js
+class NewComponent extends lng.Component {
+  _template() {
+    Box: {
+      type: withThemeStyles(Box, style),
+      onFocused: () => { console.log('mode changed to focused!'); }
+    }
+  }
+}
+```
+
 For more information on all of the ways you can set up your styles to fully utilize this mixin, read through the [Theming Documentation](?path=/docs/docs-theming-overview--page).


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Adds documentation on the addition of "onFocused" and similar mode change methods via withThemeStyles.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
