### PR TITLE
fix(NavigationManager): add style to TypeScript definition export

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/index.d.ts
@@ -16,6 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import NavigationManager from './NavigationManager';
+import NavigationManager, { NavigationManagerStyle } from './NavigationManager';
 
-export { NavigationManager as default };
+export { NavigationManager as default, NavigationManagerStyle };

--- a/packages/@lightningjs/ui-components/src/components/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/index.d.ts
@@ -74,7 +74,10 @@ export {
   MetadataCardContentStyle
 } from './MetadataCardContent';
 export { default as MetadataTile, MetadataTileStyle } from './MetadataTile';
-export { default as NavigationManager } from './NavigationManager';
+export {
+  default as NavigationManager,
+  NavigationManagerStyle
+} from './NavigationManager';
 export { default as ProgressBar, ProgressBarStyle } from './ProgressBar';
 export { default as Provider, ProviderStyle } from './Provider';
 export { default as Radio, RadioStyle } from './Radio';


### PR DESCRIPTION
## Description

Adds NavigationManager's style to the list of TypeScript exports.

## Testing

You should now be able to import `NavigationManagerStyle` from the package instead of directly from the source.

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
