### PR TITLE
fix(InlineContent): reset tracked x position after new line

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
@@ -197,7 +197,7 @@ export default class InlineContent extends Base {
 
       if (isNewLineElement) {
         line++;
-        contentEndX = w;
+        contentEndX = 0;
         return acc;
       }
 

--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.stories.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright 2023 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +28,9 @@ export default {
   args: {
     contentWrap: false,
     justify: 'center',
-    contentProperties: { marginBottom: -4 }
+    contentProperties: { marginBottom: -4 },
+    maxLines: 0,
+    maxLinesSuffix: '..'
   },
   argTypes: {
     contentProperties: {
@@ -69,7 +71,7 @@ export default {
       description: 'maximum number of lines to render before truncation',
       type: 'number',
       table: {
-        defaultValue: { summary: undefined }
+        defaultValue: { summary: 'undefined' }
       }
     },
     maxLinesSuffix: {


### PR DESCRIPTION
## Description
This resolves an issue where the number of lines rendered by InlineContent sometimes exceeds the maxLines. The source of the issue was where we calculate which line each piece of text/icon/badge is rendered on. When a new line is in the content string, the next item should start on a new line. Prior to this change, that would increase the line number for the next item and set the ending x position of the last item rendered to the width of the InlineContent component. Both of those changes individually are meant to denote a new line should be started, so doing both resulted in adding 2 lines. This change still increases the line number but sets the tracked end x position of the last item to the beginning of the component.

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References
LUI-1016
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
This issue was only reproducible in the inner source repo. 
1. Navigate to "InlineContent / With Inline Content String" story
2. set contentWrap to true and set maxLines to 4
ER: 4 lines of text are rendered
<!-- step by step instructions to review this PR's changes -->

## Automation
Bug initially reported by Automation team.
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
