### PR TITLE
fix(CardContent): update all expandedW and expandedH styles to expanded expandedWidth and expandedHeight

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.d.ts
@@ -29,8 +29,12 @@ type ImageSize = {
 
 type CardContentStyle = CardStyle & {
   backgroundColor: Color;
+  /** @deprecated */
   expandedW: number;
+  expandedWidth: number;
+  /** @deprecated */
   expandedH: number;
+  expandedHeight: number;
   imageSize: ImageSize;
   metadata: TextBoxStyle;
 };

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.js
@@ -54,6 +54,13 @@ export default class CardContent extends Card {
     return [...super.tags, 'Metadata', 'Tile'];
   }
 
+  static get aliasStyles() {
+    return [
+      { prev: 'expandedW', curr: 'expandedWidth' },
+      { prev: 'expandedH', curr: 'expandedHeight' }
+    ];
+  }
+
   _update() {
     this._updateSize();
     this._updateTile();
@@ -68,9 +75,9 @@ export default class CardContent extends Card {
 
   _updateTile() {
     let w = this.style.imageSize.w;
-    let h = this.style.expandedH;
+    let h = this.style.expandedHeight;
     if (this._orientation !== 'horizontal') {
-      w = this.style.expandedW;
+      w = this.style.expandedWidth;
       h = this.style.imageSize.h;
     }
 
@@ -108,8 +115,8 @@ export default class CardContent extends Card {
   }
 
   _updateSize() {
-    let w = this.style.expandedW;
-    let h = this.style.expandedH;
+    let w = this.style.expandedWidth;
+    let h = this.style.expandedHeight;
     if (this._collapse) {
       if (this._orientation === 'horizontal') {
         w = this._collapseW;
@@ -150,12 +157,13 @@ export default class CardContent extends Card {
     const paddingHorizontal = this.style.paddingHorizontal * 2;
     const paddingVertical = this.style.paddingVertical * 2;
 
-    let w = this.style.expandedW - this.style.imageSize.w - paddingHorizontal;
-    let h = this.style.expandedH - paddingVertical;
+    let w =
+      this.style.expandedWidth - this.style.imageSize.w - paddingHorizontal;
+    let h = this.style.expandedHeight - paddingVertical;
 
     if (this.orientation !== 'horizontal') {
-      w = this.style.expandedW - paddingHorizontal;
-      h = this.style.expandedH - this.style.imageSize.h - paddingVertical;
+      w = this.style.expandedWidth - paddingHorizontal;
+      h = this.style.expandedHeight - this.style.imageSize.h - paddingVertical;
     }
     return { w, h };
   }
@@ -189,13 +197,13 @@ export default class CardContent extends Card {
 
   get _collapseW() {
     return this.collapseToMetadata
-      ? this.style.expandedW - this.style.imageSize.w
+      ? this.style.expandedWidth - this.style.imageSize.w
       : this.style.imageSize.w;
   }
 
   get _collapseH() {
     return this.collapseToMetadata
-      ? this.style.expandedH - this.style.imageSize.h
+      ? this.style.expandedHeight - this.style.imageSize.h
       : this.style.imageSize.h;
   }
 

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.mdx
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.mdx
@@ -67,8 +67,8 @@ class Basic extends lng.Component {
 | name              | type             | description                                                                    |
 | ----------------- | ---------------- | ------------------------------------------------------------------------------ |
 | backgroundColor   | string           | color of the card                                                              |
-| expandedW         | number           | the desired width of the card when in the fully expanded (not collapsed) mode  |
-| expandedH         | number           | the desired height of the card when in the fully expanded (not collapsed) mode |
+| expandedWidth     | number           | the desired width of the card when in the fully expanded (not collapsed) mode  |
+| expandedHeight    | number           | the desired height of the card when in the fully expanded (not collapsed) mode |
 | imageSize         | {w, h}           | the desired width and height the image in the card                             |
 | metadata          | string \| object | text style for the metadata                                                    |
 | paddingHorizontal | number           | padding on the x-axis between the right and left of the card and its content   |

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.styles.js
@@ -19,9 +19,12 @@
 import utils from '../../utils';
 
 export const base = theme => ({
-  expandedW: utils.getWidthByUpCount(theme, 2),
-  expandedH: utils.getDimensions(theme, { ratioX: 16, ratioY: 9, upCount: 4 })
-    .h,
+  expandedWidth: utils.getWidthByUpCount(theme, 2),
+  expandedHeight: utils.getDimensions(theme, {
+    ratioX: 16,
+    ratioY: 9,
+    upCount: 4
+  }).h,
   imageSize: {
     width: utils.getDimensions(theme, { ratioX: 16, ratioY: 9, upCount: 4 }).w,
     height: utils.getDimensions(theme, { ratioX: 16, ratioY: 9, upCount: 4 }).h

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContentHorizontal.test.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContentHorizontal.test.js
@@ -58,7 +58,9 @@ describe('CardContentHorizontal', () => {
     cardContentHorizontal.shouldCollapse = false;
     cardContentHorizontal.collapseToMetadata = false;
     testRenderer.forceAllUpdates();
-    expect(cardContentHorizontal.w).toBe(cardContentHorizontal.style.expandedWidth);
+    expect(cardContentHorizontal.w).toBe(
+      cardContentHorizontal.style.expandedWidth
+    );
 
     cardContentHorizontal.shouldCollapse = true;
     cardContentHorizontal.collapseToMetadata = false;

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContentHorizontal.test.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContentHorizontal.test.js
@@ -42,11 +42,11 @@ describe('CardContentHorizontal', () => {
     cardContentHorizontal.shouldCollapse = false;
     testRenderer.forceAllUpdates();
     const w =
-      cardContentHorizontal.style.expandedW -
+      cardContentHorizontal.style.expandedWidth -
       2 * cardContentHorizontal.style.paddingHorizontal -
       cardContentHorizontal.style.imageSize.w;
     const h =
-      cardContentHorizontal.style.expandedH -
+      cardContentHorizontal.style.expandedHeight -
       2 * cardContentHorizontal.style.paddingVertical;
     expect(cardContentHorizontal._Metadata.w).toBe(w);
     expect(cardContentHorizontal._Metadata.h).toBe(h);
@@ -58,7 +58,7 @@ describe('CardContentHorizontal', () => {
     cardContentHorizontal.shouldCollapse = false;
     cardContentHorizontal.collapseToMetadata = false;
     testRenderer.forceAllUpdates();
-    expect(cardContentHorizontal.w).toBe(cardContentHorizontal.style.expandedW);
+    expect(cardContentHorizontal.w).toBe(cardContentHorizontal.style.expandedWidth);
 
     cardContentHorizontal.shouldCollapse = true;
     cardContentHorizontal.collapseToMetadata = false;
@@ -70,7 +70,7 @@ describe('CardContentHorizontal', () => {
     cardContentHorizontal.collapseToMetadata = true;
     testRenderer.forceAllUpdates();
     expect(cardContentHorizontal.w).toBe(
-      cardContentHorizontal.style.expandedW -
+      cardContentHorizontal.style.expandedWidth -
         cardContentHorizontal.style.imageSize.w
     );
   });

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContentHorizontalLarge.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContentHorizontalLarge.styles.js
@@ -25,9 +25,9 @@ export const base = theme => {
     upCount: 3
   });
   return {
-    expandedW: utils.getWidthByColumnSpan(theme, 8),
-    expandedH: h,
-    imageSize: { w, h },
+    expandedWidth: utils.getWidthByColumnSpan(theme, 8),
+    expandedHeight: h,
+    imageSize: { width: w, height: h },
     metadata: { descriptionTextStyle: { maxLines: 3 } }
   };
 };

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVertical.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVertical.styles.js
@@ -19,8 +19,8 @@
 import utils from '../../utils';
 
 export const base = theme => ({
-  expandedW: utils.getWidthByUpCount(theme, 4),
-  expandedH:
+  expandedWidth: utils.getWidthByUpCount(theme, 4),
+  expandedHeight:
     utils.getDimensions(theme, { ratioX: 16, ratioY: 9, upCount: 4 }).h +
     theme.spacer.xxxl * 7 +
     theme.spacer.lg +

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVertical.test.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVertical.test.js
@@ -42,10 +42,10 @@ describe('CardContentVertical', () => {
     cardContentVertical.shouldCollapse = true;
     testRenderer.forceAllUpdates();
     const w =
-      cardContentVertical.style.expandedW -
+      cardContentVertical.style.expandedWidth -
       2 * cardContentVertical.style.paddingHorizontal;
     const h =
-      cardContentVertical.style.expandedH -
+      cardContentVertical.style.expandedHeight -
       2 * cardContentVertical.style.paddingVertical -
       cardContentVertical.style.imageSize.h;
     expect(cardContentVertical._Metadata.w).toBe(w);
@@ -58,7 +58,7 @@ describe('CardContentVertical', () => {
     cardContentVertical.shouldCollapse = false;
     cardContentVertical.collapseToMetadata = false;
     testRenderer.forceAllUpdates();
-    expect(cardContentVertical.h).toBe(cardContentVertical.style.expandedH);
+    expect(cardContentVertical.h).toBe(cardContentVertical.style.expandedHeight);
 
     cardContentVertical.shouldCollapse = true;
     cardContentVertical.collapseToMetadata = false;
@@ -68,7 +68,7 @@ describe('CardContentVertical', () => {
     cardContentVertical.collapseToMetadata = true;
     testRenderer.forceAllUpdates();
     expect(cardContentVertical.h).toBe(
-      cardContentVertical.style.expandedH -
+      cardContentVertical.style.expandedHeight -
         cardContentVertical.style.imageSize.h
     );
   });

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVertical.test.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVertical.test.js
@@ -58,7 +58,9 @@ describe('CardContentVertical', () => {
     cardContentVertical.shouldCollapse = false;
     cardContentVertical.collapseToMetadata = false;
     testRenderer.forceAllUpdates();
-    expect(cardContentVertical.h).toBe(cardContentVertical.style.expandedHeight);
+    expect(cardContentVertical.h).toBe(
+      cardContentVertical.style.expandedHeight
+    );
 
     cardContentVertical.shouldCollapse = true;
     cardContentVertical.collapseToMetadata = false;

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVerticalSmall.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVerticalSmall.styles.js
@@ -19,7 +19,7 @@
 import utils from '../../utils';
 
 export const base = theme => ({
-  expandedH:
+  expandedHeight:
     utils.getDimensions(theme, { ratioX: 16, ratioY: 9, upCount: 4 }).h +
     theme.spacer.md * 14,
   metadata: { descriptionTextStyle: { maxLines: 1 } }

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
@@ -626,6 +626,7 @@ export const replaceAliasValues = (value, aliasStyles = []) => {
       typeof alias.curr === 'string'
     ) {
       !alias.skipWarn &&
+        str.search(`"${alias.prev}":`) >= 0 &&
         console.warn(
           `The style property "${alias.prev}" is deprecated and will be removed in a future release. Please use "${alias.curr}" instead.`
         );


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Updates all instances of `expandedW` and `expandedH` in CardContent to `expandedWidth` and `expandedHeight` via the aliasing to ensure the previous property names still work but throw a deprecation warning if used.

This also adds a check to the console.warn in utils's `replaceAliasValues` to only print the warning if an instance of the old property was actually found.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
In the CardContent story's template, try setting the style of expandedW and expandedWidth, as well as expandedH and expandedHeight, and observe in the console that there are deprecation warnings for the old property names, but that all 4 still appropriately apply the new style. For example:
```js
          style: {
            expandedW: 1000,
            expandedH: 500
          }
```
vs
```js
          style: {
            expandedWidth: 1000,
            expandedHeight: 500
          }
```

and the warning:
```
The style property "expandedW" is deprecated and will be removed in a future release. Please use "expandedWidth" instead.
```

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
