### PR TITLE
feat(TextBox): allow defining whether or not texture should display after loading

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.d.ts
@@ -32,6 +32,7 @@ export default class TextBox extends Base {
   content?: string | TextContent[];
   fixed?: boolean;
   marquee?: boolean;
+  displayOnLoad?: boolean;
   get marqueeOverrideLoopX(): number;
   set marqueeOverrideLoopX(v: number);
   get style(): TextBoxStyle;

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.d.ts
@@ -32,7 +32,7 @@ export default class TextBox extends Base {
   content?: string | TextContent[];
   fixed?: boolean;
   marquee?: boolean;
-  displayOnLoad?: boolean;
+  hideOnLoad?: boolean;
   get marqueeOverrideLoopX(): number;
   set marqueeOverrideLoopX(v: number);
   get style(): TextBoxStyle;

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
@@ -67,7 +67,6 @@ export default class TextBox extends Base {
       'fixed',
       'marquee',
       'marqueeProps',
-      // 'displayOnLoad'
       'hideOnLoad'
     ];
   }

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
@@ -66,7 +66,9 @@ export default class TextBox extends Base {
       'content',
       'fixed',
       'marquee',
-      'marqueeProps'
+      'marqueeProps',
+      // 'displayOnLoad'
+      'hideOnLoad'
     ];
   }
 
@@ -87,7 +89,7 @@ export default class TextBox extends Base {
       }
 
       // Position updates can produce flash of poorly positioned content, hide the element until measurements are made.
-      if (this.alpha < 1) {
+      if (!this.hideOnLoad && this.alpha < 1) {
         this.alpha = 1;
       }
 

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.mdx
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.mdx
@@ -60,11 +60,12 @@ TextBox: {
 
 ### Properties
 
-| name    | type    | required | default   | description                                                |
-| ------- | ------- | -------- | --------- | ---------------------------------------------------------- |
-| content | string  | true     | undefined | Text to be displayed in element                            |
-| fixed   | boolean | false    | false     | If `true`, allows the width of the text to be set with `w` |
-| marquee | boolean | false    | false     | Allows text to be scrollable                               |
+| name       | type    | required | default   | description                                                                                                                                          |
+| ---------- | ------- | -------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| content    | string  | true     | undefined | Text to be displayed in element                                                                                                                      |
+| hideOnLoad | boolean | false    | undefined | If `true`, the component will not render as visible following the text texture loading. This allows manually controlling the alpha of the component. |
+| fixed      | boolean | false    | false     | If `true`, allows the width of the text to be set with `w`                                                                                           |
+| marquee    | boolean | false    | false     | Allows text to be scrollable                                                                                                                         |
 
 TextBox also supports rendering as an InlineContent component. See [InlineContent documentation](/docs/components-inlinecontent--basic) for table of supported properties.
 

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.stories.js
@@ -57,6 +57,7 @@ Basic.args = {
   content: lorum,
   marquee: false,
   fixed: true,
+  hideOnLoad: false,
   w: 600
 };
 
@@ -80,6 +81,15 @@ Basic.argTypes = {
     control: 'boolean',
     description:
       'Flag that when set to `true`, allows the width of the component to be set with `w`',
+    table: {
+      defaultValue: { summary: false }
+    }
+  },
+  hideOnLoad: {
+    control: 'boolean',
+    remount: true,
+    description:
+      'If `true`, the component will not render as visible following the text texture loading. This allows manually controlling the alpha of the component. The component will not render as visible if this is set to true.',
     table: {
       defaultValue: { summary: false }
     }

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.test.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.test.js
@@ -106,6 +106,34 @@ describe('TextBox', () => {
       textBox.smooth = { w: 100 };
       expect(warnMock.mock.calls.length).toBe(1);
     });
+
+    it('should default displaying text after the texture has loaded', async () => {
+      [textBox, testRenderer] = createTextBox(
+        {},
+        { spyOnMethods: ['_setDimensions'] }
+      );
+
+      expect(textBox.alpha).toBe(0.001);
+
+      textBox.content = 'text';
+      await textBox.__setDimensionsSpyPromise;
+
+      expect(textBox.alpha).toBe(1);
+    });
+
+    it('should allow not displaying text after the texture has loaded', async () => {
+      [textBox, testRenderer] = createTextBox(
+        { hideOnLoad: true },
+        { spyOnMethods: ['_setDimensions'] }
+      );
+
+      expect(textBox.alpha).toBe(0.001);
+
+      textBox.content = 'text';
+      await textBox.__setDimensionsSpyPromise;
+
+      expect(textBox.alpha).toBe(0.001);
+    });
   });
 
   describe('styling', () => {


### PR DESCRIPTION
## Description
Adds new property, `displayOnLoad`, which defines if the component should be visible after the text texture has loaded. To maintain current behavior, this property is defaulted to `true`.

**Related:** This property should be added to the updated TypeScript definition for this component once both are merged. https://github.com/rdkcentral/Lightning-UI-Components/pull/324


<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
The TextBox component stories should be unchanged.
Unit tests have been added to test this behavior, so the unit test suite should pass.
<!-- step by step instructions to review this PR's changes -->

## Automation
Resolves related issues caught by automation team.
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
