### PR TITLE
fix(Checkbox): update checkW and checkH to checkWidth and checkHeight

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Checkbox/Checkbox.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Checkbox/Checkbox.d.ts
@@ -26,8 +26,12 @@ type CheckboxStyle = {
   backgroundColor: Color;
   backgroundColorChecked: Color;
   checkColor: Color;
+  /** @deprecated */
   checkH: number;
+  checkHeight: number;
+  /** @deprecated */
   checkW: number;
+  checkWidth: number;
   checkSrc: string;
   radius: lng.Tools.CornerRadius;
   strokeColor: Color;

--- a/packages/@lightningjs/ui-components/src/components/Checkbox/Checkbox.js
+++ b/packages/@lightningjs/ui-components/src/components/Checkbox/Checkbox.js
@@ -54,6 +54,13 @@ export default class Checkbox extends Base {
     return ['checked'];
   }
 
+  static get aliasStyles() {
+    return [
+      { prev: 'checkH', curr: 'checkHeight' },
+      { prev: 'checkW', curr: 'checkWidth' }
+    ];
+  }
+
   _update() {
     this._updateBody();
     this._updateStroke();
@@ -67,8 +74,8 @@ export default class Checkbox extends Base {
 
   _updateCheck() {
     this._Check.patch({
-      w: this.style.checkW,
-      h: this.style.checkH,
+      w: this.style.checkWidth,
+      h: this.style.checkHeight,
       icon: this.style.checkSrc,
       style: { color: this.style.checkColor }
     });

--- a/packages/@lightningjs/ui-components/src/components/Checkbox/Checkbox.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Checkbox/Checkbox.mdx
@@ -65,9 +65,9 @@ class Example extends lng.Component {
 | backgroundColor        | string | color of Checkbox background when unchecked |
 | backgroundColorChecked | string | color of Checkbox background when checked   |
 | checkColor             | string | color of check icon                         |
-| checkH                 | number | height of check icon                        |
+| checkHeight            | number | height of check icon                        |
 | checkSrc               | string | path the icon to use for the checkmark      |
-| checkW                 | number | width of check icon                         |
+| checkWidth             | number | width of check icon                         |
 | radius                 | number | radius of Checkbox                          |
 | strokeColor            | string | color of the Checkbox border                |
 | strokeWidth            | number | width of Checkbox border                    |

--- a/packages/@lightningjs/ui-components/src/components/Checkbox/Checkbox.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/Checkbox/Checkbox.styles.js
@@ -23,8 +23,8 @@ export const base = theme => {
     alpha: theme.alpha.primary,
     width: size,
     height: size,
-    checkW: theme.spacer.lg,
-    checkH: theme.spacer.md + theme.spacer.xs,
+    checkWidth: theme.spacer.lg,
+    checkHeight: theme.spacer.md + theme.spacer.xs,
     checkSrc: theme.asset.check,
     radius: size / 2,
     strokeWidth

--- a/packages/@lightningjs/ui-components/src/components/Checkbox/CheckboxSmall.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/Checkbox/CheckboxSmall.styles.js
@@ -22,8 +22,8 @@ export const base = theme => {
   return {
     width: size,
     height: size,
-    checkW: theme.spacer.md,
-    checkH: theme.spacer.md + theme.spacer.xxs,
+    checkWidth: theme.spacer.md,
+    checkHeight: theme.spacer.md + theme.spacer.xxs,
     radius: size / 2,
     strokeWidth
   };


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
~~BLOCKED BY #356 (console warnings will not work correctly until that PR goes in)~~
Updates all instances of `checkW` and `checkH` in Checkbox to `checkWidth` and `checkHeight` via the aliasing to ensure the previous property names still work but throw a deprecation warning if used.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
In the Checkbox story's template, try setting the style of checkW and checkWidth, as well as checkH and checkHeight, and observe in the console that there are deprecation warnings for the old property names, but that all 4 still appropriately apply the new style. For example:
```js
          style: {
            checkW: 100,
            checkH: 100
          }
```
vs
```js
          style: {
            checkWidth: 200,
            checkHeight: 200
          }
```

and the warning:
```
The style property "checkW" is deprecated and will be removed in a future release. Please use "checkWidth" instead.
```

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
