### PR TITLE
fix(FocusManager): in handle methods, check if user passed in custom methods

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.js
+++ b/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.js
@@ -482,21 +482,29 @@ export default class FocusManager extends Base {
       class None extends this {},
       class Row extends this {
         _handleLeft() {
-          return this.selectPrevious();
+          return typeof this.onLeft === 'function'
+            ? this.onLeft(this)
+            : this.selectPrevious();
         }
 
         _handleRight() {
-          return this.selectNext();
+          return typeof this.onRight === 'function'
+            ? this.onRight(this)
+            : this.selectNext();
         }
       },
 
       class Column extends this {
         _handleUp() {
-          return this.selectPrevious();
+          return typeof this.onUp === 'function'
+            ? this.onUp(this)
+            : this.selectPrevious();
         }
 
         _handleDown() {
-          return this.selectNext();
+          return typeof this.onDown === 'function'
+            ? this.onDown(this)
+            : this.selectNext();
         }
       }
     ];

--- a/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.test.js
+++ b/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.test.js
@@ -230,6 +230,18 @@ describe('FocusManager', () => {
       const focusManager = testRenderer.getInstance();
       expect(focusManager.selectedIndex).toBe(1);
     });
+
+    it('should accept a custom onUp', () => {
+      focusManager.onUp = jest.fn();
+      testRenderer.keyPress('Up');
+      expect(focusManager.onUp).toHaveBeenCalled();
+    });
+
+    it('should accept a custom onDown', () => {
+      focusManager.onDown = jest.fn();
+      testRenderer.keyPress('Down');
+      expect(focusManager.onDown).toHaveBeenCalled();
+    });
   });
 
   describe('direction row', () => {
@@ -251,6 +263,18 @@ describe('FocusManager', () => {
       testRenderer.keyPress('Right');
       testRenderer.keyPress('Left');
       expect(focusManager.selectedIndex).toBe(1);
+    });
+
+    it('should accept a custom onLeft', () => {
+      focusManager.onLeft = jest.fn();
+      testRenderer.keyPress('Left');
+      expect(focusManager.onLeft).toHaveBeenCalled();
+    });
+
+    it('should accept a custom onRight', () => {
+      focusManager.onRight = jest.fn();
+      testRenderer.keyPress('Right');
+      expect(focusManager.onRight).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Due to [this thread](https://discord.com/channels/1020300788016353311/1118171618842255371), I noticed that there is no way to pass in custom handle logic for FocusManager components, so I followed the same process we use in components like Checkbox to check for a custom on[Key] method before executing our logic.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
Confirm all FocusManager/Column/Row stories are still working as expected and that in the stories, you can pass in custom logic, like:
```js
onLeft: () => console.log('custom left pressed!');
```

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
