### PR TITLE
fix(Key): update iconW and iconH to iconWidth and iconHeight

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Key/Key.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Key/Key.d.ts
@@ -31,8 +31,12 @@ type SizeObject = {
 type KeyStyle = ButtonStyle & {
   h: number;
   sizes: SizeObject;
+  /** @deprecated */
   iconW: number;
+  iconWidth: number;
+  /** @deprecated */
   iconH: number;
+  iconHeight: number;
 };
 
 declare namespace Key {

--- a/packages/@lightningjs/ui-components/src/components/Key/Key.js
+++ b/packages/@lightningjs/ui-components/src/components/Key/Key.js
@@ -74,6 +74,13 @@ export default class Key extends Button {
     return [...super.properties, 'icon', 'size', 'toggle'];
   }
 
+  static get aliasStyles() {
+    return [
+      { prev: 'iconH', curr: 'iconHeight' },
+      { prev: 'iconW', curr: 'iconWidth' }
+    ];
+  }
+
   _construct() {
     super._construct();
     this._size = 'sm';
@@ -96,8 +103,8 @@ export default class Key extends Button {
     this._prefix = {
       type: Icon,
       icon,
-      w: this.style.iconW,
-      h: this.style.iconH,
+      w: this.style.iconWidth,
+      h: this.style.iconHeight,
       ...props
     };
   }

--- a/packages/@lightningjs/ui-components/src/components/Key/Key.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Key/Key.mdx
@@ -62,14 +62,14 @@ class Basic extends lng.Component {
 
 ### Style Properties
 
-| name      | type             | description                                                                            |
-| --------- | ---------------- | -------------------------------------------------------------------------------------- |
-| iconW     | number           | width set to all icons                                                                 |
-| iconH     | number           | height set to all icons                                                                |
-| minWidth  | number           | used as a fallback width if no width is passed into the component and `fixed` is false |
-| paddingX  | number           | space between the button horizontal edge and the content                               |
-| sizes     | object           | used to determine the width of key, contains the properties `sm`, `md`, `lg`, `xl`     |
-| textStyle | string \| object | text style to apply to the title                                                       |
+| name       | type             | description                                                                            |
+| ---------- | ---------------- | -------------------------------------------------------------------------------------- |
+| iconWidth  | number           | width set to all icons                                                                 |
+| iconHeight | number           | height set to all icons                                                                |
+| minWidth   | number           | used as a fallback width if no width is passed into the component and `fixed` is false |
+| paddingX   | number           | space between the button horizontal edge and the content                               |
+| sizes      | object           | used to determine the width of key, contains the properties `sm`, `md`, `lg`, `xl`     |
+| textStyle  | string \| object | text style to apply to the title                                                       |
 
 ### Events
 

--- a/packages/@lightningjs/ui-components/src/components/Key/Key.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/Key/Key.styles.js
@@ -30,7 +30,7 @@ export const base = theme => {
       xl: theme.spacer.md * 47,
       xxl: theme.spacer.md * 95
     },
-    iconW: textStyle.lineHeight,
-    iconH: textStyle.lineHeight
+    iconWidth: textStyle.lineHeight,
+    iconHeight: textStyle.lineHeight
   };
 };


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
~~BLOCKED BY #356 (console warnings will not work correctly until that PR goes in)~~
Updates all instances of `iconW` and `iconH` in Key to `iconWidth` and `iconHeight` via the aliasing to ensure the previous property names still work but throw a deprecation warning if used.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
In the Key story's template, try setting the style of iconW and iconWidth, as well as iconH and iconHeight, and observe in the console that there are deprecation warnings for the old property names, but that all 4 still appropriately apply the new style. For example:
```js
          style: {
            iconW: 100,
            iconH: 100
          }
```
vs
```js
          style: {
            iconWidth: 200,
            iconHeight: 200
          }
```

and the warning:
```
The style property "iconW" is deprecated and will be removed in a future release. Please use "iconWidth" instead.
```

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
