### PR TITLE
fix(Tooltip): update pointerW and pointerH to pointerWidth and pointerHeight

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.d.ts
@@ -26,8 +26,12 @@ type TooltipStyle = {
   marginBottom: number;
   paddingX: number;
   paddingY: number;
+  /** @deprecated */
   pointerW: number;
+  pointerWidth: number;
+  /** @deprecated */
   pointerH: number;
+  pointerHeight: number;
   radius: lng.Tools.CornerRadius;
   textStyle: TextBoxStyle;
   transition: lng.types.TransitionSettings;

--- a/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.js
+++ b/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.js
@@ -55,6 +55,13 @@ export default class Tooltip extends Base {
     return ['Background', { name: 'Text', path: 'Background.Text' }];
   }
 
+  static get aliasStyles() {
+    return [
+      { prev: 'pointerH', curr: 'pointerHeight' },
+      { prev: 'pointerW', curr: 'pointerWidth' }
+    ];
+  }
+
   _update() {
     this._updateText();
   }
@@ -75,7 +82,7 @@ export default class Tooltip extends Base {
 
   _updateBackground() {
     const backgroundH =
-      this._Text.finalH + this.style.paddingY * 2 + this.style.pointerH;
+      this._Text.finalH + this.style.paddingY * 2 + this.style.pointerHeight;
     const backgroundW = this._Text.finalW + this.style.paddingX * 2;
 
     this.patch({
@@ -91,8 +98,8 @@ export default class Tooltip extends Base {
           w: backgroundW,
           h: backgroundH,
           radius: this.style.radius,
-          pointerW: this.style.pointerW,
-          pointerH: this.style.pointerH,
+          pointerWidth: this.style.pointerWidth,
+          pointerHeight: this.style.pointerHeight,
           color: this.style.backgroundColor
         }
       }
@@ -104,7 +111,7 @@ export default class Tooltip extends Base {
       this._Text.patch({
         mount: 0.5,
         x: this._Background.w / 2,
-        y: (this._Background.h - this.style.pointerH) / 2
+        y: (this._Background.h - this.style.pointerHeight) / 2
       });
     }
   }

--- a/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.mdx
@@ -85,8 +85,8 @@ Tooltip is only visible on focus of the parent.
 | marginBottom    | number                           | space below tooltip                                  |
 | paddingX        | number                           | space on left and right sides of tooltip text        |
 | paddingY        | number                           | space above and below tooltip text                   |
-| pointerW        | number                           | width of point beneath rounded rectangle of tooltip  |
-| pointerH        | number                           | height of point beneath rounded rectangle of tooltip |
+| pointerWidth    | number                           | width of point beneath rounded rectangle of tooltip  |
+| pointerHeight   | number                           | height of point beneath rounded rectangle of tooltip |
 | radius          | number \| array                  | radius of tooltip corners                            |
 | textStyle       | string \| object                 | text styles used for Tooltip's text                  |
 | transition      | <DocsLink id="lng.Transition" /> | transition to apply to text                          |

--- a/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.styles.js
@@ -20,8 +20,8 @@ export const base = theme => ({
   marginBottom: theme.spacer.xxxl,
   paddingX: theme.spacer.lg,
   paddingY: theme.spacer.md,
-  pointerW: theme.spacer.xl,
-  pointerH: theme.spacer.md + theme.spacer.xs,
+  pointerWidth: theme.spacer.xl,
+  pointerHeight: theme.spacer.md + theme.spacer.xs,
   radius: theme.radius.md,
   textStyle: {
     ...theme.typography.caption1,


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
~~BLOCKED BY #356 (console warnings will not work correctly until that PR goes in)~~
Updates all instances of `pointerW` and `pointerH` in Tooltip to `pointerWidth` and `pointerHeight` via the aliasing to ensure the previous property names still work but throw a deprecation warning if used.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
In the Tooltip story's template, try setting the style of pointerW and pointerWidth, as well as pointerH and pointerHeight, and observe in the console that there are deprecation warnings for the old property names, but that all 4 still appropriately apply the new style. For example:
```js
          style: {
            pointerW: 100,
            pointerH: 100
          }
```
vs
```js
          style: {
            pointerWidth: 200,
            pointerHeight: 200
          }
```

and the warning:
```
The style property "pointerW" is deprecated and will be removed in a future release. Please use "pointerWidth" instead.
```

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
