### PR TITLE
fix(Marquee): update fadeW to fadeWidth

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Marquee/Marquee.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Marquee/Marquee.d.ts
@@ -22,7 +22,9 @@ import { Color, StylePartial } from '../../types/lui';
 import { TextBoxStyle } from '../TextBox';
 
 type MarqueeStyle = {
+  /** @deprecated */
   fadeW: number;
+  fadeWidth: number;
   offset: number;
   shouldSmooth: boolean;
   textStyle: TextBoxStyle;

--- a/packages/@lightningjs/ui-components/src/components/Marquee/Marquee.js
+++ b/packages/@lightningjs/ui-components/src/components/Marquee/Marquee.js
@@ -73,6 +73,10 @@ export default class Marquee extends Base {
     ];
   }
 
+  static get aliasStyles() {
+    return [{ prev: 'fadeW', curr: 'fadeWidth' }];
+  }
+
   _construct() {
     super._construct();
     this._scrolling = false;
@@ -154,11 +158,11 @@ export default class Marquee extends Base {
 
   _updateShader() {
     this._ContentClipper.patch({
-      w: this.w > 0 ? this.w + this.style.fadeW / 2 : 0,
+      w: this.w > 0 ? this.w + this.style.fadeWidth / 2 : 0,
       shader: {
         type: FadeShader,
         positionLeft: 0,
-        positionRight: this.style.fadeW
+        positionRight: this.style.fadeWidth
       },
       rtt: true
     });
@@ -186,8 +190,8 @@ export default class Marquee extends Base {
           v: {
             sm: 0,
             0: { v: 0 },
-            0.1: { v: this.style.fadeW },
-            0.4: { v: this.style.fadeW },
+            0.1: { v: this.style.fadeWidth },
+            0.4: { v: this.style.fadeWidth },
             0.5: { v: 0 }
           }
         }
@@ -233,9 +237,9 @@ export default class Marquee extends Base {
   }
 
   get _shouldClip() {
-    // using fadeW / 4 so that if something like the last character is slightly
+    // using fadeWidth / 4 so that if something like the last character is slightly
     // faded out but still visible, we don't unnecessarily scroll
-    return this._textRenderedW > this.w - this.style.fadeW / 4;
+    return this._textRenderedW > this.w - this.style.fadeWidth / 4;
   }
 
   _shouldCenter() {

--- a/packages/@lightningjs/ui-components/src/components/Marquee/Marquee.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Marquee/Marquee.mdx
@@ -76,7 +76,7 @@ class Example extends lng.Component {
 
 | name         | type             | description                                                                              |
 | ------------ | ---------------- | ---------------------------------------------------------------------------------------- |
-| fadeW        | number           | Starting point of where fadeShader is applied                                            |
+| fadeWidth    | number           | Starting point of where fadeShader is applied                                            |
 | offset       | number           | Helps decide whether content should be clipped and where it should be positioned         |
 | shouldSmooth | boolean          | Determines whether things like centering should happen immediately or animate into place |
 | textStyle    | string \| object | text style to apply to the title                                                         |

--- a/packages/@lightningjs/ui-components/src/components/Marquee/Marquee.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/Marquee/Marquee.styles.js
@@ -17,7 +17,7 @@
  */
 
 export const base = theme => ({
-  fadeW: 100,
+  fadeWidth: 100,
   offset: theme.spacer.xxl,
   shouldSmooth: false,
   textStyle: theme.typography.body1


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
~~BLOCKED BY #356 (console warnings will not work correctly until that PR goes in)~~
Updates all instances of `fadeW` in Marquee to `fadeWidth` via the aliasing to ensure the previous property names still work but throw a deprecation warning if used.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
In the Marquee story's template, try setting the style of fadeW and fadeWidth, and observe in the console that there are deprecation warnings for the old property names, but that both still appropriately apply the new style. For example:
```js
          style: {
            fadeW: 100
          }
```
vs
```js
          style: {
            fadeWidth: 200
          }
```

and the warning:
```
The style property "fadeW" is deprecated and will be removed in a future release. Please use "fadeWidth" instead.
```

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
