### PR TITLE
fix(Button): remove all unused prefixH and suffixH values

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Button/ButtonSmall.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Button/ButtonSmall.d.ts
@@ -18,16 +18,10 @@
 
 import lng from '@lightningjs/core';
 import Button, { ButtonStyle } from './Button';
-import { StylePartial } from '../../types/lui';
-
-type ButtonSmallStyle = ButtonStyle;
 
 declare class ButtonSmall<
   TemplateSpec extends Button.TemplateSpec = Button.TemplateSpec,
   TypeConfig extends lng.Component.TypeConfig = lng.Component.TypeConfig
-> extends Button<TemplateSpec, TypeConfig> {
-  get style(): ButtonSmallStyle;
-  set style(v: StylePartial<ButtonSmallStyle>);
-}
+> extends Button<TemplateSpec, TypeConfig> {}
 
-export { ButtonSmall as default, ButtonSmallStyle };
+export { ButtonSmall as default, ButtonStyle };

--- a/packages/@lightningjs/ui-components/src/components/Button/ButtonSmall.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Button/ButtonSmall.d.ts
@@ -17,11 +17,11 @@
  */
 
 import lng from '@lightningjs/core';
-import Button, { ButtonStyle } from './Button';
+import Button from './Button';
 
 declare class ButtonSmall<
   TemplateSpec extends Button.TemplateSpec = Button.TemplateSpec,
   TypeConfig extends lng.Component.TypeConfig = lng.Component.TypeConfig
 > extends Button<TemplateSpec, TypeConfig> {}
 
-export { ButtonSmall as default, ButtonStyle };
+export default ButtonSmall;

--- a/packages/@lightningjs/ui-components/src/components/Button/ButtonSmall.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Button/ButtonSmall.d.ts
@@ -20,10 +20,7 @@ import lng from '@lightningjs/core';
 import Button, { ButtonStyle } from './Button';
 import { StylePartial } from '../../types/lui';
 
-type ButtonSmallStyle = ButtonStyle & {
-  prefixH: number;
-  suffixH: number;
-};
+type ButtonSmallStyle = ButtonStyle;
 
 declare class ButtonSmall<
   TemplateSpec extends Button.TemplateSpec = Button.TemplateSpec,

--- a/packages/@lightningjs/ui-components/src/components/Button/ButtonSmall.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/Button/ButtonSmall.styles.js
@@ -22,7 +22,5 @@ export const base = theme => ({
   height: theme.spacer.md * 8,
   minWidth: getWidthByColumnSpan(theme, 1),
   paddingX: theme.spacer.xxl,
-  prefixH: theme.spacer.xl,
-  suffixH: theme.spacer.xl,
   textStyle: theme.typography.button2
 });

--- a/packages/@lightningjs/ui-components/src/components/Control/Control.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Control/Control.d.ts
@@ -17,8 +17,7 @@
  */
 
 import type lng from '@lightningjs/core';
-import { ButtonSmallStyle } from '../Button/ButtonSmall';
-import Button from '../Button';
+import Button, { ButtonStyle } from '../Button';
 import { StylePartial } from '../../types/lui';
 
 type LogoStyleObject = {
@@ -27,7 +26,7 @@ type LogoStyleObject = {
   w: number;
 };
 
-type ControlStyle = ButtonSmallStyle & {
+type ControlStyle = ButtonStyle & {
   iconStyle: Record<string, unknown>;
   logoStyle: LogoStyleObject;
   radius: lng.Tools.CornerRadius;

--- a/packages/@lightningjs/ui-components/src/components/Control/Control.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/Control/Control.styles.js
@@ -36,7 +36,6 @@ export const base = theme => {
     minWidth: theme.spacer.md * 9,
     paddingX,
     paddingXNoTitle: theme.spacer.md,
-    prefixH: theme.spacer.md * 6,
     prefixPadding: theme.spacer.md,
     radius,
     titlePadding: theme.spacer.md

--- a/packages/@lightningjs/ui-components/src/components/Control/ControlSmall.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/Control/ControlSmall.styles.js
@@ -32,7 +32,6 @@ export const base = theme => {
       height: theme.spacer.md * 5,
       width: theme.spacer.md * 6
     },
-    prefixH: theme.spacer.md * 5,
     radius,
     minWidth: theme.spacer.md * 8,
     textStyle: theme.typography.button2

--- a/packages/@lightningjs/ui-components/src/components/Control/ControlSmall.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Control/ControlSmall.test.js
@@ -51,7 +51,6 @@ describe('ControlSmall', () => {
       expect.objectContaining({
         height: expect.any(Number),
         logoStyle: expect.any(Object),
-        prefixH: expect.any(Number),
         radius: expect.any(Number),
         textStyle: expect.any(Object),
         minWidth: expect.any(Number)

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.d.ts
@@ -32,7 +32,6 @@ type ListItemStyle = ButtonStyle & {
   descriptionTextStyle: TextBoxStyle;
   logoStyle: LogoStyleObject;
   paddingX: number;
-  prefixH: number;
   suffixH: number;
   titlePadding: number;
   titleTextStyle: TextBoxStyle;

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.mdx
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.mdx
@@ -73,7 +73,5 @@ class Basic extends lng.Component {
 | descriptionTextStyle | object | text style to apply to the description       |
 | logoStyle            | object | custom styling for the logo element          |
 | paddingX             | number | padding on left and right sides of text      |
-| prefixH              | number | height of prefix                             |
-| suffixH              | number | height of suffix                             |
 | titlePadding         | number | padding between title and prefix             |
 | titleTextStyle       | object | text style to apply to the title             |

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.styles.js
@@ -32,8 +32,6 @@ export const base = theme => ({
     radius: theme.radius.sm
   },
   paddingX: theme.spacer.xl,
-  prefixH: theme.spacer.xxxl + theme.spacer.xl,
-  suffixH: theme.spacer.xxxl + theme.spacer.xl,
   titlePadding: theme.spacer.lg,
   titleTextStyle: {
     ...theme.typography.headline3,


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
In scrubbing the library for other width/height values to alias, I found the prefixH and suffixH values as styles in all extensions of Button. These are completely unused and must have been a mistake in extending Button, or leftover for something we no longer support in Button. Button has getters for prefixW and suffixW that are shorthands to get the width of the component, but that should not be changed.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
Confirm that Button, ButtonSmall, Control, ControlSmall, and all ListItems seem to work and display the same way as before. Confirm no unit tests or snapshots have changed.

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
