### PR TITLE
fix: onMode method binding

### DIFF
--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
@@ -266,7 +266,7 @@ export default function withThemeStyles(Base, mixinStyle = {}) {
       if (typeof v !== 'string' || this._mode === v) return;
       this._mode = v;
       const event = this[`on${capitalizeFirstLetter(v)}`];
-      if (event && typeof event === 'function') event();
+      if (event && typeof event === 'function') event.call(this);
       this._styleManager.update();
     }
 


### PR DESCRIPTION
## Description

Currently when using the mode method hook ex.`onFocused || onUnfocused` you are unable to access the component with `this`. This PR adds the correct bindings

## Testing

When using _onFocused() {} on a component `this` should now reference the component instance itself.
