### PR TITLE
fix: update deep merge order for withThemeStyles

### DIFF
--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
@@ -405,14 +405,12 @@ export const generateComponentStyleSource = component => {
     for (const toneItem of [
       ...new Set(['neutral', ...Object.keys(tone), ...toneProperties])
     ]) {
-      let payload = clone(base, tone[toneItem]);
-      payload = clone(payload, overwrite);
-      payload = clone(payload, tone[toneItem]?.mode?.[modeItem] || {});
+      let payload = clone(base, overwrite);
+      payload = clone(payload, tone[toneItem]);
       payload = clone(payload, mode[modeItem]);
-      solution[modeItem + '_' + toneItem] = clone(
-        payload,
-        mode[modeItem]?.tone?.[toneItem] || {}
-      );
+      payload = clone(payload, tone[toneItem]?.mode?.[modeItem] || {});
+      payload = clone(payload, mode[modeItem]?.tone?.[toneItem] || {});
+      solution[modeItem + '_' + toneItem] = payload;
     }
   }
 


### PR DESCRIPTION
## Description

After the withThemeStyles refactor, the merge order of the styles is off. The styles should be applied in the following order:

1. tones
2. modes
3. tone-modes
4. mode-tones

Instead, modes seem to always take precedence over tone-modes. 

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
 Adding these rules to button should be a sufficient test. Should also work at the componentConfig level
  ```
class Button extends lng.Component {
    static _template() {
      return {
        Button: {
          type: ButtonComponent,
          style: {
            mode: {
              unfocused: {
                height: 50
              }
            },
            tone: {
              inverse: {
                mode: {
                  disabled: {
                    height: 500
                  }
                }
              },
              brand: {
                mode: {
                  unfocused: {
                    height: 10
                  }
                }
              }
            }
          }
        }
      };
    }
  }; 

```
