### PR TITLE
fix(InlineContent): ignore invalid maxLines numbers

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
@@ -444,6 +444,12 @@ export default class InlineContent extends Base {
     return this._customStyleMappings || {};
   }
 
+  _setMaxLines(maxLines) {
+    // only accept positive numbers
+    // round down any decimals to whole numbers
+    return maxLines >= 1 ? Math.floor(maxLines) : 0;
+  }
+
   get textHeight() {
     return this.style.textStyle.lineHeight || this.style.textStyle.fontSize;
   }


### PR DESCRIPTION
## Description
Update the setter for `maxLines` to only accept numbers that are greater than or equal to 1.
Numbers less than 1 will be ignored.
If a number with decimal values is passed in, it will be rounded down to the closest whole number.

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->
LUI-1046
## Testing
On `TextBox / With Inline Content String` story:
1. set `contentWrap: true`
2. set `maxLines` to any positive integer: that number of lines should be displayed
3. set `maxLines` to 0: no truncation should be applied and the full text renders
4. set `maxLines` to a negative number: no truncation should be applied and the full text renders
5. set `maxLines` to decimal number less than 1: no truncation should be applied and the full text renders
6. set `maxLines` to decimal number greater than 1: that number will be rounded down and display that number of lines (ex. 3.5 will render 3 lines)
<!-- step by step instructions to review this PR's changes -->

## Automation
Bug reported by automation. Verify it is resolved with this change.
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
