### PR TITLE
fix(Button): prevent repatching all prefix items on mode change

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Button/Button.js
+++ b/packages/@lightningjs/ui-components/src/components/Button/Button.js
@@ -114,10 +114,36 @@ export default class Button extends Surface {
         };
       }
       this._Content.patch({ Prefix: prefixPatch });
-      this._Prefix.items = this._addButtonProps(this.prefix);
+
+      /**
+       * Repatching all items re-renders all the components in the Prefix Row.
+       * This can cause items to shift while their layout in the Row is re-calculated if
+       * any of the items do not have width or height on their initial render (ex. an Icon
+       * does not have width and height until after its texture loads).
+       * If the contents of the Prefix are the same components and this update was triggered
+       * from something else (ex. a change in mode), only update the styles applied to the
+       * items in the Prefix (ex. updating the color to the value appropriate to the new mode).
+       */
+      const prefixString = JSON.stringify(this.prefix);
+      if (prefixString !== this._prevPrefix) {
+        this._prevPrefix = prefixString;
+        this._Prefix.items = this._addButtonProps(this.prefix);
+      } else {
+        this._updatePrefixStyles();
+      }
     } else {
       this._Content.patch({ Prefix: undefined });
     }
+  }
+
+  _updatePrefixStyles() {
+    this._Prefix.Items.children.forEach((item, idx) => {
+      item.color = this.prefix[idx].color;
+      item.style = {
+        ...item.style,
+        color: this.style.contentColor
+      };
+    });
   }
 
   _updateTitle() {


### PR DESCRIPTION
## Description
This issue was occurring due to re-patching all `items` to the prefix `Row` on each update. When `items` are patched to a `Row`, the row runs though its updates including `_updateLayout` which calculates the positions of each item in the row based on the dimensions of each item. `Icon` components do not  have `w` and `h` available until the icon texture has loaded, so both those values are 0 on the first iterations of `_updateLayout`, causing the icon and text to overlap.

This fix resolves this issue by preventing `items` from being re-patched (and triggering Row's layout updates) if the prefix items are the same as their previous value. If the values are the same, only styles will be updated on each item in the prefix array (ex. in response to something like `mode` changing).

## References
LUI-1027
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
On the `Button` story:
1. add a prefix icon
2. switch the mode between unfocused and focused
The text should not ever overlap the icon or shift as focus changes.
<!-- step by step instructions to review this PR's changes -->

## Automation
n/a
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
