### PR TITLE
feat(TextBox): export TextContent TS definition

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/TextBox/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/index.d.ts
@@ -16,6 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import TextBox, { TextBoxStyle } from './TextBox';
+import TextBox, { TextBoxStyle, TextContent } from './TextBox';
 
-export { TextBox as default, TextBoxStyle };
+export { TextBox as default, TextBoxStyle, TextContent };

--- a/packages/@lightningjs/ui-components/src/components/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/index.d.ts
@@ -89,7 +89,7 @@ export { default as Shadow, ShadowStyle } from './Shadow';
 export { default as Slider, SliderStyle } from './Slider';
 export { default as Surface, SurfaceStyle } from './Surface';
 export { default as TabBar, TabBarStyle, Tab, TabStyle } from './TabBar';
-export { default as TextBox, TextBoxStyle } from './TextBox';
+export { default as TextBox, TextBoxStyle, TextContent } from './TextBox';
 export { default as Tile, TileStyle } from './Tile';
 export { default as TitleRow, TitleRowStyle } from './TitleRow';
 export { default as Toggle, ToggleStyle } from './Toggle';


### PR DESCRIPTION
## Description
This exports the TextContent TypeScript definition from the TextBox component so that consuming applications have access to it.
<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References
LUI-976 (The component in this ticket currently just copies the definition. This change will allow importing it from here).
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
n/a
<!-- step by step instructions to review this PR's changes -->

## Automation
n/a
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax