### PR TITLE
fix(TabBar): update height if Tabs row height changes

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.js
@@ -142,6 +142,12 @@ export default class TabBar extends Base {
     });
   }
 
+  $itemChanged() {
+    // triggered when the Tabs Row resizes
+    // update the height of TabBar using the latest h value from Tabs
+    this._updateTabBarHeight();
+  }
+
   _updateTabBarHeight() {
     let h;
     if (this.collapse) {

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
@@ -128,7 +128,7 @@ describe('TabBar', () => {
     expect(tabBar._Tabs.items[1].mode).toBe('unfocused');
   });
 
-  it('should not repeatedly selecte the tabs when already selected', async () => {
+  it('should not repeatedly select the tabs when already selected', async () => {
     await tabBar.__updateSpyPromise;
     jest.spyOn(tabBar, '_updateTabs');
     expect(tabBar._updateTabs).not.toHaveBeenCalled();

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
@@ -128,6 +128,21 @@ describe('TabBar', () => {
     expect(tabBar._Tabs.items[1].mode).toBe('unfocused');
   });
 
+  it('should update the TabBar height if the Tabs height changes', async () => {
+    [tabBar, testRenderer] = createComponent(
+      { tabs },
+      { focused: true, spyOnMethods: ['$itemChanged'] }
+    );
+    await tabBar.__updateSpyPromise;
+    const initialHeight = tabBar.h;
+
+    // this triggers the Tabs Row to fire an $itemChanged signal
+    tabBar.tabs = [{ rect: true, h: initialHeight + 20, w: 200 }];
+    await tabBar._$itemChangedSpyPromise;
+
+    expect(tabBar.h).toBeGreaterThan(initialHeight);
+  });
+
   it('should not repeatedly select the tabs when already selected', async () => {
     await tabBar.__updateSpyPromise;
     jest.spyOn(tabBar, '_updateTabs');


### PR DESCRIPTION
## Description
`TabBar` relies on the height of `Tabs` (which is a `Row` component) when calculating its height. Prior to this change, if the height of the Tabs were to change, the TabBar's height did not update. This adds a listener for the `$itemChanged` signal fired from `NavigationManager` (parent class of `Row`) that will update the `TabBar` height if that `Row` height changes. 
<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References
LUI-877
LUI-882
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
On `TabBar / Basic` story:
1. inspect the DOM and note the height of the `TabBar`
2. navigate to another `TabBar` story and then back to `TabBar / Basic`
3. inspect the DoM again, the height of `TabBar` should be the same as the previously noted value
(prior to this change, the height in step 3 would not include the height of the Tabs Row)
<!-- step by step instructions to review this PR's changes -->

## Automation
Bug caught by Automation team. Update them for retest after merge.
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
