### PR TITLE
fix(Row): left Value consistent when scrolling past lazy scroll

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Row/Row.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.js
@@ -122,6 +122,7 @@ export default class Row extends NavigationManager {
       this.selectedIndex >= this.stopLazyScrollIndex &&
       this.selectedIndex < prevIndex
     ) {
+      // if navigating left on items after stop lazy scroll index
       const currItemsX = this.Items.x;
 
       return (
@@ -129,6 +130,16 @@ export default class Row extends NavigationManager {
         (this.prevSelected.w +
           this.style.itemSpacing +
           (this.selected.extraItemSpacing || 0))
+      );
+    } else if (prev && this.selectedIndex > this.stopLazyScrollIndex) {
+      // if navigating right on items after stop lazy scroll index
+      const prevX = prev.x;
+
+      return (
+        -prevX +
+        this.prevSelected.w +
+        this.style.itemSpacing +
+        (this.selected.extraItemSpacing || 0)
       );
     } else if (prev) {
       // otherwise, no start/stop indexes, perform normal lazy scroll
@@ -189,6 +200,7 @@ export default class Row extends NavigationManager {
           ? this._getLazyScrollX(prev)
           : this._getScrollX();
     }
+
     if (itemsContainerX !== undefined) {
       this.updatePositionOnAxis(this.Items, itemsContainerX);
     }


### PR DESCRIPTION
## Description

Within the Xfinity theme in the 'RowLazyScrollIndexes' component, when navigating to the final button (clicking the right key 11 times) inspecting the elements shows the Item container at a different x and left value every time it is run. This was resolved by having the scrolling after the stopLazyScroll index rely on the previous value rather than the selected value. This change the issue because for the last index the `this.selected.x` is not consistent when holding down right key (likely due to an animation not completing). This fix uses a different value for that index to keep consistency.

## References

LUI-1048

## Testing

- copy the Row.js file from this branch to node_modules in IS repo
     - path to where Row.js should be copied into 
        /lightning-ui/node_modules/@lightningjs/ui components/src/components/Row/Row.js
- install and run the application
- inspect the elements to migrate to the Items component of the row
     - Helpful for finding element in question: https://cim.slack.com/archives/G016H2NU946/p1695849090374869
- notice each time it is run, the left and x value of the Items within the Row is always the same at each position

<img width="943" alt="Screenshot 2023-09-26 at 12 24 58 PM" src="https://github.com/rdkcentral/Lightning-UI-Components/assets/89874756/3b022592-b9ea-45ce-b355-03d38767f342">
