### PR TITLE
fix(TitleRow): default autoResizeHeight to prevent infinite loop

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.js
+++ b/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.js
@@ -38,8 +38,7 @@ export default class TitleRow extends Row {
           textBoxChanged: '_titleLoaded'
         }
       },
-      ...super._template(),
-      autoResizeHeight: false
+      ...super._template()
     };
   }
 
@@ -55,10 +54,20 @@ export default class TitleRow extends Row {
     this._updateRow();
   }
 
+  _construct() {
+    super._construct();
+    this._autoResizeHeight = true;
+  }
+
   _update() {
     super._update();
     this._updateTitle();
     this._updateRow();
+  }
+
+  _autoResize() {
+    this.w = this.w || this.style.w;
+    this.h = this.autoResizeHeight ? this.Items.y + this.Items.h : this.h;
   }
 
   _updateTitle() {
@@ -79,10 +88,6 @@ export default class TitleRow extends Row {
   _updateRow() {
     this.Items.patch({
       y: this._Title.finalH + this.style.rowMarginTop
-    });
-    this.patch({
-      w: this.w || this.style.w,
-      h: this.Items.y + this.Items.h
     });
   }
 

--- a/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.mdx
+++ b/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.mdx
@@ -65,9 +65,10 @@ It allows setting all
 [properties, style properties, and child properties](/docs/components-row--basic#properties)
 supported by `Row`.
 
-| name  | type   | required | default   | description                                          |
-| ----- | ------ | -------- | --------- | ---------------------------------------------------- |
-| title | string | false    | undefined | The title text to be displayed above the `Row` items |
+| name             | type    | required | default   | description                                                                                           |
+| ---------------- | ------- | -------- | --------- | ----------------------------------------------------------------------------------------------------- |
+| autoResizeHeight | boolean | false    | true      | If true, the height of the TitleRow will be set to the height of the title, vertical padding, and row |
+| title            | string  | false    | undefined | The title text to be displayed above the `Row` items                                                  |
 
 ## Methods
 

--- a/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.test.js
+++ b/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.test.js
@@ -111,4 +111,37 @@ describe('TitleRow', () => {
       );
     });
   });
+
+  it('should by default resize the TitleRow to the total height of its contents', async () => {
+    [titleRow, testRenderer] = createComponent(
+      {
+        title: 'Title',
+        items
+      },
+      { spyOnMethods: ['_update', '_autoResize'] }
+    );
+
+    await titleRow._updateSpyPromise;
+    await titleRow.__autoResizeSpyPromise;
+
+    expect(titleRow.h).toBe(titleRow.Items.y + titleRow.Items.h);
+  });
+
+  it('should allow setting the height manually', async () => {
+    const h = 100;
+    [titleRow, testRenderer] = createComponent(
+      {
+        title: 'Title',
+        items,
+        autoResizeHeight: false,
+        h
+      },
+      { spyOnMethods: ['_update', '_autoResize'] }
+    );
+
+    await titleRow._updateSpyPromise;
+    await titleRow.__autoResizeSpyPromise;
+
+    expect(titleRow.h).toBe(h);
+  });
 });


### PR DESCRIPTION
## Description
Previous to this change, if `TitleRow.autoResizeHeight` was set to `true`, an infinite update loop would be triggered. This would happen because `TitleRow._updateRow` would set the `h` of `TitleRow` to one value (height of title + padding + height of tallest item in row) then `NavigationManager` (which TitleRow is a subclass of) would set the `h` to a different value (height of tallest item in row) which would trigger another update loop and repeat the process.

This change aims to make the TitleRow behave more similarly to the Row:
- `autoResizeHeight: true`: the TitleRow will set its `h` by adding up all the heights of its contents (title + padding + row)
- `autoResizeHeight: false`: the TitleRow will not calculate its height and must be set by the consumer
To maintain the current functionality of TitleRow resizing by default, `TitleRow.autoResizeHeight` is defaulted to `true`
<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References
LUI-941
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
n/a
<!-- step by step instructions to review this PR's changes -->

## Automation
n/a
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax