### PR TITLE
fix(Button): handle prefix arrays and objects with color updates

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Button/Button.js
+++ b/packages/@lightningjs/ui-components/src/components/Button/Button.js
@@ -138,7 +138,9 @@ export default class Button extends Surface {
 
   _updatePrefixStyles() {
     this._Prefix.Items.children.forEach((item, idx) => {
-      item.color = this.prefix[idx].color;
+      item.color = Array.isArray(this.prefix)
+        ? this.prefix[idx].color
+        : this.prefix.color;
       item.style = {
         ...item.style,
         color: this.style.contentColor


### PR DESCRIPTION
## Description
The change introduced in this https://github.com/rdkcentral/Lightning-UI-Components/pull/373 resolved an issue of prefix icons/badges flashing from getting re-patched and re-rendered. That change incorrectly assumed that `Button.prefix` would always be an array and relied on looking up an item by index on that array. `Button.prefix` also supports accepting an object. This change allows looking up the desired value for both prefix arrays and prefix objects.
<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
n/a - issue that prompted this is only visible in inner source repo
<!-- step by step instructions to review this PR's changes -->

## Automation
n/a
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
