### PR TITLE
fix(MetadataBase): rename subtitle property, tag, and style to details

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.d.ts
@@ -39,6 +39,10 @@ declare namespace MetadataBase {
      */
     description?: string;
     /**
+     * relevant content data in the middle
+     */
+    details?: string;
+    /**
      * logo to display at bottom of component
      */
     logo?: string;
@@ -63,9 +67,10 @@ declare namespace MetadataBase {
      */
     marquee?: boolean;
     /**
+     * @deprecated
      * relevant content data in the middle
      */
-    details?: string;
+    subtitle?: string;
     /**
      * first line or headline of the content
      */
@@ -92,6 +97,10 @@ declare class MetadataBase<
    */
   description?: string;
   /**
+   * relevant content data in the middle
+   */
+  details?: string;
+  /**
    * logo to display at bottom of component
    */
   logo?: string;
@@ -116,9 +125,10 @@ declare class MetadataBase<
    */
   marquee?: boolean;
   /**
+   * @deprecated
    * relevant content data in the middle
    */
-  details?: string;
+  subtitle?: string;
   /**
    * first line or headline of the content
    */

--- a/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.d.ts
@@ -28,7 +28,7 @@ type MetadataBaseStyle = {
   logoWidth: number;
   logoHeight: number;
   logoPadding: number;
-  subtitleTextStyle: TextBoxStyle;
+  detailsTextStyle: TextBoxStyle;
   titleTextStyle: TextBoxStyle;
 };
 
@@ -65,7 +65,7 @@ declare namespace MetadataBase {
     /**
      * relevant content data in the middle
      */
-    subtitle?: string;
+    details?: string;
     /**
      * first line or headline of the content
      */
@@ -118,7 +118,7 @@ declare class MetadataBase<
   /**
    * relevant content data in the middle
    */
-  subtitle?: string;
+  details?: string;
   /**
    * first line or headline of the content
    */
@@ -129,8 +129,8 @@ declare class MetadataBase<
 
   // Tags
   get _Title(): TextBox;
-  get _SubtitleWrapper(): TextBox;
-  get _Subtitle(): TextBox;
+  get _DetailsWrapper(): TextBox;
+  get _Details(): TextBox;
   get _Description(): TextBox;
   get _Logo(): Icon;
 }

--- a/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.js
@@ -42,11 +42,11 @@ class MetadataBase extends Base {
             textBoxChanged: '_titleLoaded'
           }
         },
-        SubtitleWrapper: {
-          Subtitle: {
+        DetailsWrapper: {
+          Details: {
             type: TextBox,
             signals: {
-              textBoxChanged: '_subtitleLoaded'
+              textBoxChanged: '_detailsLoaded'
             }
           }
         },
@@ -76,7 +76,7 @@ class MetadataBase extends Base {
       'logoPosition',
       'logoTitle',
       'logoWidth',
-      'subtitle',
+      'details',
       'title',
       'marquee'
     ];
@@ -90,12 +90,12 @@ class MetadataBase extends Base {
         path: 'Text.Title'
       },
       {
-        name: 'SubtitleWrapper',
-        path: 'Text.SubtitleWrapper'
+        name: 'DetailsWrapper',
+        path: 'Text.DetailsWrapper'
       },
       {
-        name: 'Subtitle',
-        path: 'Text.SubtitleWrapper.Subtitle'
+        name: 'Details',
+        path: 'Text.DetailsWrapper.Details'
       },
       {
         name: 'Description',
@@ -105,12 +105,20 @@ class MetadataBase extends Base {
     ];
   }
 
+  static get aliasStyles() {
+    return [{ prev: 'subtitleTextStyle', curr: 'detailsTextStyle' }];
+  }
+
+  static get aliasProperties() {
+    return [{ prev: 'subtitle', curr: 'details' }];
+  }
+
   _titleLoaded() {
     this._updateLayout();
   }
 
-  _subtitleLoaded({ w, h }) {
-    this._updateSubtitleLayout({ w, h });
+  _detailsLoaded({ w, h }) {
+    this._updateDetailsLayout({ w, h });
     this._updateLayout();
   }
 
@@ -118,10 +126,10 @@ class MetadataBase extends Base {
     this._updateLayout();
   }
 
-  _updateSubtitleLayout({ w, h }) {
-    this._SubtitleWrapper.alpha = this.style.alpha;
-    this._SubtitleWrapper.w = w;
-    this._SubtitleWrapper.h = h;
+  _updateDetailsLayout({ w, h }) {
+    this._DetailsWrapper.alpha = this.style.alpha;
+    this._DetailsWrapper.w = w;
+    this._DetailsWrapper.h = h;
   }
 
   _update() {
@@ -132,7 +140,7 @@ class MetadataBase extends Base {
   _updateLines() {
     this._Text.w = this._textW();
     this._updateTitle();
-    this._updateSubtitle();
+    this._updateDetails();
     this._updateDescription();
   }
 
@@ -185,13 +193,13 @@ class MetadataBase extends Base {
     }
   }
 
-  _updateSubtitle() {
-    this._Subtitle.patch({
-      content: this.subtitle,
-      style: { textStyle: this.style.subtitleTextStyle }
+  _updateDetails() {
+    this._Details.patch({
+      content: this.details,
+      style: { textStyle: this.style.detailsTextStyle }
     });
-    if (this._Subtitle.finalW > this._textW()) {
-      this._SubtitleWrapper.patch({
+    if (this._Details.finalW > this._textW()) {
+      this._Details.patch({
         w: this._textW() + this.style.fadeWidth / 2,
         shader: {
           type: FadeShader,
@@ -201,10 +209,10 @@ class MetadataBase extends Base {
         rtt: true
       });
     } else {
-      this._SubtitleWrapper.shader = undefined;
+      this._DetailsWrapper.shader = undefined;
     }
-    this._SubtitleWrapper.visible = this.subtitle ? true : false;
-    this._SubtitleWrapper.alpha = this.style.alpha;
+    this._DetailsWrapper.visible = this.details ? true : false;
+    this._DetailsWrapper.alpha = this.style.alpha;
   }
 
   _updateDescription() {
@@ -242,11 +250,11 @@ class MetadataBase extends Base {
 
   _textH() {
     const titleH = (this.title && this._Title && this._Title.h) || 0;
-    const subtitleH =
-      (this.subtitle && this._SubtitleWrapper && this._SubtitleWrapper.h) || 0;
+    const detailsH =
+      (this.details && this._DetailsWrapper && this._DetailsWrapper.h) || 0;
     const descriptionH =
       (this.description && this._Description && this._Description.h) || 0;
-    return titleH + subtitleH + descriptionH;
+    return titleH + detailsH + descriptionH;
   }
 
   _getLogoWidth() {
@@ -273,7 +281,7 @@ class MetadataBase extends Base {
     return [
       ...(this.title ? [this._Title] : []),
       ...(this.description ? [this._Description] : []),
-      ...(this.subtitle ? [this._Subtitle] : [])
+      ...(this.details ? [this._Details] : [])
     ];
   }
 
@@ -285,7 +293,7 @@ class MetadataBase extends Base {
     return (
       this._announce || [
         this._Title && this._Title.announce,
-        this._Subtitle && this._Subtitle.announce,
+        this._Details && this._Details.announce,
         this._Description && this._Description.announce,
         this.logoTitle
       ]

--- a/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.mdx
+++ b/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.mdx
@@ -44,7 +44,7 @@ class Example extends lng.Component {
         w: 400,
         h: 300,
         title: 'Title',
-        subtitle: [
+        details: [
           '94%',
           {
             icon: lightningbolt,
@@ -78,12 +78,12 @@ class Example extends lng.Component {
 | name         | type           | required             | default   | description                                  |
 | ------------ | -------------- | -------------------- | --------- | -------------------------------------------- |
 | description  | string         | false                | undefined | third line or description of the content     |
+| details      | inline content | false                | undefined | relevant content data in the middle          |
 | logo         | string         | false                | undefined | logo to display at bottom of component       |
 | logoHeight   | number         | true (if using logo) | undefined | height of logo                               |
 | logoPosition | string         | false                | 'right'   | which side to place logo (`right` or `left`) |
 | logoTitle    | string         | true (if using logo) | undefined | title of logo to use for announcer           |
 | logoWidth    | number         | true (if using logo) | undefined | width of logo                                |
-| subtitle     | inline content | false                | undefined | relevant content data in the middle          |
 | title        | string         | false                | undefined | first line or headline of the content        |
 
 ### Style Properties
@@ -91,9 +91,9 @@ class Example extends lng.Component {
 | name                 | type             | description                                                     |
 | -------------------- | ---------------- | --------------------------------------------------------------- |
 | descriptionTextStyle | string \| object | text style for description                                      |
+| detailsTextStyle     | string \| object | text style for details                                          |
 | fadeWidth            | number           | width of fade applied to second line if text encroaches on logo |
 | logoHeight           | number           | height for logo                                                 |
 | logoPadding          | number           | spacing between logo and secondLine                             |
 | logoWidth            | number           | width for logo                                                  |
-| subtitleTextStyle    | string \| object | text style for subtitle                                         |
 | titleTextStyle       | string \| object | text style for title                                            |

--- a/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.stories.js
@@ -50,7 +50,7 @@ MetadataBase.storyName = 'MetadataBase';
 MetadataBase.args = {
   w: 400,
   title: 'Title',
-  subtitle: [
+  details: [
     '94%',
     {
       icon: lightningbolt,
@@ -86,9 +86,9 @@ MetadataBase.argTypes = {
       defaultValue: { summary: 'undefined' }
     }
   },
-  subtitle: {
+  details: {
     control: 'object',
-    description: 'subtitle content',
+    description: 'details content',
     table: {
       defaultValue: { summary: 'undefined' }
     }

--- a/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.styles.js
@@ -22,7 +22,7 @@ export const base = theme => ({
   logoWidth: theme.typography.body3.lineHeight,
   logoHeight: theme.typography.body3.lineHeight,
   logoPadding: theme.spacer.lg,
-  subtitleTextStyle: theme.typography.body3,
+  detailsTextStyle: theme.typography.body3,
   titleTextStyle: { ...theme.typography.headline1, maxLines: 1 },
   marqueeSync: true,
   alpha: theme.alpha.primary
@@ -30,7 +30,7 @@ export const base = theme => ({
 
 export const mode = theme => ({
   disabled: {
-    subtitleTextStyle: { textColor: theme.color.textNeutralDisabled },
+    detailsTextStyle: { textColor: theme.color.textNeutralDisabled },
     alpha: theme.alpha.inactive
   }
 });
@@ -38,12 +38,12 @@ export const mode = theme => ({
 export const tone = theme => ({
   neutral: {
     titleTextStyle: { textColor: theme.color.textNeutral },
-    subtitleTextStyle: { textColor: theme.color.textNeutral },
+    detailsTextStyle: { textColor: theme.color.textNeutral },
     descriptionTextStyle: { textColor: theme.color.textNeutralSecondary },
     mode: {
       disabled: {
         titleTextStyle: { textColor: theme.color.textNeutralDisabled },
-        subtitleTextStyle: { textColor: theme.color.textNeutralDisabled },
+        detailsTextStyle: { textColor: theme.color.textNeutralDisabled },
         descriptionTextStyle: {
           textColor: theme.color.textNeutralDisabled
         }
@@ -52,12 +52,12 @@ export const tone = theme => ({
   },
   inverse: {
     titleTextStyle: { textColor: theme.color.textInverse },
-    subtitleTextStyle: { textColor: theme.color.textInverse },
+    detailsTextStyle: { textColor: theme.color.textInverse },
     descriptionTextStyle: { textColor: theme.color.textInverseSecondary },
     mode: {
       disabled: {
         titleTextStyle: { textColor: theme.color.textNeutralDisabled },
-        subtitleTextStyle: { textColor: theme.color.textNeutralDisabled },
+        detailsTextStyle: { textColor: theme.color.textNeutralDisabled },
         descriptionTextStyle: {
           textColor: theme.color.textNeutralDisabled
         }
@@ -66,12 +66,12 @@ export const tone = theme => ({
   },
   brand: {
     titleTextStyle: { textColor: theme.color.textNeutral },
-    subtitleTextStyle: { textColor: theme.color.textNeutral },
+    detailsTextStyle: { textColor: theme.color.textNeutral },
     descriptionTextStyle: { textColor: theme.color.textNeutralSecondary },
     mode: {
       disabled: {
         titleTextStyle: { textColor: theme.color.textNeutralDisabled },
-        subtitleTextStyle: { textColor: theme.color.textNeutralDisabled },
+        detailsTextStyle: { textColor: theme.color.textNeutralDisabled },
         descriptionTextStyle: {
           textColor: theme.color.textNeutralDisabled
         }

--- a/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.test.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.test.js
@@ -49,14 +49,14 @@ describe('MetadataBase', () => {
 
   it('sets the announce string to the appropriate text content status', () => {
     const title = 'Title';
-    const subtitle = 'Subtitle';
+    const details = 'Details';
     const description = 'Description';
     const logoTitle = 'Logo Title';
-    metadataBase.patch({ title, subtitle, description, logoTitle });
+    metadataBase.patch({ title, details, description, logoTitle });
     testRenderer.forceAllUpdates();
     expect(metadataBase.announce).toEqual([
       title,
-      subtitle,
+      details,
       description,
       logoTitle
     ]);
@@ -77,19 +77,19 @@ describe('MetadataBase', () => {
     expect(metadataBase._Title.content).toBe(title);
   });
 
-  it('updates the subtitle', async () => {
-    const subtitle = 'subtitle text';
-    expect(metadataBase.subtitle).toBe(undefined);
-    expect(metadataBase._SubtitleWrapper.h).toBe(0);
+  it('updates the details', async () => {
+    const details = 'details text';
+    expect(metadataBase.details).toBe(undefined);
+    expect(metadataBase._DetailsWrapper.h).toBe(0);
 
-    metadataBase.subtitle = subtitle;
+    metadataBase.details = details;
     await metadataBase.__updateSpyPromise;
     testRenderer.update();
 
-    expect(metadataBase._Subtitle.content).toBe(subtitle);
-    expect(metadataBase._Subtitle.h).toBeGreaterThan(0);
-    expect(metadataBase._SubtitleWrapper).toMatchObject({
-      h: metadataBase._Subtitle.h,
+    expect(metadataBase._Details.content).toBe(details);
+    expect(metadataBase._Details.h).toBeGreaterThan(0);
+    expect(metadataBase._DetailsWrapper).toMatchObject({
+      h: metadataBase._Details.h,
       alpha: 1
     });
   });
@@ -118,7 +118,7 @@ describe('MetadataBase', () => {
     [metadataBase, testRenderer] = createComponent(
       {},
       {
-        spyOnMethods: ['_update', '_subtitleLoaded']
+        spyOnMethods: ['_update', '_detailsLoaded']
       }
     );
 
@@ -128,10 +128,10 @@ describe('MetadataBase', () => {
     await metadataBase.__updateSpyPromise;
     expect(metadataBase.logo).toBe(logoPath);
 
-    const subtitle = 'secondLine text';
-    metadataBase.subtitle = subtitle;
+    const details = 'secondLine text';
+    metadataBase.details = details;
     await metadataBase.__updateSpyPromise;
-    await metadataBase.__subtitleLoadedSpyPromise;
+    await metadataBase.__detailsLoadedSpyPromise;
 
     const logoX = metadataBase.w - metadataBase.logoWidth;
     expect(metadataBase._Logo.x).toBe(logoX);

--- a/packages/@lightningjs/ui-components/src/components/MetadataBase/__snapshots__/MetadataBase.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/MetadataBase/__snapshots__/MetadataBase.test.js.snap
@@ -85,13 +85,13 @@ exports[`MetadataBase renders 1`] = `
           "y": 0,
           "zIndex": 0,
         },
-        "SubtitleWrapper": {
+        "DetailsWrapper": {
           "active": false,
           "alpha": 1,
           "attached": true,
           "boundsMargin": null,
           "children": {
-            "Subtitle": {
+            "Details": {
               "active": false,
               "alpha": 0.001,
               "attached": true,
@@ -111,7 +111,7 @@ exports[`MetadataBase renders 1`] = `
               "pivot": 0.5,
               "pivotX": 0.5,
               "pivotY": 0.5,
-              "ref": "Subtitle",
+              "ref": "Details",
               "renderOfScreen": undefined,
               "renderToTexture": false,
               "scale": 1,
@@ -120,7 +120,7 @@ exports[`MetadataBase renders 1`] = `
               "state": "",
               "tag": [Function],
               "tags": [
-                "Subtitle",
+                "Details",
               ],
               "type": "TextBox",
               "visible": true,
@@ -143,7 +143,7 @@ exports[`MetadataBase renders 1`] = `
           "pivot": 0.5,
           "pivotX": 0.5,
           "pivotY": 0.5,
-          "ref": "SubtitleWrapper",
+          "ref": "DetailsWrapper",
           "renderOfScreen": undefined,
           "renderToTexture": false,
           "scale": 1,
@@ -152,7 +152,7 @@ exports[`MetadataBase renders 1`] = `
           "state": undefined,
           "tag": [Function],
           "tags": [
-            "SubtitleWrapper",
+            "DetailsWrapper",
           ],
           "visible": false,
           "w": 0,

--- a/packages/@lightningjs/ui-components/src/components/MetadataCard/MetadataCard.mdx
+++ b/packages/@lightningjs/ui-components/src/components/MetadataCard/MetadataCard.mdx
@@ -41,7 +41,7 @@ class Basic extends lng.Component {
         type: MetadataCard,
         w: args.w,
         title: args.title,
-        subtitle: args.subtitle,
+        details: args.details,
         description: args.description,
         logo: args.logo !== 'none' ? circle : null,
         logoTitle: args.logo !== 'none' ? args.logoTitle : null,
@@ -63,12 +63,12 @@ class Basic extends lng.Component {
 | name         | type           | required             | default   | description                                  |
 | ------------ | -------------- | -------------------- | --------- | -------------------------------------------- |
 | description  | string         | false                | undefined | third line or description of the content     |
+| details      | inline content | false                | undefined | relevant content data in the middle          |
 | logo         | string         | false                | undefined | logo to display at bottom of component       |
 | logoHeight   | number         | true (if using logo) | undefined | height of logo                               |
 | logoPosition | string         | false                | 'right'   | which side to place logo (`right` or `left`) |
 | logoTitle    | string         | true (if using logo) | undefined | title of logo to use for announcer           |
 | logoWidth    | number         | true (if using logo) | undefined | width of logo                                |
-| subtitle     | inline content | false                | undefined | relevant content data in the middle          |
 | title        | string         | false                | undefined | first line or headline of the content        |
 
 ### Style Properties
@@ -80,5 +80,5 @@ class Basic extends lng.Component {
 | logoHeight           | number           | height for logo                                                 |
 | logoPadding          | number           | spacing between logo and secondLine                             |
 | logoWidth            | number           | width for logo                                                  |
-| subtitleTextStyle    | string \| object | text style for subtitle                                         |
+| detailsTextStyle     | string \| object | text style for details                                          |
 | titleTextStyle       | string \| object | text style for title                                            |

--- a/packages/@lightningjs/ui-components/src/components/MetadataCard/MetadataCard.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataCard/MetadataCard.stories.js
@@ -49,7 +49,7 @@ MetadataCard.storyName = 'MetadataCard';
 MetadataCard.args = {
   w: 400,
   title: 'Title',
-  subtitle: [
+  details: [
     '94%',
     {
       icon: lightningbolt,
@@ -85,9 +85,9 @@ MetadataCard.argTypes = {
       defaultValue: { summary: 'undefined' }
     }
   },
-  subtitle: {
+  details: {
     control: 'text',
-    description: 'Subtitle content',
+    description: 'Details content',
     table: {
       defaultValue: {
         summary: 'undefined'

--- a/packages/@lightningjs/ui-components/src/components/MetadataTile/MetadataTile.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataTile/MetadataTile.js
@@ -28,24 +28,24 @@ export default class MetadataTile extends MetadataBase {
     return styles;
   }
 
-  _updateSubtitle() {
+  _updateDetails() {
     if (this.description) {
-      this._Subtitle.patch({ content: '' });
-      this._Subtitle.alpha = 0;
-      this._Subtitle.visible = false;
+      this._Details.patch({ content: '' });
+      this._Details.alpha = 0;
+      this._Details.visible = false;
     } else {
-      this._Subtitle.alpha = 1;
-      this._Subtitle.visible = true;
-      super._updateSubtitle();
+      this._Details.alpha = 1;
+      this._Details.visible = true;
+      super._updateDetails();
     }
   }
 
-  _updateSubtitleLayout({ h }) {
-    if (this.subtitle && !this.description) {
-      this._SubtitleWrapper.h = h;
-      this._SubtitleWrapper.alpha = this.style.alpha;
+  _updateDetailsLayout({ h }) {
+    if (this._Details && !this.description) {
+      this._DetailsWrapper.h = h;
+      this._DetailsWrapper.alpha = this.style.alpha;
     } else {
-      this._SubtitleWrapper.h = 0;
+      this._DetailsWrapper.h = 0;
     }
   }
 
@@ -57,7 +57,7 @@ export default class MetadataTile extends MetadataBase {
     return (
       this._announce || [
         this._Title && this._Title.announce,
-        (this._Subtitle && this._Subtitle.announce) ||
+        (this._Details && this._Details.announce) ||
           (this._Description && this._Description.announce),
         this.logoTitle
       ]
@@ -66,14 +66,14 @@ export default class MetadataTile extends MetadataBase {
 
   _textH() {
     const titleH = (this.title && this._Title && this._Title.h) || 0;
-    const subtitleH =
-      (this.subtitle &&
-        this._Subtitle &&
-        this._Subtitle.visible &&
-        this._SubtitleWrapper.h) ||
+    const detailsH =
+      (this.details &&
+        this._Details &&
+        this._Details.visible &&
+        this._DetailsWrapper.h) ||
       0;
     const descriptionH =
       (this.description && this._Description && this._Description.h) || 0;
-    return titleH + subtitleH + descriptionH;
+    return titleH + detailsH + descriptionH;
   }
 }

--- a/packages/@lightningjs/ui-components/src/components/MetadataTile/MetadataTile.mdx
+++ b/packages/@lightningjs/ui-components/src/components/MetadataTile/MetadataTile.mdx
@@ -29,7 +29,7 @@ https://github.com/rdkcentral/Lightning-UI-Components/blob/develop/packages/@lig
 
 ## Usage
 
-MetadataTile can be used with title (text), subtitle (inline content) or description (text), and/or a logo.
+MetadataTile can be used with title (text), details (inline content) or description (text), and/or a logo.
 
 ```js
 import { MetadataTile } from '@lightningjs/ui-components';
@@ -44,7 +44,7 @@ class Example extends lng.Component {
         w: 400,
         h: 300,
         title: 'Title',
-        subtitle: [
+        details: [
           '94%',
           {
             icon: lightningbolt,
@@ -76,13 +76,13 @@ class Example extends lng.Component {
 
 | name         | type           | required             | default   | description                                                             |
 | ------------ | -------------- | -------------------- | --------- | ----------------------------------------------------------------------- |
-| description  | string         | false                | undefined | description text to place under title (hides subtitle)                  |
+| description  | string         | false                | undefined | description text to place under title (hides details)                   |
+| details      | inline content | false                | undefined | relevant content data in the middle (hidden if description is provided) |
 | logo         | string         | false                | undefined | logo to display at bottom of component                                  |
 | logoHeight   | number         | true (if using logo) | undefined | height of logo                                                          |
 | logoPosition | string         | false                | 'right'   | which side to place logo (`right` or `left`)                            |
 | logoTitle    | string         | true (if using logo) | undefined | title of logo to use for announcer                                      |
 | logoWidth    | number         | true (if using logo) | undefined | width of logo                                                           |
-| subtitle     | inline content | false                | undefined | relevant content data in the middle (hidden if description is provided) |
 | title        | string         | false                | undefined | first line or headline of the content                                   |
 
 ### Style Properties
@@ -94,5 +94,5 @@ class Example extends lng.Component {
 | logoHeight           | number           | height for logo                                                 |
 | logoPadding          | number           | spacing between logo and secondLine                             |
 | logoWidth            | number           | width for logo                                                  |
-| subtitleTextStyle    | string \| object | text style for subtitle                                         |
+| detailsTextStyle     | string \| object | text style for details                                          |
 | titleTextStyle       | string \| object | text style for title                                            |

--- a/packages/@lightningjs/ui-components/src/components/MetadataTile/MetadataTile.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataTile/MetadataTile.stories.js
@@ -42,7 +42,7 @@ export const MetadataTile = args =>
           type: MetadataTileComponent,
           w: args.w,
           title: args.title,
-          subtitle: args.subtitle,
+          details: args.details,
           description: args.description,
           logo: args.logo !== 'none' ? circle : null,
           logoTitle: args.logo !== 'none' ? args.logoTitle : null,
@@ -61,7 +61,7 @@ MetadataTile.storyName = 'MetadataTile';
 MetadataTile.args = {
   w: 400,
   title: 'Title',
-  subtitle: [
+  details: [
     '94%',
     {
       icon: lightningbolt,
@@ -97,7 +97,7 @@ MetadataTile.argTypes = {
       defaultValue: { summary: 'undefined' }
     }
   },
-  subtitle: {
+  details: {
     control: 'object',
     table: {
       defaultValue: { summary: 'undefined' }

--- a/packages/@lightningjs/ui-components/src/components/MetadataTile/MetadataTile.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataTile/MetadataTile.styles.js
@@ -23,11 +23,11 @@ export const base = theme => ({
 
 export const tone = theme => ({
   neutral: {
-    subtitleTextStyle: { textColor: theme.color.textNeutralSecondary },
+    detailsTextStyle: { textColor: theme.color.textNeutralSecondary },
     descriptionTextStyle: { textColor: theme.color.textNeutral },
     mode: {
       disabled: {
-        subtitleTextStyle: { textColor: theme.color.textNeutralDisabled },
+        detailsTextStyle: { textColor: theme.color.textNeutralDisabled },
         descriptionTextStyle: {
           textColor: theme.color.textNeutralDisabled
         }
@@ -35,11 +35,11 @@ export const tone = theme => ({
     }
   },
   inverse: {
-    subtitleTextStyle: { textColor: theme.color.textInverseSecondary },
+    detailsTextStyle: { textColor: theme.color.textInverseSecondary },
     descriptionTextStyle: { textColor: theme.color.textInverse },
     mode: {
       disabled: {
-        subtitleTextStyle: { textColor: theme.color.textNeutralDisabled },
+        detailsTextStyle: { textColor: theme.color.textNeutralDisabled },
         descriptionTextStyle: {
           textColor: theme.color.textNeutralDisabled
         }
@@ -47,11 +47,11 @@ export const tone = theme => ({
     }
   },
   brand: {
-    subtitleTextStyle: { textColor: theme.color.textNeutralSecondary },
+    detailsTextStyle: { textColor: theme.color.textNeutralSecondary },
     descriptionTextStyle: { textColor: theme.color.textNeutral },
     mode: {
       disabled: {
-        subtitleTextStyle: { textColor: theme.color.textNeutralDisabled },
+        detailsTextStyle: { textColor: theme.color.textNeutralDisabled },
         descriptionTextStyle: {
           textColor: theme.color.textNeutralDisabled
         }

--- a/packages/@lightningjs/ui-components/src/components/MetadataTile/MetadataTile.test.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataTile/MetadataTile.test.js
@@ -31,7 +31,7 @@ describe('MetadataTile', () => {
     [metadataTile, testRenderer] = createComponent(
       {},
       {
-        spyOnMethods: ['_update', '_subtitleLoaded']
+        spyOnMethods: ['_update', '_detailsLoaded']
       }
     );
   });
@@ -47,13 +47,13 @@ describe('MetadataTile', () => {
 
   it('sets the announce string to the appropriate text content status', () => {
     const title = 'Title';
-    const subtitle = 'Subtitle';
+    const details = 'Details';
     const description = 'Description';
     const logoTitle = 'Logo Title';
-    metadataTile.patch({ title, subtitle, logoTitle });
+    metadataTile.patch({ title, details, logoTitle });
     testRenderer.forceAllUpdates();
-    expect(metadataTile.announce).toEqual([title, subtitle, logoTitle]);
-    metadataTile.patch({ title, subtitle: undefined, description, logoTitle });
+    expect(metadataTile.announce).toEqual([title, details, logoTitle]);
+    metadataTile.patch({ title, details: undefined, description, logoTitle });
     testRenderer.forceAllUpdates();
     expect(metadataTile.announce).toEqual([title, description, logoTitle]);
   });
@@ -65,26 +65,26 @@ describe('MetadataTile', () => {
     expect(metadataTile.announce).toBe(overrideString);
   });
 
-  it('hides subtitle if description is provided', async () => {
-    metadataTile.subtitle = 'subtitle';
+  it('hides details if description is provided', async () => {
+    metadataTile.details = 'details';
     await metadataTile.__updateSpyPromise;
-    expect(metadataTile._Subtitle.alpha).toBe(1);
-    expect(metadataTile._Subtitle.visible).toBe(true);
+    expect(metadataTile._Details.alpha).toBe(1);
+    expect(metadataTile._Details.visible).toBe(true);
     metadataTile.description = 'description';
     await metadataTile.__updateSpyPromise;
-    expect(metadataTile._Subtitle.alpha).toBe(0);
-    expect(metadataTile._Subtitle.visible).toBe(false);
-    expect(metadataTile._SubtitleWrapper.h).toBe(0);
+    expect(metadataTile._Details.alpha).toBe(0);
+    expect(metadataTile._Details.visible).toBe(false);
+    expect(metadataTile._DetailsWrapper.h).toBe(0);
   });
 
-  it('should render a subtitle', async () => {
-    const subtitle = 'subtitle text';
-    expect(metadataTile._SubtitleWrapper.h).toBe(0);
-    metadataTile.subtitle = subtitle;
-    await metadataTile.__subtitleLoadedSpyPromise;
+  it('should render details', async () => {
+    const details = 'details text';
+    expect(metadataTile._DetailsWrapper.h).toBe(0);
+    metadataTile.details = details;
+    await metadataTile.__detailsLoadedSpyPromise;
     testRenderer.forceAllUpdates();
-    expect(metadataTile._Subtitle.content).toBe(subtitle);
-    expect(metadataTile._SubtitleWrapper.h).toBeGreaterThan(0);
-    expect(metadataTile._SubtitleWrapper.alpha).toBe(1);
+    expect(metadataTile._Details.content).toBe(details);
+    expect(metadataTile._DetailsWrapper.h).toBeGreaterThan(0);
+    expect(metadataTile._DetailsWrapper.alpha).toBe(1);
   });
 });

--- a/packages/@lightningjs/ui-components/src/components/MetadataTile/__snapshots__/MetadataTile.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/MetadataTile/__snapshots__/MetadataTile.test.js.snap
@@ -85,13 +85,13 @@ exports[`MetadataTile renders 1`] = `
           "y": 0,
           "zIndex": 0,
         },
-        "SubtitleWrapper": {
+        "DetailsWrapper": {
           "active": false,
           "alpha": 1,
           "attached": true,
           "boundsMargin": null,
           "children": {
-            "Subtitle": {
+            "Details": {
               "active": false,
               "alpha": 1,
               "attached": true,
@@ -111,7 +111,7 @@ exports[`MetadataTile renders 1`] = `
               "pivot": 0.5,
               "pivotX": 0.5,
               "pivotY": 0.5,
-              "ref": "Subtitle",
+              "ref": "Details",
               "renderOfScreen": undefined,
               "renderToTexture": false,
               "scale": 1,
@@ -120,7 +120,7 @@ exports[`MetadataTile renders 1`] = `
               "state": "",
               "tag": [Function],
               "tags": [
-                "Subtitle",
+                "Details",
               ],
               "type": "TextBox",
               "visible": true,
@@ -143,7 +143,7 @@ exports[`MetadataTile renders 1`] = `
           "pivot": 0.5,
           "pivotX": 0.5,
           "pivotY": 0.5,
-          "ref": "SubtitleWrapper",
+          "ref": "DetailsWrapper",
           "renderOfScreen": undefined,
           "renderToTexture": false,
           "scale": 1,
@@ -152,7 +152,7 @@ exports[`MetadataTile renders 1`] = `
           "state": undefined,
           "tag": [Function],
           "tags": [
-            "SubtitleWrapper",
+            "DetailsWrapper",
           ],
           "visible": false,
           "w": 0,

--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.mdx
@@ -80,7 +80,7 @@ class Basic extends lng.Component {
         metadata: {
           type: MetadataCard
           title: 'Title',
-          subtitle: 'Subtitle'
+          details: 'Details'
         }
       }
     };


### PR DESCRIPTION
## Description

Renames `subtitle` property, tag, and relevant styles in Metadata components to `details`.

## References

LUI-1040

## Testing

All components should continue functioning exactly the same.

## Automation

The Subtitle tag has been replaced with Description, so some tests may need to be updated, as the path has changed.

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
