### PR TITLE
fix: change replaceAll to RegExp for compatibility with older devices

### DIFF
--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
@@ -627,7 +627,10 @@ export const replaceAliasValues = (value, aliasStyles = []) => {
         console.warn(
           `The style property "${alias.prev}" is deprecated and will be removed in a future release. Please use "${alias.curr}" instead.`
         );
-        str = str.replace(new RegExp(`"${alias.prev}":`, 'gi'), `"${alias.curr}":`);
+      str = str.replace(
+        new RegExp(`"${alias.prev}":`, 'gi'),
+        `"${alias.curr}":`
+      );
     }
   });
   return JSON.parse(str);

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
@@ -627,7 +627,7 @@ export const replaceAliasValues = (value, aliasStyles = []) => {
         console.warn(
           `The style property "${alias.prev}" is deprecated and will be removed in a future release. Please use "${alias.curr}" instead.`
         );
-      str = str.replaceAll(`"${alias.prev}":`, `"${alias.curr}":`);
+        str = str.replace(new RegExp(`"${alias.prev}":`, 'gi'), `"${alias.curr}":`);
     }
   });
   return JSON.parse(str);


### PR DESCRIPTION
Solves issue experiences on older devices as outlined in this thread https://discord.com/channels/1020300788016353311/1156684431617175632

## Description

Changed replaceAll to RegExp so LUI will run on older STB

## References

[<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->](https://ccp.sys.comcast.net/browse/LUI-1109)

## Testing

style aliases ex. `w = width` should still function as they did with the previous implementation 