### PR TITLE
fix(gitignore): add .gitignore to themePropertyTables directory

### DIFF
--- a/packages/apps/lightning-ui-docs/scripts/themePropertyTables/.gitignore
+++ b/packages/apps/lightning-ui-docs/scripts/themePropertyTables/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
## Description

Adds a `.gitignore` to the `themePropertyTables` directory to ensure that the directory always exists, but files within it continue to be ignored.

The error, up until now, was that the directory did not exist by the time the runner attempted to write the files.

## References

LUI-849

## Testing

Will have to check to make sure that Actions no longer fail when trying to write `color.md`.

## Automation

N/A

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
