### PR TITLE
fix(TitleRow): alias rowMarginTop to titleMarginBottom

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.d.ts
@@ -34,6 +34,8 @@ type TitleRowStyle = NavigationManagerStyle & {
   w: number;
   titleMarginLeft: number;
   titleTextStyle: TextBoxStyle;
+  titleMarginBottom: number;
+  /** @deprecated */
   rowMarginTop: number;
 };
 

--- a/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.js
+++ b/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.js
@@ -91,7 +91,7 @@ export default class TitleRow extends Row {
 
   _updateRow() {
     this.Items.patch({
-      y: this._Title.finalH + this.style.titleMarginBottom
+      y: this.title ? this._Title.finalH + this.style.titleMarginBottom : 0
     });
   }
 

--- a/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.js
+++ b/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.js
@@ -50,6 +50,10 @@ export default class TitleRow extends Row {
     return [...super.tags, 'Title'];
   }
 
+  static get aliasStyles() {
+    return [{ prev: 'rowMarginTop', curr: 'titleMarginBottom' }];
+  }
+
   _titleLoaded() {
     this._updateRow();
   }
@@ -87,7 +91,7 @@ export default class TitleRow extends Row {
 
   _updateRow() {
     this.Items.patch({
-      y: this._Title.finalH + this.style.rowMarginTop
+      y: this._Title.finalH + this.style.titleMarginBottom
     });
   }
 

--- a/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.styles.js
@@ -25,7 +25,7 @@ export const base = theme => ({
     ...theme.typography.headline1,
     textColor: theme.color.textNeutral
   },
-  rowMarginTop: theme.spacer.lg
+  titleMarginBottom: theme.spacer.lg
 });
 
 export const tone = theme => ({

--- a/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.test.js
+++ b/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.test.js
@@ -102,12 +102,12 @@ describe('TitleRow', () => {
           spyOnMethods: ['_titleLoaded']
         }
       );
-      expect(titleRow._Items.y).toBe(titleRow.style.rowMarginTop);
+      expect(titleRow._Items.y).toBe(titleRow.style.titleMarginBottom);
 
       await titleRow.__titleLoadedSpyPromise;
 
       expect(titleRow._Items.y).toBe(
-        titleRow._Title.finalH + titleRow.style.rowMarginTop
+        titleRow._Title.finalH + titleRow.style.titleMarginBottom
       );
     });
   });


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Updating rowMarginTop to titleMarginBottom to be more inline with other title props and Rail components.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
1. In the TitleRow component story, confirm the "titleMarginBottom" style property updates the spacing between title and content.
2. Confirm the "rowMarginTop" style property also updates the above and throws a deprecation warning about it.

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
