### PR TITLE
fix(TabBar): propogate key press events and emit tabChanged signal

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.js
@@ -62,7 +62,8 @@ export default class TabBar extends Base {
     this._isTabsFocused = true;
   }
 
-  _selectedTabChange() {
+  _selectedTabChange(selected, prevSelected) {
+    this.fireAncestors('$tabChanged', selected, prevSelected, this);
     if (
       typeof this._tabContent === 'object' &&
       typeof this._tabContent.then === 'function'

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.js
@@ -179,10 +179,12 @@ export default class TabBar extends Base {
       this._updateTabs();
       this._updateTabBarHeight();
     }
+    return false;
   }
 
   _handleUp() {
     this.selectTabs();
+    return false;
   }
 
   _setTabs(tabs) {

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.mdx
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.mdx
@@ -107,6 +107,14 @@ class Example extends lng.Component {
 
 \* `TabBar` also accepts all properties supported by the [Row](/docs/components-row--basic) component. These properties will be applied to the Row which renders the Tabs
 
+### Signals
+
+- `$tabChanged`: each time the selected tab is changed, a signal named `$tabChanged` is emitted (via `fireAncestors`) with 3 arguments in the following order: the current selected tab, the previously selected tab, and an instance of the TabBar component
+
+```js
+fireAncestors('$tabChanged', selected, prevSelected, this);
+```
+
 ### Style Properties
 
 | name             | type   | description                                  |

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import lng from '@lightningjs/core';
 import { makeCreateComponent } from '@lightningjs/ui-components-test-utils';
 import Row from '../Row';
 import Tile from '../Tile';
@@ -126,6 +127,41 @@ describe('TabBar', () => {
 
     expect(tabBar._Tabs.items[0].mode).toBe('focused');
     expect(tabBar._Tabs.items[1].mode).toBe('unfocused');
+  });
+
+  it('should propogate key events', () => {
+    const onUp = jest.fn();
+    const onDown = jest.fn();
+    class Wrapper extends lng.Component {
+      static _template() {
+        return {
+          TabBar: {
+            type: TabBar,
+            tabs
+          }
+        };
+      }
+      _handleUp() {
+        onUp();
+      }
+      _handleDown() {
+        onDown();
+      }
+      _getFocused() {
+        return this.tag('TabBar');
+      }
+    }
+    const [, testRenderer] = makeCreateComponent(Wrapper)();
+
+    expect(onUp).not.toHaveBeenCalled();
+    expect(onDown).not.toHaveBeenCalled();
+
+    testRenderer.keyPress('Down');
+    expect(onUp).not.toHaveBeenCalled();
+    expect(onDown).toHaveBeenCalled();
+
+    testRenderer.keyPress('Up');
+    expect(onUp).toHaveBeenCalled();
   });
 
   it('should update the TabBar height if the Tabs height changes', async () => {

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
@@ -129,6 +129,22 @@ describe('TabBar', () => {
     expect(tabBar._Tabs.items[1].mode).toBe('unfocused');
   });
 
+  it('should emit a $tabChanged signal when the selected tab changes', () => {
+    const prevSelected = tabBar.tag('Tabs').selected;
+    jest.spyOn(tabBar, 'fireAncestors');
+    expect(tabBar.fireAncestors).not.toHaveBeenCalled();
+
+    tabBar.tag('Tabs').selectNext();
+    const selected = tabBar.tag('Tabs').selected;
+
+    expect(tabBar.fireAncestors).toHaveBeenCalledWith(
+      '$tabChanged',
+      selected,
+      prevSelected,
+      tabBar
+    );
+  });
+
   it('should propogate key events', () => {
     const onUp = jest.fn();
     const onDown = jest.fn();


### PR DESCRIPTION
## Description
These changes add more functionality to how parent components can listen for events from TabBar:
- propogate up and down key press events so that parent components can optionally run side effects to those events
- emit a `$tabChanged` signal whenever the selected tab changes
<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References
LUI-1187
LUI-1215
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
Unit tests been added to test event propogation. If the changes introduced in Tabbar.js is removed, the tests should fail.
## Automation
n/a
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax