### PR TITLE
fix(Button): support re patching prefix after undefined

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Button/Button.js
+++ b/packages/@lightningjs/ui-components/src/components/Button/Button.js
@@ -105,6 +105,7 @@ export default class Button extends Surface {
   }
 
   _updatePrefix() {
+    const prefixString = JSON.stringify(this.prefix);
     if (this.prefix) {
       let prefixPatch = {
         style: {
@@ -128,9 +129,7 @@ export default class Button extends Surface {
        * from something else (ex. a change in mode), only update the styles applied to the
        * items in the Prefix (ex. updating the color to the value appropriate to the new mode).
        */
-      const prefixString = JSON.stringify(this.prefix);
       if (prefixString !== this._prevPrefix) {
-        this._prevPrefix = prefixString;
         this._Prefix.items = this._addButtonProps(this.prefix);
       } else {
         this._updatePrefixStyles();
@@ -138,6 +137,7 @@ export default class Button extends Surface {
     } else {
       this._Content.patch({ Prefix: undefined });
     }
+    this._prevPrefix = prefixString;
   }
 
   _updatePrefixStyles() {

--- a/packages/@lightningjs/ui-components/src/components/Button/Button.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Button/Button.test.js
@@ -150,6 +150,22 @@ describe('Button', () => {
       testRenderer.forceAllUpdates();
       expect(button._Prefix.items.length).toEqual(button.prefix.length);
     });
+
+    it('should render a new preix row when a prefix is toggled between undefined and defined', () => {
+      expect(button._Prefix).toBeUndefined();
+
+      button.prefix = [{ type: Icon }];
+      testRenderer.forceAllUpdates();
+      expect(button._Prefix.items.length).toEqual(button.prefix.length);
+
+      button.prefix = undefined;
+      testRenderer.forceAllUpdates();
+      expect(button._Prefix).toBeUndefined();
+
+      button.prefix = [{ type: Icon }];
+      testRenderer.forceAllUpdates();
+      expect(button._Prefix.items.length).toEqual(button.prefix.length);
+    });
   });
 
   describe('suffix', () => {


### PR DESCRIPTION
## Description
Previously with the Button component, if the `prefix` were to be defined, then set to undefined, then reset with the original value: the prefix would not be re-rendered. This adds support to toggling a prefix between undefined and a defined value (ex. toggling between displaying and hiding the same icon in the prefix). 
<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References
LUI-1178
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
This bug isn't reproducible in storybook as the component is recreated when toggling prefix. A unit test has been added to test the change. Removing the changes in Button.js will result in the unit test failing.
<!-- step by step instructions to review this PR's changes -->

## Automation
Issue found by automation team. Follow up with them after merge/publish.
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax