### PR TITLE
fix(FocusManager): add style TS definitions for FocusManager, NavigationManager, Row, and Column

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Base/Base.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Base/Base.d.ts
@@ -18,6 +18,8 @@
 
 import lng from '@lightningjs/core';
 
+type BaseStyle = object;
+
 declare namespace Base {
   export interface TemplateSpec extends lng.Component.TemplateSpec {
     /**
@@ -122,4 +124,4 @@ declare class Base<
   get _isUnfocusedMode(): boolean;
 }
 
-export default Base;
+export { Base as default, BaseStyle };

--- a/packages/@lightningjs/ui-components/src/components/Base/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Base/index.d.ts
@@ -16,4 +16,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { default as default } from './Base';
+import Base, { BaseStyle } from './Base';
+export { Base as default, BaseStyle };

--- a/packages/@lightningjs/ui-components/src/components/Column/Column.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.d.ts
@@ -18,7 +18,11 @@
 
 import lng from '@lightningjs/core';
 import FocusManager from '../FocusManager/FocusManager';
-import NavigationManager from '../NavigationManager';
+import NavigationManager, {
+  NavigationManagerStyle
+} from '../NavigationManager';
+
+type ColumnStyle = NavigationManagerStyle;
 
 declare namespace Column {
   export interface TemplateSpec extends NavigationManager.TemplateSpec {
@@ -67,4 +71,4 @@ declare class Column<
   $columnChanged(): void;
 }
 
-export default Column;
+export { Column as default, ColumnStyle };

--- a/packages/@lightningjs/ui-components/src/components/Column/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Column/index.d.ts
@@ -16,6 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import Column from './Column';
+import Column, { ColumnStyle } from './Column';
 
-export { Column as default };
+export { Column as default, ColumnStyle };

--- a/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.d.ts
@@ -17,13 +17,15 @@
  */
 
 import lng from '@lightningjs/core';
-import Base from '../Base';
+import Base, { BaseStyle } from '../Base';
 
 export type NavigationDirectionType = 'none' | 'column' | 'row';
 
 export type FocusItemsType = Array<
   lng.Component.NewPatchTemplate<lng.Component.Constructor> | lng.Component
 >;
+
+type FocusManagerStyle = BaseStyle;
 
 declare namespace FocusManager {
   export interface TemplateSpec extends Base.TemplateSpec {
@@ -189,4 +191,4 @@ declare class FocusManager<
   get _Items(): lng.Component;
 }
 
-export default FocusManager;
+export { FocusManager as default, FocusManagerStyle };

--- a/packages/@lightningjs/ui-components/src/components/FocusManager/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/FocusManager/index.d.ts
@@ -16,6 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import FocusManager from './FocusManager';
+import FocusManager, { FocusManagerStyle } from './FocusManager';
 
-export { FocusManager as default };
+export { FocusManager as default, FocusManagerStyle };

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.d.ts
@@ -18,7 +18,7 @@
 
 import lng from '@lightningjs/core';
 import type { StylePartial } from '../../types/lui';
-import FocusManager from '../FocusManager';
+import FocusManager, { FocusManagerStyle } from '../FocusManager';
 
 export type DirectionProps = {
   axis: string;
@@ -28,7 +28,7 @@ export type DirectionProps = {
   innerCrossDimension: string;
 };
 
-export type NavigationManagerStyle = {
+type NavigationManagerStyle = FocusManagerStyle & {
   alwaysScroll: boolean;
   itemSpacing: number;
   itemTransition: lng.types.TransitionSettings;
@@ -190,4 +190,4 @@ declare class NavigationManager<
   shouldScrollDown(): boolean;
 }
 
-export default NavigationManager;
+export { NavigationManager as default, NavigationManagerStyle };

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.d.ts
@@ -17,7 +17,12 @@
  */
 
 import FocusManager from '../FocusManager';
-import NavigationManager from '../NavigationManager';
+import type { StylePartial } from '../../types/lui';
+import NavigationManager, {
+  NavigationManagerStyle
+} from '../NavigationManager';
+
+type RowStyle = NavigationManagerStyle;
 
 declare namespace Row {
   export interface TemplateSpec extends NavigationManager.TemplateSpec {
@@ -72,6 +77,10 @@ declare class Row<
    * This will be called on every new render.
    */
   onScreenEffect(): void;
+
+  // Accessors
+  get style(): RowStyle;
+  set style(v: StylePartial<RowStyle>);
 }
 
-export default Row;
+export { Row as default, RowStyle };

--- a/packages/@lightningjs/ui-components/src/components/Row/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Row/index.d.ts
@@ -16,6 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import Row from './Row';
+import Row, { RowStyle } from './Row';
 
-export { Row as default };
+export { Row as default, RowStyle };

--- a/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.d.ts
@@ -17,9 +17,8 @@
  */
 
 import lng from '@lightningjs/core';
-import type Row from '../Row';
+import Row, { RowStyle } from '../Row';
 import FocusManager from '../FocusManager';
-import type { NavigationManagerStyle } from '../NavigationManager/NavigationManager';
 import type { StylePartial } from '../../types/lui';
 import type { TextBoxStyle } from '../TextBox';
 
@@ -27,10 +26,10 @@ import type { TextBoxStyle } from '../TextBox';
 /**
  * `Row` style props are the same as `NavigationManager` style props.
  * We are not re-mapping properties and defining a `RowStyle` in `Row` since `Row` inherits all of `NavigationManager` style props.
- * Hence `TitleRowStyle` uses `NavigationManagerStyle` rather than the previous `RowStyle`
+ * Hence `TitleRowStyle` uses `RowStyle` rather than the previous `RowStyle`
  */
 
-type TitleRowStyle = NavigationManagerStyle & {
+type TitleRowStyle = RowStyle & {
   w: number;
   titleMarginLeft: number;
   titleTextStyle: TextBoxStyle;

--- a/packages/@lightningjs/ui-components/src/components/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/index.d.ts
@@ -18,7 +18,7 @@
 
 export { default as Artwork, ArtworkStyle } from './Artwork';
 export { default as Badge, BadgeStyle } from './Badge';
-export { default as Base } from './Base';
+export { default as Base, BaseStyle } from './Base';
 export { default as Button, ButtonSmall, ButtonStyle } from './Button';
 export {
   default as Card,
@@ -39,10 +39,10 @@ export {
   CardContentStyle
 } from './CardContent';
 export { default as Checkbox, CheckboxStyle } from './Checkbox';
-export { default as Column } from './Column';
+export { default as Column, ColumnStyle } from './Column';
 export { default as Control, ControlSmall, ControlStyle } from './Control';
 export { default as ControlRow, ControlRowStyle } from './ControlRow';
-export { default as FocusManager } from './FocusManager';
+export { default as FocusManager, FocusManagerStyle } from './FocusManager';
 export { default as Gradient, GradientStyle } from './Gradient';
 export { default as GridOverlay } from './GridOverlay';
 export { default as Icon, IconStyle } from './Icon';
@@ -83,7 +83,7 @@ export {
 export { default as ProgressBar, ProgressBarStyle } from './ProgressBar';
 export { default as Provider, ProviderStyle } from './Provider';
 export { default as Radio, RadioStyle } from './Radio';
-export { default as Row } from './Row';
+export { default as Row, RowStyle } from './Row';
 export { default as ScrollWrapper, ScrollWrapperStyle } from './ScrollWrapper';
 export { default as Shadow, ShadowStyle } from './Shadow';
 export { default as Slider, SliderStyle } from './Slider';


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
In building the new Gallery component, I tried adding his to the Gallery.d.ts file:
```ts
type GalleryStyle = ColumnStyle & {
  itemLayout?: LayoutOptions;
};
```
I found that ColumnStyle doesn't actually exist. While that makes sense since there are no Column-specific style properties compared to NavigationManager, I'm thinking Row and Column should export their own style types even if they're empty, just so that we future-proof ourselves for the amount of inheritance we have.

This turned into a down the rabbit hole situation where a bunch of components need style types exported too, so I was thinking even Base could have some styles (otherwise I can remove that and just start the process at FocusManager as `FocusManagerStyles = object`).

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
