### PR TITLE
fix(Templates): update to prevent errors with new components

### DIFF
--- a/bin/templates/docs.template.js
+++ b/bin/templates/docs.template.js
@@ -38,7 +38,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0 */}
 
 import { Meta, Title } from '@storybook/blocks';
-import * ${name}Stories from './${name}.stories';
+import * as ${name}Stories from './${name}.stories';
 
 <Meta of={${name}Stories} />
 

--- a/bin/templates/story.template.js
+++ b/bin/templates/story.template.js
@@ -40,8 +40,8 @@ import ${name} from '.';
 import { CATEGORIES } from '../../docs/constants';
 
 export default {
-  // TODO: replace categoryIndex with key for which category this component's story should be nested in. See CATEGORIES object in packages/apps/lightning-ui-docs/index.js
-  title: 'CATEGORIES[categoryIndex]/${name}',
+  // TODO: replace CategoryName string with the category this component's story should be nested in. 
+  title: 'Category/${name}',
 };
 
 export const Basic = () =>


### PR DESCRIPTION
## Description

Updates templates used for the `createComponent` command to ensure that there are no errors with the newly generated files.

## References

LUI-1229

## Testing

Run `yarn createComponent @lightningjs/ui-components NewComponent`, change the "Category" in the title of the stories file to "Components", and ensure that the NewComponent story and docs open without throwing errors.

## Automation

N/A

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
