### PR TITLE
fix: updates to fix merge order issue

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.js
+++ b/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.js
@@ -90,6 +90,7 @@ export default class Artwork extends Base {
   }
 
   set w(v) {
+    if (v === super.w) return;
     super.w = v;
     this._componentSrc = this._generatePromise();
   }
@@ -99,6 +100,7 @@ export default class Artwork extends Base {
   }
 
   set h(v) {
+    if (v === super.h) return;
     super.h = v;
     this._componentSrc = this._generatePromise();
   }

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/StyleManager.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/StyleManager.js
@@ -43,7 +43,6 @@ export default class StyleManager extends lng.EventEmitter {
     this.component = component;
     this.setupListeners();
     this._style = {}; // This will be the source of truth for the style manager
-    this._props = {}; // props that are set in componentConfig will be stored here
     // Initial update is not debounced
     this.update();
   }
@@ -220,8 +219,7 @@ export default class StyleManager extends lng.EventEmitter {
         style = generateStyle(this.component, styleSource);
         this._addCache(`style_${mode}_${tone}`, style);
       }
-      this._props = style.props;
-      delete style.props;
+
       this._style = style;
       this.emit('styleUpdate', this.style);
     } catch (error) {
@@ -245,7 +243,13 @@ export default class StyleManager extends lng.EventEmitter {
   }
 
   get props() {
-    return this._props;
+    return Object.keys(this.component._componentConfig).reduce((acc, key) => {
+      if (!['base', 'tone', 'mode', 'style', 'styleConfig'].includes(key)) {
+        acc[key] = this.component._componentConfig[key];
+      }
+
+      return acc;
+    }, {});
   }
 
   /**

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/StyleManager.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/StyleManager.js
@@ -19,6 +19,7 @@
 import {
   generateComponentStyleSource,
   getStyleChainMemoized,
+  clearStyleChainCache,
   generateStyle,
   getHash
 } from './utils.js';
@@ -93,6 +94,7 @@ export default class StyleManager extends lng.EventEmitter {
    * @private
    */
   _onThemeUpdate() {
+    clearStyleChainCache()
     this.clearSourceCache();
     this.clearStyleCache();
     this.update();

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/StyleManager.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/StyleManager.js
@@ -94,7 +94,7 @@ export default class StyleManager extends lng.EventEmitter {
    * @private
    */
   _onThemeUpdate() {
-    clearStyleChainCache()
+    clearStyleChainCache();
     this.clearSourceCache();
     this.clearStyleCache();
     this.update();

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/StyleManager.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/StyleManager.js
@@ -205,9 +205,6 @@ export default class StyleManager extends lng.EventEmitter {
           alias: this.component.constructor.aliasStyles,
           componentConfig: this.component._componentConfig,
           inlineStyle: this.component._componentLevelStyle,
-          name:
-            this.component.constructor.__componentName ||
-            this.component.constructor.name,
           styleChain: getStyleChainMemoized(this.component),
           theme: this.component.theme
         });

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
@@ -21,7 +21,64 @@ import { updateManager } from '../../globals';
 import { context } from '../../globals';
 import { getComponentConfig, getSubTheme } from './utils';
 import { capitalizeFirstLetter } from '../../utils';
-import utils from '../../utils';
+
+/**
+ * Merges two objects based on the following rules:
+ * 1. If a key exists in both objects, use the value from the second object.
+ * 2. If a key exists in the first object but not in the second, set the value to undefined.
+ * 3. If a key exists in the second object but not in the first, include it in the result.
+ * 4. Maintain the structure of the first object and augment it with extra keys from the second object.
+ *
+ * @param {Object|Array} firstObj - The first object, providing the structure to match.
+ * @param {Object|Array} secondObj - The second object, whose values take precedence.
+ * @returns {Object|Array} A new object with a merged structure and values.
+ */
+function mergeObjectsWithSecondDominant(firstObj, secondObj) {
+  if (firstObj !== null && typeof firstObj === 'object') {
+    if (Array.isArray(firstObj)) {
+      return firstObj.map((item, index) =>
+        mergeObjectsWithSecondDominant(
+          item,
+          Array.isArray(secondObj) ? secondObj[index] : undefined
+        )
+      );
+    } else {
+      const result = {};
+      // Combine keys from both objects to ensure all keys are covered
+      const allKeys = new Set([
+        ...Object.keys(firstObj),
+        ...Object.keys(secondObj)
+      ]);
+      allKeys.forEach(key => {
+        // Recurse for nested objects or arrays
+        if (typeof firstObj[key] === 'object' && firstObj[key] !== null) {
+          result[key] = mergeObjectsWithSecondDominant(
+            firstObj[key],
+            secondObj[key] || {}
+          );
+        } else if (
+          typeof secondObj[key] === 'object' &&
+          secondObj[key] !== null
+        ) {
+          result[key] = mergeObjectsWithSecondDominant(
+            firstObj[key] || {},
+            secondObj[key]
+          );
+        } else {
+          // Use value from the second object if available, else set to undefined
+          result[key] = secondObj.hasOwnProperty(key)
+            ? secondObj[key]
+            : undefined;
+        }
+      });
+      return result;
+    }
+  } else {
+    // Return non-object values directly
+    return firstObj;
+  }
+}
+
 /**
  * A higher-order function that returns a class with theme styles.
  * @param {function} Base - The base class to extend.
@@ -43,7 +100,6 @@ export default function withThemeStyles(Base, mixinStyle = {}) {
 
       this._styleManager = new StyleManager({ component: this });
       this._style = this._styleManager.style; // Set the style for the first time. After this is will be updated by events
-
       this._updatePropDefaults();
       this._styleManager.on('styleUpdate', () => {
         this._style = this._styleManager.style;
@@ -70,25 +126,35 @@ export default function withThemeStyles(Base, mixinStyle = {}) {
       }
     }
 
+    /**
+     * Updates the default properties of the component based on the current theme.
+     * It compares the previous component configuration properties with the current style manager properties,
+     * and updates the component's properties accordingly. If the properties are unchanged, no action is taken.
+     * This method is crucial for ensuring the component's properties are synchronized with the theme.
+     */
     _updatePropDefaults() {
-      // Add support for properties passed through the theme
-      const componentConfigProps = this._styleManager.props || {};
+      // If the current properties are the same as the previous configuration, no update is needed
       if (
-        Object.keys(componentConfigProps).length &&
-        this.constructor.properties &&
-        this.constructor.properties.length
+        JSON.stringify(this._styleManager.props) ===
+        JSON.stringify(this._prevComponentConfigProps)
       ) {
-        Object.keys(componentConfigProps).forEach(key => {
-          if (this.constructor.properties.includes(key)) {
-            this[`_${key}`] =
-              typeof this[`_${key}`] === 'object' &&
-              this[`_${key}`] !== null &&
-              !Array.isArray(this[`_${key}`])
-                ? utils.clone(this[`_${key}`] || {}, componentConfigProps[key])
-                : componentConfigProps[key];
-          }
-        });
+        return;
       }
+      // Compare current properties with previous configuration and get the payload
+      const payload = this._prevComponentConfigProps
+        ? mergeObjectsWithSecondDominant(
+            this._prevComponentConfigProps || {},
+            this._styleManager.props || {}
+          )
+        : this._styleManager.props || {};
+
+      // Store a deep copy of the current properties for future comparison
+      this._prevComponentConfigProps =
+        this._styleManager.props &&
+        JSON.parse(JSON.stringify(this._styleManager.props));
+
+      // This will be used by withUpdates to set defaults
+      this.__componentConfigProps = payload;
     }
 
     /**

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
@@ -610,6 +610,18 @@ export function generateNameFromPrototypeChain(obj, name = '') {
 const styleChainCache = {};
 
 /**
+ * Flush the memoization cache for styleChain
+ *
+ */
+export const clearStyleChainCache = () => {
+  for (const key in styleChainCache) {
+    if (styleChainCache.hasOwnProperty(key)) {
+      delete styleChainCache[key];
+    }
+  }
+};
+
+/**
  * Memoized version of getStyleChain function. Retrieves the style chain for a component by traversing its prototype chain.
  * @param {object} componentObj - The component object to get the style chain from.
  * @returns {{ style: (object | function) }[]} - An array of style objects containing either an object of styles or a function to return an object of styles.
@@ -659,7 +671,6 @@ export const getStyleChain = componentObj => {
     ) {
       // ComponentConfig Level
       const { style: componentConfigStyle } = getComponentConfig(proto);
-
       if (Object.keys(componentConfigStyle || {}).length) {
         if (!styleMap.has(componentConfigStyle)) {
           styleMap.set(componentConfigStyle, { style: componentConfigStyle });

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
@@ -357,7 +357,7 @@ export const generateSolution = (
     'focused',
     'disabled',
     ...modeKeys,
-    'unfocused' // Focused must be at the end for proper fallback since base === 'unfocused' in many cases
+    'unfocused' // Unfocused must be at the end for proper fallback since base === 'unfocused' in many cases
   ]);
 
   const uniqueTones = getUniqueProperties([

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.test.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.test.js
@@ -11,7 +11,6 @@ import {
   getPrototypeChain,
   getUniqueProperties,
   removeEmptyObjects,
-  removeDuplicateObjects,
   // generateSolution, // TODO: Need a test for this
   enforceContract,
   generateComponentStyleSource,
@@ -622,12 +621,6 @@ describe('generateComponentStyleSource', () => {
     }).toThrow('Expected theme to be an object');
   });
 
-  it('throws an error if componentConfig is not an object', () => {
-    expect(() => {
-      generateComponentStyleSource({ componentConfig: 'string' });
-    }).toThrow('Expected componentConfig to be an object');
-  });
-
   it('throws an error if styleChain is not an array', () => {
     expect(() => {
       generateComponentStyleSource({ styleChain: 'string' });
@@ -769,183 +762,6 @@ describe('generateComponentStyleSource', () => {
     });
     expect(source).toStrictEqual({
       unfocused_neutral: { color: 'primary' },
-      unfocused_inverse: { color: 'primary' },
-      unfocused_brand: { color: 'primary' },
-      focused_neutral: { color: 'primary' },
-      focused_inverse: { color: 'primary' },
-      focused_brand: { color: 'primary' },
-      disabled_neutral: { color: 'primary' },
-      disabled_inverse: { color: 'primary' },
-      disabled_brand: { color: 'primary' }
-    });
-  });
-
-  it('will provide correct source for a component with componentConfig', () => {
-    const source = generateComponentStyleSource({
-      componentConfig: {
-        style: {
-          base: {
-            color: 'primary'
-          }
-        }
-      }
-    });
-
-    expect(source).toStrictEqual({
-      unfocused_neutral: { color: 'primary' },
-      unfocused_inverse: { color: 'primary' },
-      unfocused_brand: { color: 'primary' },
-      focused_neutral: { color: 'primary' },
-      focused_inverse: { color: 'primary' },
-      focused_brand: { color: 'primary' },
-      disabled_neutral: { color: 'primary' },
-      disabled_inverse: { color: 'primary' },
-      disabled_brand: { color: 'primary' }
-    });
-  });
-
-  it('will provide correct source for a component with componentConfig with tone', () => {
-    const source = generateComponentStyleSource({
-      componentConfig: {
-        style: {
-          base: {
-            color: 'primary'
-          },
-          tone: {
-            neutral: {
-              color: 'secondary'
-            }
-          }
-        }
-      }
-    });
-
-    expect(source).toStrictEqual({
-      unfocused_neutral: { color: 'secondary' },
-      unfocused_inverse: { color: 'primary' },
-      unfocused_brand: { color: 'primary' },
-      focused_neutral: { color: 'secondary' },
-      focused_inverse: { color: 'primary' },
-      focused_brand: { color: 'primary' },
-      disabled_neutral: { color: 'secondary' },
-      disabled_inverse: { color: 'primary' },
-      disabled_brand: { color: 'primary' }
-    });
-  });
-
-  it('will provide correct source for a component with componentConfig with mode', () => {
-    const source = generateComponentStyleSource({
-      componentConfig: {
-        style: {
-          base: {
-            color: 'primary'
-          },
-          mode: {
-            unfocused: {
-              color: 'secondary'
-            }
-          }
-        }
-      }
-    });
-
-    expect(source).toStrictEqual({
-      unfocused_neutral: { color: 'secondary' },
-      unfocused_inverse: { color: 'secondary' },
-      unfocused_brand: { color: 'secondary' },
-      focused_neutral: { color: 'primary' },
-      focused_inverse: { color: 'primary' },
-      focused_brand: { color: 'primary' },
-      disabled_neutral: { color: 'primary' },
-      disabled_inverse: { color: 'primary' },
-      disabled_brand: { color: 'primary' }
-    });
-  });
-
-  it('will provide correct source for a component with componentConfig with mode', () => {
-    const source = generateComponentStyleSource({
-      componentConfig: {
-        style: {
-          base: {
-            color: 'primary'
-          },
-          mode: {
-            unfocused: {
-              color: 'secondary'
-            }
-          }
-        }
-      }
-    });
-
-    expect(source).toStrictEqual({
-      unfocused_neutral: { color: 'secondary' },
-      unfocused_inverse: { color: 'secondary' },
-      unfocused_brand: { color: 'secondary' },
-      focused_neutral: { color: 'primary' },
-      focused_inverse: { color: 'primary' },
-      focused_brand: { color: 'primary' },
-      disabled_neutral: { color: 'primary' },
-      disabled_inverse: { color: 'primary' },
-      disabled_brand: { color: 'primary' }
-    });
-  });
-
-  it('will provide correct source for a component with componentConfig with tone/mode', () => {
-    const source = generateComponentStyleSource({
-      componentConfig: {
-        style: {
-          base: {
-            color: 'primary'
-          },
-          tone: {
-            neutral: {
-              mode: {
-                unfocused: {
-                  color: 'secondary'
-                }
-              }
-            }
-          }
-        }
-      }
-    });
-
-    expect(source).toStrictEqual({
-      unfocused_neutral: { color: 'secondary' },
-      unfocused_inverse: { color: 'primary' },
-      unfocused_brand: { color: 'primary' },
-      focused_neutral: { color: 'primary' },
-      focused_inverse: { color: 'primary' },
-      focused_brand: { color: 'primary' },
-      disabled_neutral: { color: 'primary' },
-      disabled_inverse: { color: 'primary' },
-      disabled_brand: { color: 'primary' }
-    });
-  });
-
-  it('will provide correct source for a component with componentConfig with mode/tone', () => {
-    const source = generateComponentStyleSource({
-      componentConfig: {
-        style: {
-          base: {
-            color: 'primary'
-          },
-          mode: {
-            unfocused: {
-              tone: {
-                neutral: {
-                  color: 'secondary'
-                }
-              }
-            }
-          }
-        }
-      }
-    });
-
-    expect(source).toStrictEqual({
-      unfocused_neutral: { color: 'secondary' },
       unfocused_inverse: { color: 'primary' },
       unfocused_brand: { color: 'primary' },
       focused_neutral: { color: 'primary' },
@@ -1100,116 +916,6 @@ describe('generateComponentStyleSource', () => {
       disabled_neutral: { color: 'primary' },
       disabled_inverse: { color: 'primary' },
       disabled_brand: { color: 'primary' }
-    });
-  });
-
-  it('will provide props that are available in the componentConfig', () => {
-    const source = generateComponentStyleSource({
-      componentConfig: {
-        prop1: 'string1',
-        prop2: 'string2',
-        prop3: {
-          prop4: 'string4'
-        },
-        style: {
-          base: {
-            color: 'primary'
-          }
-        }
-      }
-    });
-
-    expect(source).toStrictEqual({
-      unfocused_neutral: {
-        color: 'primary',
-        props: {
-          prop1: 'string1',
-          prop2: 'string2',
-          prop3: {
-            prop4: 'string4'
-          }
-        }
-      },
-      unfocused_inverse: {
-        color: 'primary',
-        props: {
-          prop1: 'string1',
-          prop2: 'string2',
-          prop3: {
-            prop4: 'string4'
-          }
-        }
-      },
-      unfocused_brand: {
-        color: 'primary',
-        props: {
-          prop1: 'string1',
-          prop2: 'string2',
-          prop3: {
-            prop4: 'string4'
-          }
-        }
-      },
-      focused_neutral: {
-        color: 'primary',
-        props: {
-          prop1: 'string1',
-          prop2: 'string2',
-          prop3: {
-            prop4: 'string4'
-          }
-        }
-      },
-      focused_inverse: {
-        color: 'primary',
-        props: {
-          prop1: 'string1',
-          prop2: 'string2',
-          prop3: {
-            prop4: 'string4'
-          }
-        }
-      },
-      focused_brand: {
-        color: 'primary',
-        props: {
-          prop1: 'string1',
-          prop2: 'string2',
-          prop3: {
-            prop4: 'string4'
-          }
-        }
-      },
-      disabled_neutral: {
-        color: 'primary',
-        props: {
-          prop1: 'string1',
-          prop2: 'string2',
-          prop3: {
-            prop4: 'string4'
-          }
-        }
-      },
-      disabled_inverse: {
-        color: 'primary',
-        props: {
-          prop1: 'string1',
-          prop2: 'string2',
-          prop3: {
-            prop4: 'string4'
-          }
-        }
-      },
-      disabled_brand: {
-        color: 'primary',
-        props: {
-          prop1: 'string1',
-          prop2: 'string2',
-          prop3: {
-            prop4: 'string4'
-          }
-        }
-      }
     });
   });
 });
@@ -1449,31 +1155,6 @@ describe('getStyleChainMemoized', () => {
   });
 });
 
-describe('removeDuplicateObjects', () => {
-  test('should remove duplicates from array', () => {
-    const input = [
-      { style: { color: 'red' } },
-      { style: { fontSize: 16 } },
-      { style: { color: 'red' } }
-    ];
-
-    const expected = [{ style: { color: 'red' } }, { style: { fontSize: 16 } }];
-
-    const result = removeDuplicateObjects(input);
-    expect(result).toEqual(expected);
-  });
-
-  test('should throw an error if input is not an array', () => {
-    expect(() => {
-      removeDuplicateObjects('not an array');
-    }).toThrow('Input should be an array');
-  });
-
-  test('should return an empty array if input is empty', () => {
-    expect(removeDuplicateObjects([])).toEqual([]);
-  });
-});
-
 class ComponentA {
   static get __themeStyle() {
     return { color: 'red' };
@@ -1493,8 +1174,8 @@ describe('getStyleChain', () => {
     const componentC = new ComponentC();
     const styleChain = getStyleChain(componentC);
     expect(styleChain).toHaveLength(2); // Two styles in the chain
-    expect(styleChain[0]).toEqual({ style: { fontSize: 16 } });
-    expect(styleChain[1]).toEqual({ style: { color: 'red' } });
+    expect(styleChain[0]).toEqual({ style: { color: 'red' } });
+    expect(styleChain[1]).toEqual({ style: { fontSize: 16 } });
   });
 
   it('should handle components with no styles in the chain', () => {
@@ -1518,6 +1199,99 @@ describe('getStyleChain', () => {
 
     expect(styleChain).toHaveLength(1);
     expect(styleChain[0]).toEqual({ style });
+  });
+
+  it('should add componentConfig to the prototype chain', () => {
+    const style = () => ({ fontWeight: 'bold' });
+
+    class FunctionStyleComponent {
+      static get __themeStyle() {
+        return style;
+      }
+
+      static get __componentName() {
+        return 'Test';
+      }
+
+      get theme() {
+        return {
+          componentConfig: {
+            Test: {
+              style: {
+                color: 'red'
+              }
+            }
+          }
+        };
+      }
+    }
+
+    const componentWithFunctionStyle = new FunctionStyleComponent();
+
+    const styleChain = getStyleChain(componentWithFunctionStyle);
+
+    expect(styleChain).toHaveLength(2);
+    expect(styleChain[0]).toEqual({ style });
+    expect(styleChain[1]).toEqual({ style: { color: 'red' } });
+  });
+
+  it('should add componentConfig to the prototype chain in the proper order', () => {
+    const theme = {
+      componentConfig: {
+        TestBase: {
+          style: {
+            color: 'blue'
+          }
+        },
+        Test: {
+          style: {
+            color: 'red'
+          }
+        }
+      }
+    };
+
+    const styleBase = () => ({ fontWeight: 'bold' });
+
+    class FunctionStyleComponentBase {
+      static get __themeStyle() {
+        return styleBase;
+      }
+
+      static get __componentName() {
+        return 'TestBase';
+      }
+
+      get theme() {
+        return theme;
+      }
+    }
+
+    const style = () => ({ fontWeight: 'bold' });
+
+    class FunctionStyleComponent extends FunctionStyleComponentBase {
+      static get __themeStyle() {
+        return style;
+      }
+
+      static get __componentName() {
+        return 'Test';
+      }
+
+      get theme() {
+        return theme;
+      }
+    }
+
+    const componentWithFunctionStyle = new FunctionStyleComponent();
+
+    const styleChain = getStyleChain(componentWithFunctionStyle);
+
+    expect(styleChain).toHaveLength(4);
+    expect(styleChain[0]).toEqual({ style: styleBase });
+    expect(styleChain[1]).toEqual({ style: { color: 'blue' } });
+    expect(styleChain[2]).toEqual({ style });
+    expect(styleChain[3]).toEqual({ style: { color: 'red' } });
   });
 });
 

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.test.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.test.js
@@ -196,14 +196,15 @@ describe('executeWithContextRecursive', () => {
   });
 });
 
+// Generic tests for plain vs. non-plain objects
 describe('isPlainObject', () => {
-  it('should return true for plain objects', () => {
+  it('should evaluate to true for plain objects', () => {
     expect(isPlainObject({})).toBe(true);
     expect(isPlainObject({ foo: 'bar' })).toBe(true);
     expect(isPlainObject(Object.create(null))).toBe(true);
   });
 
-  it('should return false for non-plain objects', () => {
+  it('should evaluate to false for other object types', () => {
     expect(isPlainObject([])).toBe(false);
     expect(isPlainObject(new Date())).toBe(false);
     expect(isPlainObject(null)).toBe(false);

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.test.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.test.js
@@ -672,6 +672,39 @@ describe('generateComponentStyleSource', () => {
     });
   });
 
+  it('will properly incorporate custom modes and tones', () => {
+    const source = generateComponentStyleSource({
+      styleChain: [
+        {
+          style: {
+            base: {
+              color: 'primary'
+            }
+          }
+        },
+        {
+          style: {
+            selected: {
+              color: 'brand'
+            }
+          }
+        }
+      ]
+    });
+
+    expect(source).toStrictEqual({
+      unfocused_neutral: { color: 'primary', selected: { color: 'brand' } },
+      unfocused_inverse: { color: 'primary', selected: { color: 'brand' } },
+      unfocused_brand: { color: 'primary', selected: { color: 'brand' } },
+      focused_neutral: { color: 'primary', selected: { color: 'brand' } },
+      focused_inverse: { color: 'primary', selected: { color: 'brand' } },
+      focused_brand: { color: 'primary', selected: { color: 'brand' } },
+      disabled_neutral: { color: 'primary', selected: { color: 'brand' } },
+      disabled_inverse: { color: 'primary', selected: { color: 'brand' } },
+      disabled_brand: { color: 'primary', selected: { color: 'brand' } }
+    });
+  });
+
   it('should have all objects in source be pointers to the same object in memory', () => {
     const source = generateComponentStyleSource({
       styleChain: [

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/withThemeStyles.test.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/withThemeStyles.test.js
@@ -37,8 +37,8 @@ describe('withThemeStyles', () => {
       }
     );
     const [testComponent] = createComponent();
-
-    expect(testComponent.prop1).toBe('foo');
-    expect(testComponent.style).toMatchObject({});
+    expect(testComponent.__componentConfigProps).toMatchObject({
+      prop1: 'foo'
+    });
   });
 });


### PR DESCRIPTION
## Description

It has been observed that after the last merge order style update PR some deeply nested styles were not working as expected. This ensures that a component will merge appropriately with it's prototype component.

## References
[Ticket](https://ccp.sys.comcast.net/browse/LUI-1217)

## Testing

### Merge Order

1. Add a selected mode to the ListItem story
2. Add a selected mode to the list item style file
3. Change some of the values in the selected mode
4. Select the `selected` radio button in the ListItem story and observe the change matches your updates

### Removing old styles

1. Open the Tile component
2. Right click on the iframe window containing the component in storybook and open the webmaster tools
3. Observe that no image scale on artwork is present on focus.
3. `window.CONTEXT.setTheme({componentConfig:{Tile:{artwork:{style:{imageScale:5,},},style:{paddingYProgress:10,paddingYBetweenContent:10,},},},});`
4. After update when focused you should see an imageScale effect when focusing on the Tile
5. Any combination not including the scale property should clear it. `window.CONTEXT.setTheme({componentConfig:{Tile:{artwork:{},style:{paddingYProgress:10,paddingYBetweenContent:10,},},},});`
6. Setting any value on an instance of the component itself should not allow the componentConfig to overwrite it. 
