### PR TITLE
fix(Storybook): fixes white flashes between loading

### DIFF
--- a/packages/apps/lightning-ui-docs/.storybook/manager-head.html
+++ b/packages/apps/lightning-ui-docs/.storybook/manager-head.html
@@ -16,10 +16,16 @@
   SPDX-License-Identifier: Apache-2.0
 -->
 
+<!-- use for style elements in Storybook's UI -->
 <style>
   /* overrides Storybook style to allow controls to scroll completely */
   #panel-tab-content > div:first-child {
     position: relative !important;
+  }
+
+  /* temporary solution for background issue not being recognized by appContentBG */
+  #storybook-preview-iframe {
+    /* background-color: transparent !important; */
   }
 
   .grid-overlay-panel-wrapper,
@@ -66,10 +72,5 @@
   .theme-panel-wrapper tr {
     border: 1px solid rgb(74, 74, 74);
     padding: 10px 20px;
-  }
-
-  /* temporary solution for background issue not being recognized by appContentBG */
-  #storybook-preview-iframe {
-    background-color: transparent !important;
   }
 </style>

--- a/packages/apps/lightning-ui-docs/.storybook/manager-head.html
+++ b/packages/apps/lightning-ui-docs/.storybook/manager-head.html
@@ -25,7 +25,7 @@
 
   /* temporary solution for background issue not being recognized by appContentBG */
   #storybook-preview-iframe {
-    /* background-color: transparent !important; */
+    background-color: transparent !important;
   }
 
   .grid-overlay-panel-wrapper,

--- a/packages/apps/lightning-ui-docs/.storybook/preview-head.html
+++ b/packages/apps/lightning-ui-docs/.storybook/preview-head.html
@@ -16,8 +16,26 @@
   SPDX-License-Identifier: Apache-2.0
 -->
 
+<!-- use to style elements in Storybook Docs -->
 <style>
-  .sbdocs.sbdocs-li {
-    color: white !important;
+  /* transition background Docs to Story */
+  /* transition background from Story to Doc */
+  .sb-preparing-docs,
+  .sb-preparing-story {
+    background-color: #1b1c1d;
+  }
+  /* NOTE: this class is set to background and not background-color */
+  .sb-previewBlock {
+    background: #1b1c1d;
+  }
+
+  /* hides the args table that shows briefly during transition from Story to Docs */
+  .sb-argstableBlock {
+    display: none;
+  }
+
+  /* loading icons only seen during load/transition from Story to Docs */
+  .sb-previewBlock_icon {
+    background-color: #1b1c1d;
   }
 </style>


### PR DESCRIPTION
## Description

Prior to 6.5, we were able to set `appBG` in the custom Storybook Theme to set the background in the Preview iframe. This is no longer the case. There are possible fixes coming but have not seen them actually committed to a release yet. https://github.com/storybookjs/storybook/pull/24575

The other known issue is a white flash when clicking from a Story to the Docs of that Story. This is related to some classes being displayed and not displayed during 'loading' of the pages. The CSS overrides added in this PR are to fix those issues until Storybook fixes them. [See this issue ](https://github.com/storybookjs/storybook/pull/24575)

This PR makes a few updates to the Storybook styles configuration:

- Adds CCS style overrides for style overrides the known appBG and the loading issue styles when clicking between Stories and Docs

## References
LUI-1200

## Testing

- clone pr
- go to multiple Components
- click from the Story to the Docs and back. You should no longer see the white flash

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
