### PR TITLE
docs(Marquee): added resetMarquee and toggleMarquee descriptions to MetadataBase and TextBox

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.mdx
+++ b/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.mdx
@@ -96,3 +96,9 @@ class Example extends lng.Component {
 | logoPadding          | number           | spacing between logo and secondLine                             |
 | logoWidth            | number           | width for logo                                                  |
 | titleTextStyle       | string \| object | text style for title                                            |
+
+### Methods
+
+#### resetMarquee(): void
+
+This will call [TextBox](?path=/docs/components-textbox--docs)'s `toggleMarquee` method in order to restart or stop marquee scrolling if the marquee flag has changed.

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.mdx
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.mdx
@@ -76,3 +76,9 @@ TextBox also supports rendering as an InlineContent component. See [InlineConten
 | offsetX   | number           | Used to ensure text is positioned correctly                                                                                                                                                                                                             |
 | offsetY   | number           | Used to ensure text is positioned correctly                                                                                                                                                                                                             |
 | textStyle | string \| object | Default style of text to be displayed. Object should come from the current theme or contain any properties that the [Lightning text texture supports](https://lightningjs.io/docs/#/lightning-core-reference/RenderEngine/Textures/Text?id=properties). |
+
+### Methods
+
+#### toggleMarquee(): void
+
+This will restart or stop marquee scrolling to match the marquee flag in case it has changed.


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
In working through the new Gallery component, I realized these public methods weren't documented for MetadataBase or TextBox.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
