### PR TITLE
fix(NavigationManager): adjust isFullyOnScreen and isComponentOnScreen

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Base/Base.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/Base/Base.d.ts
@@ -103,7 +103,7 @@ declare class Base<
   /**
    * returns true if this component is fully within the stage and boundsMargin
    */
-  isFullyOnScreen(): boolean;
+  isFullyOnScreen(offsets: { offsetX: number; offsetY: number }): boolean;
 
   // TODO: for future reference these accessors should technically be public
   /**

--- a/packages/@lightningjs/ui-components/src/components/Base/Base.js
+++ b/packages/@lightningjs/ui-components/src/components/Base/Base.js
@@ -121,8 +121,8 @@ class Base extends lng.Component {
     return this.mode === 'focused';
   }
 
-  isFullyOnScreen() {
-    return isComponentOnScreen(this);
+  isFullyOnScreen(offsets) {
+    return isComponentOnScreen(this, offsets);
   }
 
   getFocusScale() {

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -499,4 +499,17 @@ export default class NavigationManager extends FocusManager {
       ? this._scrollIndex
       : this.style.scrollIndex;
   }
+
+  isFullyOnScreen({ offsetX = 0, offsetY = 0 } = {}) {
+    // if the NavigationManager is nested in another Focus Manager
+    // (like a Row inside of a Column),
+    // the `isComponentOnScreen` method needs to account for
+    // how much the Items container is moving as it scrolls
+    const focusmanager = this.parent?.parent;
+    if (focusmanager instanceof FocusManager) {
+      offsetX += focusmanager.Items.transition('x').targetValue || 0;
+      offsetY += focusmanager.Items.transition('y').targetValue || 0;
+    }
+    return super.isFullyOnScreen({ offsetX, offsetY });
+  }
 }

--- a/packages/@lightningjs/ui-components/src/docs/Base.mdx
+++ b/packages/@lightningjs/ui-components/src/docs/Base.mdx
@@ -80,7 +80,7 @@ Any component which extends the Base component and uses the `withThemeStyles` mi
 This method accepts a target component, patch object, and optional smooth object. If the component is visible, it will smooth in the smooth object, or fall back to
 the patch object, if not it will apply the patch.
 
-#### isFullyOnScreen({ offsetX: number, offsetY: number }): bool
+#### isFullyOnScreen(\{ offsetX: number, offsetY: number \}): bool
 
 Returns a boolean for whether or not the entirety of the component is rendered within the bounds of the screen size.
 

--- a/packages/@lightningjs/ui-components/src/docs/Base.mdx
+++ b/packages/@lightningjs/ui-components/src/docs/Base.mdx
@@ -80,7 +80,7 @@ Any component which extends the Base component and uses the `withThemeStyles` mi
 This method accepts a target component, patch object, and optional smooth object. If the component is visible, it will smooth in the smooth object, or fall back to
 the patch object, if not it will apply the patch.
 
-#### isFullyOnScreen(): bool
+#### isFullyOnScreen({ offsetX: number, offsetY: number }): bool
 
 Returns a boolean for whether or not the entirety of the component is rendered within the bounds of the screen size.
 


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
The `onScreenEffect` in our ColumnContainer and Gallery components was not properly alpha-ing off the rows as they scrolled above and off screen. These adjustments make sure that if a component's _parent_ is animating (specifically inside of a FocusManager), that we use the target transition value to determine if the component is fully on the screen or not, otherwise the `isComponentOnScreen` will return true, even as a row is sliding partially off screen.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
Will need to build and import into IS LUI to confirm it is working as expected in ColumnContainer and Gallery, otherwise you can make a custom story of Rows nested in Columns and add the following as the Column's `onScreenEffect`
```js
      onScreenEffect: function () {
        if (this.items && this.items.length) {
          this.items.forEach((item, idx) => {
            const alpha =
              item.isFullyOnScreen() || idx >= this.selectedIndex ? 1 : 0;

            if (this.shouldSmooth) {
              item.smooth = { alpha };
            } else {
              item.alpha = alpha;
            }
          });
        }
      }
```

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
