### PR TITLE
fix(Storybook): adds docs/story-components to the main index file

### DIFF
--- a/packages/@lightningjs/ui-components/index.js
+++ b/packages/@lightningjs/ui-components/index.js
@@ -22,3 +22,4 @@ export * from './src/globals';
 export * from './src/mixins';
 export * from './src/shaders';
 export * from './src/textures';
+export * from './src/docs/story-components';


### PR DESCRIPTION
## Description

This PR adds the export of `doc/story-components` so that we can reuse SignalButton in LUI inner source components.


## References

LUI-1236

## Testing

Could test this by creating a build of the OS side importing into the node_modules folder on in inner source side, 
@lightningjs/ui-components.
Then try importing Signal Button to a story

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
