### PR TITLE
docs(ListItem): adds parent props to ListItem

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,22 +24,30 @@ The following is a set of guidelines for contributing to `@lightningjs/ui-compon
 
 ## Table of Contents
 
-- [I don't want to read this whole thing I just have a question!!!](#i-dont-want-to-read-this-whole-thing-i-just-have-a-question)
-- [How Can I Contribute?](#how-can-i-contribute)
-  - [Reporting Bugs](#reporting-bugs)
-  - [Suggesting Enhancements](#suggesting-enhancements)
-  - [Your First Code Contribution](#your-first-code-contribution)
-  - [Pull Requests](#pull-requests)
-- [Style Guides](#style-guides)
-  - [TypeScript](#typescript)
-  - [Git Commit Messages](#git-commit-messages)
-  - [JavaScript Style Guide](#javascript-style-guide)
-  - [Test Style Guide](#test-style-guide)
-  - [Documentation Style Guide](#documentation-style-guide)
-    - [Live Examples](#live-examples)
-    - [Storybook](#storybook)
-    - [Usage Documentation](#usage-documentation)
-    - [API Documentation](#api-documentation)
+- [Contributing to `@lightningjs/ui-components`](#contributing-to-lightningjsui-components)
+  - [Table of Contents](#table-of-contents)
+  - [I don't want to read this whole thing I just have a question!!!](#i-dont-want-to-read-this-whole-thing-i-just-have-a-question)
+  - [How Can I Contribute?](#how-can-i-contribute)
+    - [Reporting Bugs](#reporting-bugs)
+      - [How Do I Submit A (Good) Bug Report?](#how-do-i-submit-a-good-bug-report)
+    - [Suggesting Enhancements](#suggesting-enhancements)
+      - [Before Submitting An Enhancement Suggestion](#before-submitting-an-enhancement-suggestion)
+      - [How Do I Submit A (Good) Enhancement Suggestion?](#how-do-i-submit-a-good-enhancement-suggestion)
+    - [Your First Code Contribution](#your-first-code-contribution)
+  - [Installation](#installation)
+    - [Installing dependencies](#installing-dependencies)
+    - [Starting the project](#starting-the-project)
+  - [New component](#new-component)
+    - [Requirements](#requirements)
+    - [Development](#development)
+    - [Pull Requests](#pull-requests)
+  - [Style Guides](#style-guides)
+    - [TypeScript](#typescript)
+    - [Git Commit Messages](#git-commit-messages)
+    - [JavaScript Style Guide](#javascript-style-guide)
+    - [Test Style Guide](#test-style-guide)
+  - [`spyOnMethods`](#spyonmethods)
+    - [Documentation Style Guide](#documentation-style-guide)
 
 ## I don't want to read this whole thing I just have a question!!!
 
@@ -160,7 +168,7 @@ Before a new component will be reviewed, it must meet the following prerequisite
 If you are creating a new component, you can bootstrap the required file structure with:
 
 ```sh
-yarn createComponent <packageName> <componentName>
+yarn createComponent <packageName> <componentName> <parentName>
 ```
 
 - `packageName`: name of which package the component will be published to (`@lightningjs/ui-components` or `@lightningjs/ui-components`)

--- a/bin/create.js
+++ b/bin/create.js
@@ -28,13 +28,13 @@ const {
   styleTemplate,
   typescriptDefinitionsTemplate,
   exportTemplate,
-  exportTypeScriptDefinitionsTemplate,
+  exportTypeScriptDefinitionsTemplate
 } = require('./templates');
 
 const compDir = './packages/';
 const validDirs = [/* '@lightningjs/ui', */ '@lightningjs/ui-components'];
 
-const [componentDir, componentName] = process.argv.slice(2);
+const [componentDir, componentName, parentName] = process.argv.slice(2);
 
 if (!componentDir || !componentName) {
   throw new Error(`Missing component name or type.
@@ -56,26 +56,39 @@ if (fs.existsSync(workingDir)) {
   throw new Error(message);
 }
 
-
 const componentContent = componentTemplate(componentName, componentDir);
 const storyContent = storyTemplate(componentName, componentDir);
-const mdxContent = docsTemplate(componentName, componentDir);
+const mdxContent = docsTemplate(componentName, parentName, componentDir);
 const testContent = testTemplate(componentName, componentDir);
 const styleContent = styleTemplate(componentName, componentDir);
-const typescriptDefinitionsContent = typescriptDefinitionsTemplate(componentName, componentDir);
+const typescriptDefinitionsContent = typescriptDefinitionsTemplate(
+  componentName,
+  componentDir
+);
 const exportContent = exportTemplate(componentName, componentDir);
-const exportTypescriptDefinitionsContent = exportTypeScriptDefinitionsTemplate(componentName, componentDir);
+const exportTypescriptDefinitionsContent = exportTypeScriptDefinitionsTemplate(
+  componentName,
+  componentDir
+);
 
-fs.mkdirp(workingDir).then(() => {
-  fs.writeFile(`${workingDir}/${componentName}.js`, componentContent);
-  fs.writeFile(`${workingDir}/${componentName}.stories.js`, storyContent);
-  fs.writeFile(`${workingDir}/${componentName}.mdx`, mdxContent);
-  fs.writeFile(`${workingDir}/${componentName}.test.js`, testContent);
-  fs.writeFile(`${workingDir}/${componentName}.styles.js`, styleContent);
-  fs.writeFile(`${workingDir}/${componentName}.d.ts`, typescriptDefinitionsContent);
-  fs.writeFile(`${workingDir}/index.js`, exportContent);
-  fs.writeFile(`${workingDir}/index.d.ts`, exportTypescriptDefinitionsContent);
-}).catch(err => {
-  console.error('component creation failed\n');
-  throw new Error(err);
-});
+fs.mkdirp(workingDir)
+  .then(() => {
+    fs.writeFile(`${workingDir}/${componentName}.js`, componentContent);
+    fs.writeFile(`${workingDir}/${componentName}.stories.js`, storyContent);
+    fs.writeFile(`${workingDir}/${componentName}.mdx`, mdxContent);
+    fs.writeFile(`${workingDir}/${componentName}.test.js`, testContent);
+    fs.writeFile(`${workingDir}/${componentName}.styles.js`, styleContent);
+    fs.writeFile(
+      `${workingDir}/${componentName}.d.ts`,
+      typescriptDefinitionsContent
+    );
+    fs.writeFile(`${workingDir}/index.js`, exportContent);
+    fs.writeFile(
+      `${workingDir}/index.d.ts`,
+      exportTypescriptDefinitionsContent
+    );
+  })
+  .catch(err => {
+    console.error('component creation failed\n');
+    throw new Error(err);
+  });

--- a/bin/templates/docs.template.js
+++ b/bin/templates/docs.template.js
@@ -39,7 +39,7 @@ SPDX-License-Identifier: Apache-2.0 */}
 
 import { Meta, Title, ArgTypes, Description } from '@storybook/blocks';
 import * as ${name}Stories from './${name}.stories';
-import * as ${parentName}Stories from '../${parentName}/${parentName}.stories'; //TODO: Make sure the path is correct or removed if not needed
+import * as ${parentName}Stories from '../${parentName}/${parentName}.stories'; {/** TODO: Make sure the path is correct or removed if not needed **/}
 
 <Meta of={${name}Stories} />
 
@@ -70,14 +70,17 @@ class Basic extends lng.Component {
 ## API
 
 ### Parent Properties
+{/** TODO: If you added a parent props table check the appropriate props pulled otherwise delete this section. **/}
 
-//TODO: If you added a parent props table check the appropriate props pulled otherwise delete this section. 
-//Also check the name of the story of the parent component matches the name here.
+{/** TODO: check the path is correct in the url **/}
+${name} has the same properties as [${parentName}](?path=/docs/components-${parentName}--docs)
+
+{/**TODO: check the name of the story of the parent component matches the name here. **/}
 <ArgTypes of={${parentName}Stories.${parentName}} />
 
 ### Properties
-// TODO: if you change the name of the story from Basic to something else, also update then name here 
-<ArgTypes of={${name}Stories.Basic} />
+{/** TODO: if you change the name of the story from Basic to something else, also update then name here **/}
+<ArgTypes of={${name}Stories.Basic} /> 
 
 ### Style Properties
 

--- a/bin/templates/docs.template.js
+++ b/bin/templates/docs.template.js
@@ -22,7 +22,7 @@
 const urlBase =
   'https://github.com/rdkcentral/Lightning-UI-Components/tree/develop/packages/%40lightningjs/ui-components/src/components/';
 
-module.exports = name => `{/* prettier-ignore */}
+module.exports = (name, parentName) => `{/* prettier-ignore */}
 {/*Copyright 2023 Comcast Cable Communications Management, LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -37,12 +37,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 SPDX-License-Identifier: Apache-2.0 */}
 
-import { Meta, Title } from '@storybook/blocks';
+import { Meta, Title, ArgTypes, Description } from '@storybook/blocks';
 import * as ${name}Stories from './${name}.stories';
+import * as ${parentName}Stories from '../${parentName}/${parentName}.stories'; //TODO: Make sure the path is correct
 
 <Meta of={${name}Stories} />
 
-<Title />
+<Title /> 
+
+<Description />  
 
 ## Source
 
@@ -66,11 +69,15 @@ class Basic extends lng.Component {
 
 ## API
 
-### Properties
+### Parent Properties
 
-| name  | type   | required | default | description |
-| ----- | ------ | -------- | ------- | ----------- |
-|       |        |          |         |             |
+//TODO: If you added a parent props table check the appropriate props pulled otherwise delete this section. 
+//Also check the name of the story of the parent component matches the name here.
+<ArgTypes of={${parentName}Stories.${parentName}} />
+
+### Properties
+// TODO: if you change the name of the story from Basic to something else, also update then name here 
+<ArgTypes of={${name}Stories.Basic} />
 
 ### Style Properties
 

--- a/bin/templates/docs.template.js
+++ b/bin/templates/docs.template.js
@@ -39,7 +39,7 @@ SPDX-License-Identifier: Apache-2.0 */}
 
 import { Meta, Title, ArgTypes, Description } from '@storybook/blocks';
 import * as ${name}Stories from './${name}.stories';
-import * as ${parentName}Stories from '../${parentName}/${parentName}.stories'; //TODO: Make sure the path is correct
+import * as ${parentName}Stories from '../${parentName}/${parentName}.stories'; //TODO: Make sure the path is correct or removed if not needed
 
 <Meta of={${name}Stories} />
 

--- a/bin/templates/export.template.js
+++ b/bin/templates/export.template.js
@@ -36,5 +36,5 @@ module.exports = name => {
  */
 
 export { default as default } from './${name}';
-`
-}
+`;
+};

--- a/bin/templates/index.js
+++ b/bin/templates/index.js
@@ -34,4 +34,4 @@ module.exports = {
   typescriptDefinitionsTemplate,
   exportTemplate,
   exportTypeScriptDefinitionsTemplate
-}
+};

--- a/bin/templates/story.template.js
+++ b/bin/templates/story.template.js
@@ -37,7 +37,10 @@ module.exports = name => {
 
 import lng from '@lightningjs/core';
 import ${name} from '.';
-import { CATEGORIES } from '../../docs/constants';
+
+/**
+ * TODO: Use this JS Comment to add description of component that will be imported into the docs under Description
+ */
 
 export default {
   // TODO: replace CategoryName string with the category this component's story should be nested in. 
@@ -54,15 +57,18 @@ export const Basic = () =>
       };
     }
   };
+
 Basic.args = {
   // argName: undefined
 };
+
 Basic.argTypes = {
   // argName: {
   //   control: '',
   //   description: '',
   //   table: {
-  //     defaultValue: { summary: undefined }
+  //     defaultValue: { summary: undefined },
+  //     type: {summary: 'string'}
   //   }
   // }
 };

--- a/packages/@lightningjs/ui-components/src/components/Button/Button.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Button/Button.stories.js
@@ -58,7 +58,8 @@ export default {
       description:
         'When the fixed property is true, this will set the width of the component',
       table: {
-        defaultValue: { summary: 0 }
+        defaultValue: { summary: 0 },
+        type: { summary: 'number' }
       }
     },
     justify: {
@@ -66,7 +67,8 @@ export default {
       options: ['left', 'center', 'right'],
       description: 'Justification of button content',
       table: {
-        defaultValue: { summary: 'center' }
+        defaultValue: { summary: 'center' },
+        type: { summary: 'string' }
       }
     },
     prefix: {
@@ -74,7 +76,8 @@ export default {
       options: [null, 'icon', 'checkbox', 'combo'],
       description: 'Lightning components to be placed to the left of the title',
       table: {
-        defaultValue: { summary: 'undefined' }
+        defaultValue: { summary: 'undefined' },
+        type: { summary: 'object or array' }
       }
     },
     suffix: {
@@ -83,7 +86,8 @@ export default {
       description:
         'Lightning components to be placed to the right of the title',
       table: {
-        defaultValue: { summary: 'undefined' }
+        defaultValue: { summary: 'undefined' },
+        type: { summary: 'object or array' }
       }
     }
   },

--- a/packages/@lightningjs/ui-components/src/components/Button/Button.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Button/Button.stories.js
@@ -41,14 +41,16 @@ export default {
       control: 'text',
       description: 'Title text',
       table: {
-        defaultValue: { summary: 'undefined' }
+        defaultValue: { summary: 'undefined' },
+        type: { summary: 'string' }
       }
     },
     fixed: {
       control: 'boolean',
       description: controlDescriptions.fixed,
       table: {
-        defaultValue: { summary: false }
+        defaultValue: { summary: false },
+        type: { summary: 'boolean' }
       }
     },
     w: {

--- a/packages/@lightningjs/ui-components/src/components/Card/Card.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Card/Card.stories.js
@@ -46,7 +46,8 @@ Card.argTypes = {
     control: 'text',
     description: 'Title text',
     table: {
-      defaultValue: { summary: 'undefined' }
+      defaultValue: { summary: 'undefined' },
+      type: { summary: 'string' }
     }
   }
 };

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.mdx
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.mdx
@@ -17,9 +17,10 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 \*/}
 
-import { Meta, Title } from '@storybook/blocks';
+import { Meta, Title, ArgTypes } from '@storybook/blocks';
+import * as CardStories from '../Card/Card.stories.js';
 
-<Meta title="Components/CardContent" />
+<Meta title="Components/CardContent" />;
 
 # CardContent
 
@@ -71,3 +72,7 @@ class Basic extends lng.Component {
 | metadata          | string \| object | text style for the metadata                                                    |
 | paddingHorizontal | number           | padding on the x-axis between the right and left of the card and its content   |
 | paddingVertical   | number           | padding on the y-axis between the top and bottom of the card and its content   |
+
+### Parent Componet Properties
+
+<ArgTypes of={CardStories} />

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.mdx
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.mdx
@@ -17,14 +17,15 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 \*/}
 
-import { Meta, Title, ArgTypes } from '@storybook/blocks';
+import { Meta, Description, Title, ArgTypes } from '@storybook/blocks';
+import * as CardContentStories from './CardContent.stories.js';
 import * as CardStories from '../Card/Card.stories.js';
 
-<Meta title="Components/CardContent" />;
+<Meta of={CardContentStories} />
 
-# CardContent
+<Title />
 
-Formats a Card with one part Tile and one part Metadata.
+<Description of={CardContentStories} />
 
 ## Source
 
@@ -50,16 +51,17 @@ class Basic extends lng.Component {
 
 ## API
 
+### Parent Componet Properties
+
+`CardContent` extends `Card` therefore shares same properties
+
+<ArgTypes of={CardStories.Card} exclude={['mode']} />
+
 ### Properties
 
-| name               | type                       | required | default      | description                                                                                                                          |
-| ------------------ | -------------------------- | -------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| collapseToMetadata | boolean                    | false    | false        | when true, the collapsed state will hide the tile and show the metadata (when false, the metadata is hidden and the tile is visible) |
-| metadata           | object                     | true     | undefined    | object with all of the properties for [MetadataCardContent](?path=/story/elements-metadatacardcontent--basic)                        |
-| orientation        | ['horizontal', 'vertical'] | false    | 'horizontal' | orientation of card's layout                                                                                                         |
-| shouldCollapse     | boolean                    | false    | false        | will collapse the Card when the Card is not focused                                                                                  |
-| src                | string                     | false    | undefined    | path to artwork image (can also be set via `{ tile: { artwork: { src } } }`)                                                         |
-| tile               | object                     | false    | undefined    | Object containing all properties supported in the [Tile component](?path=/docs/components-tile--basic)                               |
+In addition the `Card` properties, `CardContent` has the following properties:
+
+<ArgTypes of={CardContentStories.CardContent} exclude={['mode']} />
 
 ### Style Properties
 
@@ -72,7 +74,3 @@ class Basic extends lng.Component {
 | metadata          | string \| object | text style for the metadata                                                    |
 | paddingHorizontal | number           | padding on the x-axis between the right and left of the card and its content   |
 | paddingVertical   | number           | padding on the y-axis between the top and bottom of the card and its content   |
-
-### Parent Componet Properties
-
-<ArgTypes of={CardStories} />

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.stories.js
@@ -23,6 +23,9 @@ import { MetadataCardContent as MetadataStory } from '../MetadataCardContent/Met
 import { createModeControl, generateSubStory } from '../../docs/utils';
 import { controlDescriptions } from '../../docs/constants';
 
+/**
+ * Formats a Card with one part Tile and one part Metadata.
+ */
 export default {
   title: 'Components/CardContent/CardContent'
 };
@@ -83,7 +86,8 @@ CardContent.argTypes = {
     control: 'boolean',
     description: controlDescriptions.shouldCollapse,
     table: {
-      defaultValue: { summary: false }
+      defaultValue: { summary: false },
+      type: { summary: 'boolean' }
     }
   },
   badge: {
@@ -93,7 +97,8 @@ CardContent.argTypes = {
     table: {
       category: tileCategory,
       subcategory: 'Badge',
-      defaultValue: { summary: 'undefined' }
+      defaultValue: { summary: 'undefined' },
+      type: { summary: 'string' }
     }
   },
   label: {
@@ -103,7 +108,8 @@ CardContent.argTypes = {
     table: {
       category: tileCategory,
       subcategory: 'Label',
-      defaultValue: { summary: 'undefined' }
+      defaultValue: { summary: 'undefined' },
+      type: { summary: 'string' }
     }
   },
   progress: {
@@ -117,7 +123,8 @@ CardContent.argTypes = {
     table: {
       category: tileCategory,
       subcategory: 'ProgressBar',
-      defaultValue: { summary: 0 }
+      defaultValue: { summary: 0 },
+      type: { summary: 'number' }
     }
   }
 };

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.mdx
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.mdx
@@ -27,8 +27,6 @@ import * as ButtonStories from '../Button/Button.stories';
 
 <Description of={ListItemStories} />
 
-<Description of={ListItemStories.ListItem} />
-
 ## Source
 
 https://github.com/rdkcentral/Lightning-UI-Components/tree/develop/packages/%40lightningjs/ui-components/src/components/ListItem
@@ -57,9 +55,15 @@ class Basic extends lng.Component {
 
 ## API
 
+### Button Properties
+
+`ListItem` extends `Button` therefore shares the same properties
+
+<ArgTypes of={ButtonStories} exclude={['mode']} />
+
 ### Properties
 
-`ListItem` has the same properties as the ones listed in [Button](?path=/docs/components-button--basic) in addition to a couple listed below:
+In addition the `Button` properties, `ListItem` has the following properties:
 
 <ArgTypes
   of={ListItemStories.ListItem}
@@ -76,9 +80,3 @@ class Basic extends lng.Component {
 | paddingX             | number | padding on left and right sides of text      |
 | contentSpacing       | number | padding between title and prefix             |
 | titleTextStyle       | object | text style to apply to the title             |
-
-### Button Properties
-
-List item extends button
-
-<ArgTypes of={ButtonStories} exclude={['mode']} />

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.mdx
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.mdx
@@ -17,21 +17,17 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 \*/}
 
-import {
-  Meta,
-  Title,
-  ArgTypes,
-  Description,
-  Subtitle
-} from '@storybook/blocks';
+import { Meta, Title, ArgTypes, Description } from '@storybook/blocks';
 import * as ListItemStories from './ListItem.stories';
 import * as ButtonStories from '../Button/Button.stories';
 
-<Meta title="Components/ListItem" />
+<Meta of={ListItemStories} />
 
-# ListItem
+<Title />
 
-Component to represent a single item within a list.
+<Description of={ListItemStories} />
+
+<Description of={ListItemStories.ListItem} />
 
 ## Source
 
@@ -65,12 +61,10 @@ class Basic extends lng.Component {
 
 `ListItem` has the same properties as the ones listed in [Button](?path=/docs/components-button--basic) in addition to a couple listed below:
 
-| name           | type    | default   | description                                                                           |
-| -------------- | ------- | --------- | ------------------------------------------------------------------------------------- |
-| description    | string  | undefined | description text                                                                      |
-| prefixLogo     | string  | undefined | Logo to be placed to the left of the title and description                            |
-| shouldCollapse | boolean | false     | flag that if `true`, hides the title when `ListItem` is in unfocused or disabled mode |
-| suffixLogo     | string  | undefined | Logo to be placed to the right of the title and description                           |
+<ArgTypes
+  of={ListItemStories.ListItem}
+  exclude={['suffix', 'prefix', 'title', 'mode']}
+/>
 
 ### Style Properties
 
@@ -87,4 +81,4 @@ class Basic extends lng.Component {
 
 List item extends button
 
-<ArgTypes of={ButtonStories} />
+<ArgTypes of={ButtonStories} exclude={['mode']} />

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.mdx
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.mdx
@@ -55,7 +55,7 @@ class Basic extends lng.Component {
 
 ## API
 
-### Button Properties
+### Parent Component Properties
 
 `ListItem` extends `Button` therefore shares the same properties
 

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.stories.js
@@ -24,8 +24,21 @@ import { default as Checkbox } from '../Checkbox';
 import { default as Radio } from '../Radio';
 import { default as Toggle } from '../Toggle';
 
+/**
+ * ListItem component with the ability to let a user pick from a list of options.
+ */
 export default {
-  title: 'Components/ListItem/ListItem'
+  title: 'Components/ListItem/ListItem',
+  args: {
+    title: 'List Item',
+    shouldCollapse: false,
+    description: 'Description',
+    prefix: null,
+    prefixLogo: 'none',
+    suffix: null,
+    suffixLogo: 'none',
+    mode: 'focused'
+  }
 };
 
 export const ListItem = () =>
@@ -41,31 +54,22 @@ export const ListItem = () =>
 
 ListItem.storyName = 'ListItem';
 
-ListItem.args = {
-  title: 'List Item',
-  shouldCollapse: false,
-  description: 'Description',
-  prefix: null,
-  prefixLogo: 'none',
-  suffix: null,
-  suffixLogo: 'none',
-  mode: 'focused'
-};
-
 ListItem.argTypes = {
-  ...createModeControl({ summaryValue: ListItem.args.mode }),
+  ...createModeControl({ summaryValue: 'focused' }),
   title: {
     control: 'text',
     description: 'Title text',
     table: {
-      defaultValue: { summary: 'undefined' }
+      defaultValue: { summary: 'undefined' },
+      type: { summary: 'string' }
     }
   },
   description: {
     control: 'text',
     description: 'Description text',
     table: {
-      defaultValue: { summary: 'undefined' }
+      defaultValue: { summary: 'undefined' },
+      type: { summary: 'string' }
     }
   },
   shouldCollapse: {
@@ -73,7 +77,8 @@ ListItem.argTypes = {
     description:
       'When in unfocused or disabled mode, if this flag is true the description will collapse (when focused, it will always be expanded)',
     table: {
-      defaultValue: { summary: false }
+      defaultValue: { summary: false },
+      type: { summary: 'boolean' }
     }
   },
   prefix: {
@@ -81,7 +86,8 @@ ListItem.argTypes = {
     options: [null, 'toggle', 'radio', 'checkbox'],
     description: 'Lightning components to be placed to the left of the title',
     table: {
-      defaultValue: { summary: 'undefined' }
+      defaultValue: { summary: 'undefined' },
+      type: { summary: 'object or array' }
     }
   },
   prefixLogo: {
@@ -90,7 +96,8 @@ ListItem.argTypes = {
     description:
       'Logo to be placed to the left of the title. If prefix and prefixLogo are both set, prefixLogo will take precedence for what is rendered and prefix will be ignored',
     table: {
-      defaultValue: { summary: 'undefined' }
+      defaultValue: { summary: 'undefined' },
+      type: { summary: 'string' }
     }
   },
   suffix: {
@@ -98,7 +105,8 @@ ListItem.argTypes = {
     options: [null, 'toggle', 'radio', 'checkbox'],
     description: 'Lightning components to be placed to the right of the title',
     table: {
-      defaultValue: { summary: 'undefined' }
+      defaultValue: { summary: 'undefined' },
+      type: { summary: 'object or array' }
     }
   },
   suffixLogo: {
@@ -107,7 +115,8 @@ ListItem.argTypes = {
     description:
       'Logo to be placed to the right of the title. If suffix and suffixLogo are both set, suffixLogo will take precedence for what is rendered and suffix will be ignored',
     table: {
-      defaultValue: { summary: 'undefined' }
+      defaultValue: { summary: 'undefined' },
+      type: { summary: 'string' }
     }
   }
 };
@@ -155,4 +164,11 @@ const sharedArgActions = {
   }
 };
 
-ListItem.parameters = { argActions: sharedArgActions };
+ListItem.parameters = {
+  argActions: sharedArgActions,
+  docs: {
+    description: {
+      story: 'story tests'
+    }
+  }
+};

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItem.stories.js
@@ -165,10 +165,5 @@ const sharedArgActions = {
 };
 
 ListItem.parameters = {
-  argActions: sharedArgActions,
-  docs: {
-    description: {
-      story: 'story tests'
-    }
-  }
+  argActions: sharedArgActions
 };

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemPicker.mdx
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemPicker.mdx
@@ -17,14 +17,15 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 \*/}
 
-import { Meta, Title } from '@storybook/blocks';
+import { Meta, Title, ArgTypes, Description } from '@storybook/blocks';
 import * as ListItemPickerStories from './ListItemPicker.stories';
+import * as ListItemStories from './ListItem.stories.js';
 
 <Meta of={ListItemPickerStories} />
 
 <Title />
 
-ListItem component with the ability to let a user pick from a list of options.
+<Description />
 
 ## Source
 
@@ -52,14 +53,18 @@ class Basic extends lng.Component {
 
 ## API
 
+### Parent Properties
+
+`ListItemPicker` has the same properties as `ListItem`
+
+<ArgTypes
+  of={ListItemStories.ListItem}
+  exclude={['suffix', 'prefix', 'title', 'mode']}
+/>
+
 ### Properties
 
-`ListItemPicker` has the same properties as the ones listed in [ListItem](?path=/docs/components-listitem--list-item) in addition to a couple listed below:
-
-| name          | type     | default   | description                      |
-| ------------- | -------- | --------- | -------------------------------- |
-| options       | string[] | undefined | list of selectable options       |
-| selectedIndex | number   | undefined | index of current selected option |
+<ArgTypes of={ListItemPickerStories.ListItemPicker} />
 
 ### Style Properties
 

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemPicker.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemPicker.stories.js
@@ -20,10 +20,6 @@ import lng from '@lightningjs/core';
 import { default as ListItemPickerComponent } from './ListItemPicker';
 import { createModeControl } from '../../docs/utils';
 
-/**
- *
- */
-
 export default {
   title: 'Components/ListItem/ListItemPicker'
 };

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemPicker.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemPicker.stories.js
@@ -20,6 +20,10 @@ import lng from '@lightningjs/core';
 import { default as ListItemPickerComponent } from './ListItemPicker';
 import { createModeControl } from '../../docs/utils';
 
+/**
+ *
+ */
+
 export default {
   title: 'Components/ListItem/ListItemPicker'
 };
@@ -51,7 +55,8 @@ ListItemPicker.argTypes = {
     control: 'text',
     description: 'Title text',
     table: {
-      defaultValue: { summary: 'undefined' }
+      defaultValue: { summary: 'undefined' },
+      type: { summary: 'string' }
     }
   },
   shouldCollapse: {
@@ -59,12 +64,16 @@ ListItemPicker.argTypes = {
     description:
       'When in unfocused or disabled mode,if this flag is true the description will collapse (when focused, it will always be expanded)',
     table: {
-      defaultValue: { summary: false }
+      defaultValue: { summary: false },
+      type: { summary: 'boolean' }
     }
   },
   options: {
     control: 'object',
     description: 'List of selectable options',
-    table: { defaultValue: { summary: 'undefined' } }
+    table: {
+      defaultValue: { summary: 'undefined' },
+      type: { summary: 'object' }
+    }
   }
 };

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.mdx
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.mdx
@@ -1,11 +1,13 @@
-﻿import { Meta, Title } from '@storybook/blocks';
+﻿import { Meta, Title, ArgTypes, Description } from '@storybook/blocks';
 import * as ListItemSliderStories from './ListItemSlider.stories';
+import * as ListItemStories from './ListItem.stories';
+import * as SliderStories from '../Slider/Slider.stories';
 
 <Meta of={ListItemSliderStories} />
 
 <Title />
 
-A ListItem component with slider functionality
+<Description />
 
 ## Source
 
@@ -33,12 +35,19 @@ class Basic extends lng.Component {
 
 ## API
 
+### Parent Properties
+
+`ListItemSlider` contains all the properties of `ListItem`
+
+<ArgTypes of={ListItemStories.ListItem} />
+
 ### Properties
 
-| name   | type   | required | default   | description                                                                                                |
-| ------ | ------ | -------- | --------- | ---------------------------------------------------------------------------------------------------------- |
-| slider | object | false    | undefined | object containing all properties supported in the [Slider component](?path=/docs/components-slider--basic) |
-| value  | string | false    | undefined | current value of slider                                                                                    |
+<ArgTypes of={ListItemSliderStories.ListItemSlider} />
+
+### Slider Properties
+
+<ArgTypes of={SliderStories.Basic} />
 
 ### Style Properties
 

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.stories.js
@@ -21,6 +21,10 @@ import { default as ListItemSliderComponent } from './ListItemSlider';
 import { createModeControl, generateSubStory } from '../../docs/utils';
 import { Basic as SliderStory } from '../Slider/Slider.stories';
 
+/**
+ * A ListItem component with slider functionality
+ */
+
 export default {
   title: 'Components/ListItem/ListItemSlider'
 };
@@ -44,21 +48,22 @@ ListItemSlider.args = {
   shouldCollapse: false,
   mode: 'focused'
 };
-
 ListItemSlider.argTypes = {
-  ...createModeControl({ summaryValue: ListItemSlider.args.mode }),
+  ...createModeControl({ summaryValue: 'focused' }),
   title: {
     control: 'text',
     description: 'Title text',
     table: {
-      defaultValue: { summary: 'undefined' }
+      defaultValue: { summary: 'undefined' },
+      type: { summary: 'string' }
     }
   },
   value: {
     control: 'number',
     description: 'Current slider value',
     table: {
-      defaultValue: { summary: 'undefined' }
+      defaultValue: { summary: 'undefined' },
+      type: { summary: 'number' }
     }
   },
   shouldCollapse: {
@@ -66,7 +71,8 @@ ListItemSlider.argTypes = {
     description:
       'When in unfocused or disabled mode, if shouldCollapse property is true it will collapse the slider (when focused, it will always be expanded)',
     table: {
-      defaultValue: { summary: false }
+      defaultValue: { summary: false },
+      type: { summary: 'boolean' }
     }
   }
 };

--- a/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.stories.js
@@ -58,42 +58,48 @@ MetadataCardContent.argTypes = {
     control: 'number',
     description: 'Width of component',
     table: {
-      defaultValue: { summary: 0 }
+      defaultValue: { summary: 0 },
+      type: { summary: 'number' }
     }
   },
   h: {
     control: 'number',
     description: 'Height of component',
     table: {
-      defaultValue: { summary: 0 }
+      defaultValue: { summary: 0 },
+      type: { summary: 'number' }
     }
   },
   title: {
     control: 'text',
     description: 'Title text',
     table: {
-      defaultValue: { summary: 'undefined' }
+      defaultValue: { summary: 'undefined' },
+      type: { summary: 'string' }
     }
   },
   description: {
     control: 'text',
     description: 'Description text directly below title',
     table: {
-      defaultValue: { summary: 'undefined' }
+      defaultValue: { summary: 'undefined' },
+      type: { summary: 'string' }
     }
   },
   details: {
     control: 'text',
     description: 'Details text at bottom left of componentDetails text',
     table: {
-      defaultValue: { summary: 'undefined' }
+      defaultValue: { summary: 'undefined' },
+      type: { summary: 'string' }
     }
   },
   visibleCount: {
     control: { type: 'range', min: 1, max: 10, step: 1 },
     description: 'Number of visible providers',
     table: {
-      defaultValue: { summary: 1 }
+      defaultValue: { summary: 1 },
+      type: { summary: 'number' }
     }
   }
 };

--- a/packages/@lightningjs/ui-components/src/components/Slider/Slider.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Slider/Slider.stories.js
@@ -61,27 +61,30 @@ Basic.argTypes = {
   min: {
     control: 'number',
     description: 'Lower bound of value',
-    table: { defaultValue: { summary: 0 } }
+    table: { defaultValue: { summary: 0 }, type: { summary: 'number' } }
   },
   max: {
     control: 'number',
     description: 'Upper bound of value',
-    table: { defaultValue: { summary: 100 } }
+    table: { defaultValue: { summary: 100 }, type: { summary: 'number' } }
   },
   value: {
     control: 'number',
     description: 'Current value',
-    table: { defaultValue: { summary: '0 or min' } }
+    table: {
+      defaultValue: { summary: '0 or min' },
+      type: { summary: 'number' }
+    }
   },
   step: {
     control: 'number',
     description: '+/- value on change',
-    table: { defaultValue: { summary: 1 } }
+    table: { defaultValue: { summary: 1 }, type: { summary: 'number' } }
   },
   vertical: {
     control: 'boolean',
     description: 'If true, the slider is displayed vertically',
-    table: { defaultValue: { summary: false } }
+    table: { defaultValue: { summary: false }, type: { summary: 'boolean' } }
   }
 };
 

--- a/packages/apps/lightning-ui-docs/.storybook/preview.js
+++ b/packages/apps/lightning-ui-docs/.storybook/preview.js
@@ -41,7 +41,11 @@ const preview = {
       sort: 'requiredFirst'
     },
     docs: {
-      theme: themes.dark
+      theme: themes.dark,
+      argTypes: {
+        sort: 'alpha',
+        exclude: ['mode']
+      }
     },
     options: {
       /** NOTE:  v7 storySort must be self-contained function & no reference to outside variables


### PR DESCRIPTION
## Description

This PR adds some new features to the Docs. Only added to ListItem and the other ListItem components for now.
Note: Updates are only on ListItem and CardContent, as a poc 
- adds props of parent components to docs using `ArgTypes`
- adds props of component to docs using `ArgTypes`. This reduces the duplicating code. All the information for the props comes from the `argTypes` in the component's story
- adds `type` to argsType `table` so types will show on props table
- adds `Description` which can be taken from two different locations. It's really up to us on the preference. It can be written as a JSDOC comment in the story or it can be written in the `parameters.docs.description.story`. In this PR it's coming from JSDoc comment in story
- updates docs and stories template for createComponent. 
- Adds auto generated parent component URL under Parent Properties. 
- Adds auto generated parent props table
- updates createComponent script to now take a parent component for doc props creation

## References

LUI-1168

## Testing

- clone and cd into branch
- go to ListItem and CardContent story docs, observe the new additions to the docs, Parent Component Prop, auto generated description (under title)

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
