### PR TITLE
fix(Artwork): changes one of the parameters to be commented out

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.stories.js
@@ -108,37 +108,6 @@ Artwork.argTypes = {
   }
 };
 
-// Artwork.parameters = {
-//   argActions: {
-//     foregroundSrc: (foregroundSrc, component) => {
-//       component.tag('Artwork').foregroundSrc =
-//         'none' !== foregroundSrc ? foregroundSrc : undefined;
-//     },
-//     srcCallback: (active, component) => {
-//       if (active) {
-//         // Accepts a regular function or function that returns a promise
-//         component.tag('Artwork').patch({
-//           src: '8501866671289235112',
-//           srcCallback: ({ w, closestAspectRatio, src }) => {
-//             return new Promise(resolve => {
-//               setTimeout(() => {
-//                 resolve(
-//                   `https://myriad.merlin.comcast.com/select/image?entityId=${src}&width=${w}&ratio=${closestAspectRatio}&rule=noTitle`
-//                 );
-//               }, 500);
-//             });
-//           }
-//         });
-//       } else {
-//         component.tag('Artwork').patch({
-//           src: 'https://myriad.merlin.comcast.com/select/image?entityId=8501866671289235112&width=400&ratio=3x4&rule=noTitle',
-//           srcCallback: undefined
-//         });
-//       }
-//     }
-//   }
-// };
-
 Artwork.parameters = {
   argActions: {
     foregroundSrc: (foregroundSrc, component) => {

--- a/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.stories.js
@@ -108,37 +108,6 @@ Artwork.argTypes = {
   }
 };
 
-Artwork.parameters = {
-  argActions: {
-    foregroundSrc: (foregroundSrc, component) => {
-      component.tag('Artwork').foregroundSrc =
-        'none' !== foregroundSrc ? foregroundSrc : undefined;
-    },
-    srcCallback: (active, component) => {
-      if (active) {
-        // Accepts a regular function or function that returns a promise
-        component.tag('Artwork').patch({
-          src: '8501866671289235112',
-          srcCallback: ({ w, closestAspectRatio, src }) => {
-            return new Promise(resolve => {
-              setTimeout(() => {
-                resolve(
-                  `https://myriad.merlin.comcast.com/select/image?entityId=${src}&width=${w}&ratio=${closestAspectRatio}&rule=noTitle`
-                );
-              }, 500);
-            });
-          }
-        });
-      } else {
-        component.tag('Artwork').patch({
-          src: 'https://myriad.merlin.comcast.com/select/image?entityId=8501866671289235112&width=400&ratio=3x4&rule=noTitle',
-          srcCallback: undefined
-        });
-      }
-    }
-  }
-};
-
 // Artwork.parameters = {
 //   argActions: {
 //     foregroundSrc: (foregroundSrc, component) => {
@@ -149,12 +118,12 @@ Artwork.parameters = {
 //       if (active) {
 //         // Accepts a regular function or function that returns a promise
 //         component.tag('Artwork').patch({
-//           src: 'https://image.tmdb.org/t/p/w500/sWgBv7LV2PRoQgkxwlibdGXKz1S.jpg',
-//           srcCallback: () => {
+//           src: '8501866671289235112',
+//           srcCallback: ({ w, closestAspectRatio, src }) => {
 //             return new Promise(resolve => {
 //               setTimeout(() => {
 //                 resolve(
-//                   'https://image.tmdb.org/t/p/w500/o7qi2v4uWQ8bZ1tW3KI0Ztn2epk.jpg'
+//                   `https://myriad.merlin.comcast.com/select/image?entityId=${src}&width=${w}&ratio=${closestAspectRatio}&rule=noTitle`
 //                 );
 //               }, 500);
 //             });
@@ -162,10 +131,41 @@ Artwork.parameters = {
 //         });
 //       } else {
 //         component.tag('Artwork').patch({
-//           src: 'https://image.tmdb.org/t/p/w500/sWgBv7LV2PRoQgkxwlibdGXKz1S.jpg',
+//           src: 'https://myriad.merlin.comcast.com/select/image?entityId=8501866671289235112&width=400&ratio=3x4&rule=noTitle',
 //           srcCallback: undefined
 //         });
 //       }
 //     }
 //   }
 // };
+
+Artwork.parameters = {
+  argActions: {
+    foregroundSrc: (foregroundSrc, component) => {
+      component.tag('Artwork').foregroundSrc =
+        'none' !== foregroundSrc ? foregroundSrc : undefined;
+    },
+    srcCallback: (active, component) => {
+      if (active) {
+        // Accepts a regular function or function that returns a promise
+        component.tag('Artwork').patch({
+          src: 'https://image.tmdb.org/t/p/w500/sWgBv7LV2PRoQgkxwlibdGXKz1S.jpg',
+          srcCallback: () => {
+            return new Promise(resolve => {
+              setTimeout(() => {
+                resolve(
+                  'https://image.tmdb.org/t/p/w500/o7qi2v4uWQ8bZ1tW3KI0Ztn2epk.jpg'
+                );
+              }, 500);
+            });
+          }
+        });
+      } else {
+        component.tag('Artwork').patch({
+          src: 'https://image.tmdb.org/t/p/w500/sWgBv7LV2PRoQgkxwlibdGXKz1S.jpg',
+          srcCallback: undefined
+        });
+      }
+    }
+  }
+};

--- a/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.stories.js
@@ -139,33 +139,33 @@ Artwork.parameters = {
   }
 };
 
-Artwork.parameters = {
-  argActions: {
-    foregroundSrc: (foregroundSrc, component) => {
-      component.tag('Artwork').foregroundSrc =
-        'none' !== foregroundSrc ? foregroundSrc : undefined;
-    },
-    srcCallback: (active, component) => {
-      if (active) {
-        // Accepts a regular function or function that returns a promise
-        component.tag('Artwork').patch({
-          src: 'https://image.tmdb.org/t/p/w500/sWgBv7LV2PRoQgkxwlibdGXKz1S.jpg',
-          srcCallback: () => {
-            return new Promise(resolve => {
-              setTimeout(() => {
-                resolve(
-                  'https://image.tmdb.org/t/p/w500/o7qi2v4uWQ8bZ1tW3KI0Ztn2epk.jpg'
-                );
-              }, 500);
-            });
-          }
-        });
-      } else {
-        component.tag('Artwork').patch({
-          src: 'https://image.tmdb.org/t/p/w500/sWgBv7LV2PRoQgkxwlibdGXKz1S.jpg',
-          srcCallback: undefined
-        });
-      }
-    }
-  }
-};
+// Artwork.parameters = {
+//   argActions: {
+//     foregroundSrc: (foregroundSrc, component) => {
+//       component.tag('Artwork').foregroundSrc =
+//         'none' !== foregroundSrc ? foregroundSrc : undefined;
+//     },
+//     srcCallback: (active, component) => {
+//       if (active) {
+//         // Accepts a regular function or function that returns a promise
+//         component.tag('Artwork').patch({
+//           src: 'https://image.tmdb.org/t/p/w500/sWgBv7LV2PRoQgkxwlibdGXKz1S.jpg',
+//           srcCallback: () => {
+//             return new Promise(resolve => {
+//               setTimeout(() => {
+//                 resolve(
+//                   'https://image.tmdb.org/t/p/w500/o7qi2v4uWQ8bZ1tW3KI0Ztn2epk.jpg'
+//                 );
+//               }, 500);
+//             });
+//           }
+//         });
+//       } else {
+//         component.tag('Artwork').patch({
+//           src: 'https://image.tmdb.org/t/p/w500/sWgBv7LV2PRoQgkxwlibdGXKz1S.jpg',
+//           srcCallback: undefined
+//         });
+//       }
+//     }
+//   }
+// };

--- a/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.styles.js
@@ -29,7 +29,7 @@ export const base = theme => ({
   fallbackSrc: undefined,
   fillColor: theme.color.overlay,
   gradientColor: theme.color.material,
-  imageScale: 3,
+  imageScale: undefined,
   imageScalePivotX: 0.5,
   imageScalePivotY: 0.5,
   padding: theme.spacer.md,

--- a/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.styles.js
@@ -29,7 +29,7 @@ export const base = theme => ({
   fallbackSrc: undefined,
   fillColor: theme.color.overlay,
   gradientColor: theme.color.material,
-  imageScale: undefined,
+  imageScale: 3,
   imageScalePivotX: 0.5,
   imageScalePivotY: 0.5,
   padding: theme.spacer.md,

--- a/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.styles.js
@@ -29,7 +29,7 @@ export const base = theme => ({
   fallbackSrc: undefined,
   fillColor: theme.color.overlay,
   gradientColor: theme.color.material,
-  imageScale: undefined,
+  imageScale: 1,
   imageScalePivotX: 0.5,
   imageScalePivotY: 0.5,
   padding: theme.spacer.md,

--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.test.js
@@ -195,7 +195,7 @@ describe('Tile', () => {
     it('updates artwork scale when imageScale is updated', async () => {
       tile.artwork = { src: sampleImage };
       testRenderer.focus();
-      expect(tile._Artwork.style.imageScale).toBe(tile.style.imageScale); // base theme does not have a image scale change on focus
+      expect(tile._Artwork.style.imageScale).toBe(1); // imageScale for Artwork is 1
       tile.artwork.style = { imageScale: 2 };
       await tile.__updateArtworkSpyPromise;
       expect(tile._Artwork.style.imageScale).toBe(2);


### PR DESCRIPTION
## Description

This pr fixes the issue with `shouldScale` control not working on Artwork. The issue was resolved by commenting out one of the `Artwork.parameters = {....` 
Looking through the commit history I can't seem to track down where we introduced having to parameter assignments but we can't do this, Storybook gets confused on which one to use.  
I'm guessing we had two for a reason at some point. We need to decide which one to keep or we could create two stories.

## References

LUI-1238

## Testing
On OS side, change the `imageScale` prop to any number in the `Artwork.styles.js`, `yarn start`
Got to Artwork controls and toggle `shouldScroll`


## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
