### PR TITLE
fix(TextBox): ensure styles (like textStyles) are passed from TextBox to InlineContent

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
@@ -146,12 +146,21 @@ export default class TextBox extends Base {
   _updateInlineContent() {
     this.patch({ Text: undefined });
 
-    const inlineContentPatch = InlineContent.properties.reduce((acc, prop) => {
-      if (this[prop] != undefined) {
-        acc[prop] = this[prop];
+    const inlineContentPatch = InlineContent.properties.reduce(
+      (acc, prop) => {
+        if (this[prop] != undefined) {
+          acc[prop] = this[prop];
+        }
+        return acc;
+      },
+      // ensure all styles are passed down as well
+      {
+        style: {
+          ...this.style,
+          textStyle: this._textStyleSet
+        }
       }
-      return acc;
-    }, {});
+    );
 
     if (this._textStyleSet.wordWrapWidth) {
       inlineContentPatch.w = this._textStyleSet.wordWrapWidth;


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Currently, any custom styles set on TextBox as a whole as not getting passed down to the InlineContent component is the TextBox needs to use it. This means that when using TextBox with InlineContent in various Metadata components, the styles are incorrect.y

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
In TextBox.stories.js, add custom styles to the `WithInlineContentString` story and observe these now getting applied.
```js
          style: {
            textStyle: {
              textColor: getHexColor('00ff00')
            }
          }
```

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
