### PR TITLE
fix(InlineContent): check if item is text or text object before adding margin and adjust whitespace parsing

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
@@ -100,7 +100,8 @@ export default class InlineContent extends Base {
 
         // text not separated by icons/badges are grouped together
         if (isText(item)) {
-          if (typeof this._parsedContent[index + 1] === 'string') {
+          const nextItem = this._parsedContent[index + 1];
+          if (nextItem && isText(nextItem)) {
             base.flexItem.marginRight = 0;
           }
           this.childList.a(this._createText(base, item));
@@ -375,15 +376,18 @@ export default class InlineContent extends Base {
    * @return { array }
    */
   _formatSpaces(parsedContent) {
-    const whitespace = /(\s+)/;
+    // retain the white space next to the appropriate word, then filter by the empty string,
+    // otherwise all whitespace is stripped and the flexItem's marginRight adds its own space
+    // which can be a different space size than the text would apply between words
+    const whitespace = /(.+?\s+)/;
     return flatten(
       (parsedContent || []).reduce((acc, item) => {
         let parsed = item;
         if (isText(item)) {
           if (typeof item === 'object') {
             const formattedWords = item.text
-              .split(whitespace)
-              .map(word => ({ ...item, text: word.trim() }));
+              .split(whitespace) // split after whitespace character (which adds empty strings)
+              .map(word => word && { ...item, text: word }); // check for empty string before adding
             acc.push(...formattedWords);
             return acc;
           }

--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.stories.js
@@ -103,6 +103,7 @@ export const Basic = args =>
           },
           content: [
             'Text',
+            ' and some icons',
             {
               icon: lightningbolt,
               title: 'Green Lightning Bolt',
@@ -113,7 +114,7 @@ export const Basic = args =>
               icon: 'https://upload.wikimedia.org/wikipedia/commons/b/b6/Tomato-Torrent-Icon.png',
               title: 'Rotten Tomatoes rating'
             },
-            'and more text',
+            'and more text ',
             {
               text: 'with some red ',
               style: { textColor: getHexColor('FF6194') }

--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.test.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.test.js
@@ -141,8 +141,7 @@ describe('InlineContent', () => {
       },
       'and ',
       { badge: 'HD' },
-      ' ',
-      'badge ',
+      ' badge ',
       'test.'
     ]);
   });


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Previously, the spacing around the "with some red" in the InlineContent story looked larger than the other spacing. This was because the actual whitespace characters were being stripped out in this object and the flexItem's marginRight was being used instead. This ensures the whitespace characters are retained and the spacing matches the rest of the text in the component. Additionally, this ensures that text and text objects found next to each other in a string do not add the extra marginRight. Previously this was only being applied to text that was the string type.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
Observe the normalized spacing amount within text in the story and that text and text objects adhere to the actual whitespace characters, not extra marginRight's.

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
