### PR TITLE
feat(NavigationManager): allow waiting for child dimensions before rendering

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Column/Column.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.stories.js
@@ -64,7 +64,8 @@ export const Column = args =>
             context.theme.layout.screenH -
             2 * (context.theme.layout.marginY + context.theme.layout.gutterY),
           scrollIndex: args.scrollIndex,
-          items: createItems(Button, 20)
+          items: createItems(Button, 3),
+          waitForDimensions: args.waitForDimensions
         }
       };
     }
@@ -73,7 +74,8 @@ export const Column = args =>
 Column.args = {
   scroll: 1,
   scrollIndex: 0,
-  alwaysScroll: false
+  alwaysScroll: false,
+  waitForDimensions: false
 };
 
 Column.argTypes = {
@@ -93,6 +95,12 @@ Column.argTypes = {
     control: 'boolean',
     description:
       'Determines whether the column will stop scrolling as it nears the bottom to prevent white space',
+    table: { defaultValue: { summary: false } }
+  },
+  waitForDimensions: {
+    control: 'boolean',
+    description:
+      "If true, the Column will wait for all child elements' w and h to be set before displaying the Column",
     table: { defaultValue: { summary: false } }
   }
 };

--- a/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.js
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.js
@@ -110,7 +110,8 @@ export default class Keyboard extends Base {
           },
           autoResizeWidth: true,
           autoResizeHeight: true,
-          neverScroll: true
+          neverScroll: true,
+          waitForDimensions: true
         }
       });
     }
@@ -128,7 +129,8 @@ export default class Keyboard extends Base {
         style: {
           itemSpacing: this.style.keySpacing
         },
-        items: this._createKeys(keys, keyboard)
+        items: this._createKeys(keys, keyboard),
+        waitForDimensions: true
       };
     });
   }

--- a/packages/@lightningjs/ui-components/src/components/Keyboard/__snapshots__/Keyboard.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/__snapshots__/Keyboard.test.js.snap
@@ -11,7 +11,7 @@ exports[`Keyboard renders 1`] = `
       "children": {
         "Items": {
           "active": false,
-          "alpha": 1,
+          "alpha": 0.001,
           "attached": true,
           "boundsMargin": null,
           "children": {
@@ -23,7 +23,7 @@ exports[`Keyboard renders 1`] = `
               "children": {
                 "Items": {
                   "active": false,
-                  "alpha": 1,
+                  "alpha": 0.001,
                   "attached": true,
                   "boundsMargin": null,
                   "children": {
@@ -2704,7 +2704,7 @@ exports[`Keyboard renders 1`] = `
               "children": {
                 "Items": {
                   "active": false,
-                  "alpha": 1,
+                  "alpha": 0.001,
                   "attached": true,
                   "boundsMargin": null,
                   "children": {
@@ -3489,7 +3489,7 @@ exports[`Keyboard renders 1`] = `
               "children": {
                 "Items": {
                   "active": false,
-                  "alpha": 1,
+                  "alpha": 0.001,
                   "attached": true,
                   "boundsMargin": null,
                   "children": {
@@ -6170,7 +6170,7 @@ exports[`Keyboard renders 1`] = `
               "children": {
                 "Items": {
                   "active": false,
-                  "alpha": 1,
+                  "alpha": 0.001,
                   "attached": true,
                   "boundsMargin": null,
                   "children": {
@@ -8879,7 +8879,7 @@ exports[`Keyboard renders 1`] = `
               "children": {
                 "Items": {
                   "active": false,
-                  "alpha": 1,
+                  "alpha": 0.001,
                   "attached": true,
                   "boundsMargin": null,
                   "children": {
@@ -11952,7 +11952,7 @@ exports[`KeyboardInput renders 1`] = `
                   "children": {
                     "Items": {
                       "active": false,
-                      "alpha": 1,
+                      "alpha": 0.001,
                       "attached": true,
                       "boundsMargin": null,
                       "children": {
@@ -11964,7 +11964,7 @@ exports[`KeyboardInput renders 1`] = `
                           "children": {
                             "Items": {
                               "active": false,
-                              "alpha": 1,
+                              "alpha": 0.001,
                               "attached": true,
                               "boundsMargin": null,
                               "children": {
@@ -14673,7 +14673,7 @@ exports[`KeyboardInput renders 1`] = `
                           "children": {
                             "Items": {
                               "active": false,
-                              "alpha": 1,
+                              "alpha": 0.001,
                               "attached": true,
                               "boundsMargin": null,
                               "children": {
@@ -17354,7 +17354,7 @@ exports[`KeyboardInput renders 1`] = `
                           "children": {
                             "Items": {
                               "active": false,
-                              "alpha": 1,
+                              "alpha": 0.001,
                               "attached": true,
                               "boundsMargin": null,
                               "children": {
@@ -20035,7 +20035,7 @@ exports[`KeyboardInput renders 1`] = `
                           "children": {
                             "Items": {
                               "active": false,
-                              "alpha": 1,
+                              "alpha": 0.001,
                               "attached": true,
                               "boundsMargin": null,
                               "children": {
@@ -22716,7 +22716,7 @@ exports[`KeyboardInput renders 1`] = `
                           "children": {
                             "Items": {
                               "active": false,
-                              "alpha": 1,
+                              "alpha": 0.001,
                               "attached": true,
                               "boundsMargin": null,
                               "children": {

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -57,7 +57,8 @@ export default class NavigationManager extends FocusManager {
       'autoResizeWidth',
       'autoResizeHeight',
       'lazyUpCount',
-      'lazyUpCountBuffer'
+      'lazyUpCountBuffer',
+      'waitForDimensions'
     ];
   }
 
@@ -113,10 +114,19 @@ export default class NavigationManager extends FocusManager {
     let maxCrossDimensionSize = 0;
     let maxInnerCrossDimensionSize = 0;
     const childrenToCenter = [];
+    const loadingChildren = [];
 
     for (let i = 0; i < this.Items.children.length; i++) {
       const child = this.Items.children[i];
       const childCrossDimensionSize = this._calcCrossDimensionSize(child);
+
+      if (
+        this.waitForDimensions &&
+        (!childCrossDimensionSize || !child[lengthDimension])
+      ) {
+        loadingChildren.push(child);
+      }
+
       maxCrossDimensionSize = max(
         maxCrossDimensionSize,
         childCrossDimensionSize
@@ -158,6 +168,7 @@ export default class NavigationManager extends FocusManager {
       this.Items[lengthDimension] !== nextPosition;
 
     this.Items.patch({
+      alpha: this.waitForDimensions && loadingChildren.length ? 0.001 : 1,
       [crossDimension]: maxCrossDimensionSize,
       [innerCrossDimension]:
         maxInnerCrossDimensionSize || maxCrossDimensionSize,

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.mdx
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.mdx
@@ -86,6 +86,7 @@ const directionPropNames = {
 | lazyUpCountBuffer | number  | false    | 2         | If `lazyUpCount` is set, this is used to calculate the initial number of items to display on the first render (`lazyUpCount` + `lazyLoadUpCountBuffer`). The remaining items are stored as lazy items. Each time the user navigates further, the next lazy item will be added. |
 | neverScroll       | boolean | false    | false     | if true, the component will never scroll, unless alwaysScroll is set to true, and if false, the component will apply normal scrolling logic                                                                                                                                    |
 | scrollIndex       | number  | false    | 0         | Item index at which scrolling begins, provided the sum of item widths is greater than the width of the `Row`                                                                                                                                                                   |
+| waitForDimensions | boolean | false    | false     | if true, the `NavigationManager` will wait for all child elements' `w` and `h` to be set before displaying the `NavigationManager`                                                                                                                                             |
 
 ### Style Properties
 

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.stories.js
@@ -40,6 +40,7 @@ const sharedArgs = {
   lazyScroll: false,
   neverScroll: false,
   scrollIndex: 0,
+  waitForDimensions: false,
   mode: 'focused'
 };
 
@@ -67,6 +68,12 @@ const sharedArgTypes = {
     control: 'boolean',
     description:
       'Will only scroll the row if the item is off screen and alwaysScroll and neverScroll are both false',
+    table: { defaultValue: { summary: false } }
+  },
+  waitForDimensions: {
+    control: 'boolean',
+    description:
+      "If true, the Row will wait for all child elements' w and h to be set before displaying the Row",
     table: { defaultValue: { summary: false } }
   }
 };
@@ -145,14 +152,15 @@ class Title extends lng.Component {
  * Stories for various versions of the component
  */
 
-export const Row = () =>
+export const Row = args =>
   class Row extends lng.Component {
     static _template() {
       return {
         Row: {
           type: RowComponent,
           w: getWidthByUpCount(context.theme, 1),
-          items: createItems(Button, 12)
+          items: createItems(Button, 12),
+          waitForDimensions: args.waitForDimensions
         }
       };
     }
@@ -324,7 +332,8 @@ SkipFocus.argTypes = {
 
 export const LazyScrollIndexes = ({
   startLazyScrollIndex,
-  stopLazyScrollIndex
+  stopLazyScrollIndex,
+  waitForDimensions
 }) =>
   class LazyScrollIndexes extends lng.Component {
     static _template() {
@@ -339,7 +348,8 @@ export const LazyScrollIndexes = ({
             } ${i === stopLazyScrollIndex ? '(stop lazy scroll)' : ''}`
           })),
           startLazyScrollIndex,
-          stopLazyScrollIndex
+          stopLazyScrollIndex,
+          waitForDimensions: waitForDimensions
         }
       };
     }
@@ -379,6 +389,7 @@ export const AddingItems = args =>
           w: getWidthByUpCount(context.theme, 1), // x offset from preview.js * 2
           lazyUpCount: args.lazyUpCount,
           lazyUpCountBuffer: args.lazyUpCountBuffer,
+          waitForDimensions: args.waitForDimensions,
           signals: {
             append: 'appendButton',
             appendAt: 'appendButtonAt',
@@ -475,7 +486,8 @@ export const LazyUpCount = args =>
           w: getWidthByUpCount(context.theme, 1), // x offset from preview.js * 2
           lazyUpCount: args.lazyUpCount,
           lazyUpCountBuffer: args.lazyUpCountBuffer,
-          items: createItems(Button, 12)
+          items: createItems(Button, 12),
+          waitForDimensions: args.waitForDimensions
         }
       };
     }
@@ -509,13 +521,14 @@ LazyUpCount.parameters = {
     'There are 12 items passed to this Row. The number of items that are initially rendered equals the sum of the lazyUpCount and the lazyUpCountBuffer properties. Each time the next item is selected, an additional item is added to the end of the Row until all 12 items have been rendered.'
 };
 
-export const RemovingItems = () =>
+export const RemovingItems = args =>
   class RemovingItems extends lng.Component {
     static _template() {
       return {
         Row: {
           type: RowComponent,
           w: getWidthByUpCount(context.theme, 1), // x offset from preview.js * 2
+          waitForDimensions: args.waitForDimensions,
           signals: {
             removeAt: 'removeButton'
           },


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
This adds a new property, `waitForDimensions`, to `NavigationManager` (and subcomponents of `NavigationManager`, like `Row` and `Column`). When set to `true`, this will result in the `NavigationManager` to not be displayed (via setting it's alpha to `0.001`) until all items passed to the `items` property have both `w` and `h` defined and greater than 0.

This was implemented due to noticing that the `Key` components in the `Keyboard` component would sometimes initially stack on top of each other on the first render, then "snap" into their correct positions after the `Key` components' `w` or `h` updated to its final value. The `waitForDimensions` property has been enabled in the `Row` and `Column` components rendered by `Keyboard` remove that "snapping" effect and only display the `Keyboard` once the `Key` components have `w` and `h` set and their positions in the `Keyboard` can be determined more accurately.
## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
LUI-1150
<!-- step by step instructions to review this PR's changes -->

## Automation
This might require changes to automation tests if the tests were getting the initial positions of Keys in a Keyboard instead of the final positions.
<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
