### PR TITLE
fix(withTags): only create tags once per component

### DIFF
--- a/packages/@lightningjs/ui-components/src/mixins/withTags/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withTags/index.js
@@ -33,19 +33,22 @@ export default function withTags(Base) {
     }
 
     _construct() {
-      const tags = this.constructor.tags || [];
-      tags.forEach(tag => {
-        if (typeof tag === 'object') {
-          var { name, path } = tag;
-        } else {
-          var name = tag; // eslint-disable-line no-redeclare
-          var path = tag; // eslint-disable-line no-redeclare
-        }
-        const key = '_' + name;
-        const descriptor = getPropertyDescriptor(path);
-        Object.defineProperty(Object.getPrototypeOf(this), key, descriptor);
-      });
-
+      const prototype = Object.getPrototypeOf(this);
+      if (!prototype._withTagsInitialized) {
+        const tags = this.constructor.tags || [];
+        tags.forEach(tag => {
+          if (typeof tag === 'object') {
+            var { name, path } = tag;
+          } else {
+            var name = tag; // eslint-disable-line no-redeclare
+            var path = tag; // eslint-disable-line no-redeclare
+          }
+          const key = '_' + name;
+          const descriptor = getPropertyDescriptor(path);
+          Object.defineProperty(prototype, key, descriptor);
+        });
+        prototype._withTagsInitialized = true;
+      }
       super._construct && super._construct();
     }
   };


### PR DESCRIPTION
## Description

- Currently, the withTags mixin `_construct` hook runs for every instance of a component Class. Because it's modifying the prototype and not the instance, it only needs to run once. 
- This adds a guard to only add the tag accessors once using a similar pattern from withUpdates. 

### Fun Fact/Note on prototypes in lighting I wasn't aware of

For what it's worth, you would expect that setting this guard on the prototype would not be what we want, because if you set the guard on Surface's prototype, then it would evaluate to true for a Button if it's initialized after Surface as they share a prototype chain. 

However, under the hood, lightning core applies a new prototype to the component and mixes in the methods. This means our components behave like they share a prototype chain but the individual instances themselves don't.   https://github.com/rdkcentral/Lightning/blob/a36de7f0e6096a65c6eed44ddd42d9139342d555/src/application/StateMachine.mjs#L26

## Testing

- Tags should still work anywhere multiple components of the same type are rendered, ex. Row and Column stories

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
