### PR TITLE
fix(withThemeStyles): w/h setters don't need to clear style cache

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.js
+++ b/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.js
@@ -40,7 +40,7 @@ export default class ScrollWrapper extends Base {
         type: ScrollSlider,
         vertical: true,
         signals: {
-          onChange: '_updateScrollContainerSize'
+          onSizeChange: '_updateScrollContainerSize'
         },
         announce: ' '
       }
@@ -326,7 +326,7 @@ export default class ScrollWrapper extends Base {
     return content;
   }
 
-  _updateScrollContainerSize(sliderValue, slider) {
+  _updateScrollContainerSize(slider) {
     if (this._sliderWidth !== slider._Container.h) {
       this._sliderWidth = slider._Container.h;
       this._updateScrollContainer();

--- a/packages/@lightningjs/ui-components/src/components/Slider/Slider.js
+++ b/packages/@lightningjs/ui-components/src/components/Slider/Slider.js
@@ -109,11 +109,12 @@ export default class Slider extends Base {
     this._updatePositions();
     this._updateArrowAlpha();
     this._updateArrows();
-    this.signal('onChange', this.value, this);
     if (this._valueChanged) {
+      this.signal('onChange', this.value, this);
       this.fireAncestors('$announce', this.announce);
       this._valueChanged = false;
     }
+    this._checkAndSignalSizeChange();
   }
 
   _handleLeft() {
@@ -164,6 +165,19 @@ export default class Slider extends Base {
       }
     });
     this.h = Math.max(this.style.containerHeight, this.style.arrowHeight);
+  }
+
+  _checkAndSignalSizeChange() {
+    if (
+      this.h !== this.prevH ||
+      this._Container.w !== this.prevW ||
+      this.rotation !== this.prevRotation
+    ) {
+      this.signal('onSizeChange', this);
+    }
+    this.prevH = this.h;
+    this.prevW = this._Container.w;
+    this.prevRotation = this.rotation;
   }
 
   _updatePositions() {

--- a/packages/@lightningjs/ui-components/src/components/Slider/Slider.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Slider/Slider.test.js
@@ -427,6 +427,50 @@ describe('Slider', () => {
     });
   });
 
+  describe('onSizeChange signal', () => {
+    beforeEach(() => {
+      Slider.prototype.signal = jest.fn();
+      [slider, testRenderer] = createSlider({
+        value: 50
+      });
+    });
+
+    it('is fired on init', () => {
+      [slider, testRenderer] = createSlider({
+        value: 50
+      });
+      expect(slider.signal).toBeCalledWith('onSizeChange', slider);
+    });
+
+    it('is fired if vertical toggled', () => {
+      Slider.prototype.signal.mockReset();
+      slider.vertical = true;
+      testRenderer.forceAllUpdates();
+      expect(slider.signal).toBeCalledWith('onSizeChange', slider);
+    });
+
+    it('is fired if width changes', () => {
+      slider.w = 10;
+      Slider.prototype.signal.mockReset();
+      slider.w = 100;
+      testRenderer.forceAllUpdates();
+      expect(slider.signal).toBeCalledWith('onSizeChange', slider);
+    });
+
+    it('is fired if style.containerHeight changes', () => {
+      Slider.prototype.signal.mockReset();
+      slider.style = { containerHeight: 200 };
+      testRenderer.forceAllUpdates();
+      expect(slider.signal).toBeCalledWith('onSizeChange', slider);
+    });
+    it('is fired if style.arrowHeight changes', () => {
+      Slider.prototype.signal.mockReset();
+      slider.style = { arrowHeight: 200 };
+      testRenderer.forceAllUpdates();
+      expect(slider.signal).toBeCalledWith('onSizeChange', slider);
+    });
+  });
+
   describe('when a vertical slider is rendered', () => {
     beforeEach(() => {
       [slider, testRenderer] = createSlider({ vertical: true });

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.js
@@ -140,6 +140,7 @@ export default class TabBar extends Base {
     // triggered when the Tabs Row resizes
     // update the height of TabBar using the latest h value from Tabs
     this._updateTabBarHeight();
+    this._updateTabContent();
   }
 
   _updateTabBarHeight() {

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
@@ -109,7 +109,7 @@ describe('TabBar', () => {
   });
 
   it('should display which tab is selected when focused on the tab content', async () => {
-    await tabBar.__updateSpyPromise;
+    testRenderer.forceAllUpdates();
     testRenderer.keyPress('Down');
 
     expect(tabBar._Tabs.items[0].mode).toBe('selected');
@@ -117,7 +117,7 @@ describe('TabBar', () => {
   });
 
   it('should transfer focus back to the tabs on up', async () => {
-    await tabBar.__updateSpyPromise;
+    testRenderer.forceAllUpdates();
     testRenderer.keyPress('Down');
 
     expect(tabBar._Tabs.items[0].mode).toBe('selected');
@@ -196,7 +196,7 @@ describe('TabBar', () => {
   });
 
   it('should not repeatedly select the tabs when already selected', async () => {
-    await tabBar.__updateSpyPromise;
+    testRenderer.forceAllUpdates();
     jest.spyOn(tabBar, '_updateTabs');
     expect(tabBar._updateTabs).not.toHaveBeenCalled();
 
@@ -334,7 +334,7 @@ describe('TabBar', () => {
 
   describe('the reset property', () => {
     it('should reselect the first item on unfocus when reset is true', () => {
-      tabBar.__updateSpyPromise;
+      testRenderer.forceAllUpdates();
       tabBar.reset = true;
 
       testRenderer.keyPress('Right');
@@ -346,7 +346,8 @@ describe('TabBar', () => {
       expect(tabBar._Tabs.selectedIndex).toBe(0);
     });
     it('should maintain the current selection on unfocus when reset is false', () => {
-      tabBar.__updateSpyPromise;
+      testRenderer.forceAllUpdates();
+
       testRenderer.keyPress('Right');
 
       expect(tabBar._Tabs.selectedIndex).toBe(1);

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
@@ -183,11 +183,14 @@ describe('TabBar', () => {
       { tabs },
       { focused: true, spyOnMethods: ['$itemChanged'] }
     );
-    await tabBar.__updateSpyPromise;
+    testRenderer.forceAllUpdates();
+    await tabBar._$itemChangedSpyPromise;
+
     const initialHeight = tabBar.h;
 
     // this triggers the Tabs Row to fire an $itemChanged signal
     tabBar.tabs = [{ rect: true, h: initialHeight + 20, w: 200 }];
+    testRenderer.forceAllUpdates();
     await tabBar._$itemChangedSpyPromise;
 
     expect(tabBar.h).toBeGreaterThan(initialHeight);

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
@@ -109,7 +109,6 @@ describe('TabBar', () => {
   });
 
   it('should display which tab is selected when focused on the tab content', async () => {
-    await tabBar.__updateSpyPromise;
     testRenderer.keyPress('Down');
 
     expect(tabBar._Tabs.items[0].mode).toBe('selected');
@@ -117,7 +116,6 @@ describe('TabBar', () => {
   });
 
   it('should transfer focus back to the tabs on up', async () => {
-    await tabBar.__updateSpyPromise;
     testRenderer.keyPress('Down');
 
     expect(tabBar._Tabs.items[0].mode).toBe('selected');
@@ -196,7 +194,6 @@ describe('TabBar', () => {
   });
 
   it('should not repeatedly select the tabs when already selected', async () => {
-    await tabBar.__updateSpyPromise;
     jest.spyOn(tabBar, '_updateTabs');
     expect(tabBar._updateTabs).not.toHaveBeenCalled();
 

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
@@ -109,7 +109,7 @@ describe('TabBar', () => {
   });
 
   it('should display which tab is selected when focused on the tab content', async () => {
-    testRenderer.forceAllUpdates();
+    await tabBar.__updateSpyPromise;
     testRenderer.keyPress('Down');
 
     expect(tabBar._Tabs.items[0].mode).toBe('selected');
@@ -117,7 +117,7 @@ describe('TabBar', () => {
   });
 
   it('should transfer focus back to the tabs on up', async () => {
-    testRenderer.forceAllUpdates();
+    await tabBar.__updateSpyPromise;
     testRenderer.keyPress('Down');
 
     expect(tabBar._Tabs.items[0].mode).toBe('selected');
@@ -196,7 +196,7 @@ describe('TabBar', () => {
   });
 
   it('should not repeatedly select the tabs when already selected', async () => {
-    testRenderer.forceAllUpdates();
+    await tabBar.__updateSpyPromise;
     jest.spyOn(tabBar, '_updateTabs');
     expect(tabBar._updateTabs).not.toHaveBeenCalled();
 
@@ -334,7 +334,6 @@ describe('TabBar', () => {
 
   describe('the reset property', () => {
     it('should reselect the first item on unfocus when reset is true', () => {
-      testRenderer.forceAllUpdates();
       tabBar.reset = true;
 
       testRenderer.keyPress('Right');
@@ -346,8 +345,6 @@ describe('TabBar', () => {
       expect(tabBar._Tabs.selectedIndex).toBe(0);
     });
     it('should maintain the current selection on unfocus when reset is false', () => {
-      testRenderer.forceAllUpdates();
-
       testRenderer.keyPress('Right');
 
       expect(tabBar._Tabs.selectedIndex).toBe(1);

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
@@ -321,14 +321,14 @@ describe('TabBar', () => {
   });
 
   it('should allow overwriting the margin between tabs and tab content', async () => {
-    await tabBar.__updateSpyPromise;
+    testRenderer.forceAllUpdates();
     expect(tabBar._TabContent.y).toBe(
       tabBar._Tabs.h + tabBar.style.tabsMarginBottom
     );
   });
 
   it('should set the tab item spacing', async () => {
-    await tabBar.__updateSpyPromise;
+    testRenderer.forceAllUpdates();
     expect(tabBar._Tabs.style.itemSpacing).toBe(tabBar.style.tabSpacing);
   });
 

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
@@ -394,8 +394,7 @@ export default function withThemeStyles(Base, mixinStyle = {}) {
       if (this._w === v) return;
       super.w = v;
       this._wSetByUser = true;
-      this._styleManager.clearStyleCache();
-      this._styleManager.update();
+      this._updateThemeComponent();
     }
 
     /**
@@ -414,8 +413,7 @@ export default function withThemeStyles(Base, mixinStyle = {}) {
       if (this._h === v) return;
       super.h = v;
       this._hSetByUser = true;
-      this._styleManager.clearStyleCache();
-      this._styleManager.update();
+      this._updateThemeComponent();
     }
   };
 }


### PR DESCRIPTION
## Description

- Currently, in `withThemeStyles`, the w/h setters clear the StyleManger style cache. However, the style calculation doesn't change based on the w/h props. 
- Instead, we can just run the component update cycle without clearing the style cache. 

## Testing

<!-- step by step instructions to review this PR's changes -->

- In Tile story, change the itemLayout props to update the item w/h, Tile should still be styled properly. 
- If anyone can think of anything else this may impact, let me know. 
- Slider and TabBar both needed minor fixes. Ensure they render properly on init and function as expected.

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
