### PR TITLE
fix(withExtensions): Performance refactor

### DIFF
--- a/packages/@lightningjs/ui-components/src/docs/ThemingExtensions.mdx
+++ b/packages/@lightningjs/ui-components/src/docs/ThemingExtensions.mdx
@@ -145,6 +145,11 @@ If we find through A/B testing, the results are not in favor of the vibrant colo
 
 ## Things to Keep in Mind
 
+### `_construct()` usage restriction
+
+Because extensions are applied at runtime on `_contruct` of the component instance, they cannot properly support a `_construct` method override in the extension so must be avoided.
+Other lifecycle hooks are available and supported, such as `_init` and `_attach`.
+
 ### `super._update()`
 
 If we consider extensions as the child of the existing component it builds off, the `super` keyword allows us to access the properties and methods in the existing/parent component. The `_update` method is an extremely important lifecycle event since it ensures everything is up to date. Together, `super._update()` grants us access to the entire `_update` lifecycle event of the parent component.

--- a/packages/@lightningjs/ui-components/src/globals/context/context.test.js
+++ b/packages/@lightningjs/ui-components/src/globals/context/context.test.js
@@ -49,6 +49,8 @@ describe('context', () => {
   describe('context api', () => {
     it('should get the base theme by default', () => {
       const processedBaseTheme = themeManager._processTheme();
+      processedBaseTheme.lastUpdateTimestamp = expect.any(Number);
+
       expect(context.theme).toMatchObject(processedBaseTheme);
     });
 
@@ -73,6 +75,7 @@ describe('context', () => {
 
     it('should not allow context.theme to be set directly', () => {
       const processedBaseTheme = themeManager._processTheme();
+      processedBaseTheme.lastUpdateTimestamp = expect.any(Number);
       context.theme = { foo: 'bar' };
       expect(context.theme).toMatchObject(processedBaseTheme);
     });
@@ -113,6 +116,8 @@ describe('context', () => {
     it('should set a sub theme when with setSubTheme and fetch to appropriate theme when using getSubTheme', () => {
       context.setSubTheme('mySubTheme', { radius: { md: 80 } });
       const baseTheme = context.theme;
+      baseTheme.lastUpdateTimestamp = expect.any(Number);
+
       const subTheme = context.getSubTheme('mySubTheme');
       baseTheme.radius.md = 80;
       expect(subTheme).toMatchObject(baseTheme);

--- a/packages/@lightningjs/ui-components/src/globals/context/context.theme.test.js
+++ b/packages/@lightningjs/ui-components/src/globals/context/context.theme.test.js
@@ -35,17 +35,23 @@ describe('theme context', () => {
   describe('basic theme functionality', () => {
     it('should have default theme', () => {
       const processedBaseTheme = themeManager._processTheme();
+      processedBaseTheme.lastUpdateTimestamp = expect.any(Number);
+
       expect(themeManager.getTheme()).toMatchObject(processedBaseTheme);
     });
 
     it('should deep merge object with existing theme when theme is set', () => {
       const processedBaseTheme = themeManager._processTheme([{ foo: 'bar' }]);
+      processedBaseTheme.lastUpdateTimestamp = expect.any(Number);
+
       themeManager.setTheme({ foo: 'bar' });
       expect(themeManager.getTheme()).toMatchObject(processedBaseTheme);
     });
 
     it('should not attempt to set any value for theme that is not an object', () => {
       const processedBaseTheme = themeManager._processTheme();
+      processedBaseTheme.lastUpdateTimestamp = expect.any(Number);
+
       themeManager.setTheme('string');
       expect(themeManager.getTheme()).toMatchObject(processedBaseTheme);
       themeManager.setTheme(() => {
@@ -71,7 +77,17 @@ describe('theme context', () => {
     });
 
     it('should process the theme correctly', () => {
+      const startTime = Date.now();
       const processedBaseTheme = themeManager._processTheme();
+      const endTime = Date.now();
+      expect(processedBaseTheme.lastUpdateTimestamp).toBeGreaterThanOrEqual(
+        startTime
+      );
+      expect(processedBaseTheme.lastUpdateTimestamp).toBeLessThanOrEqual(
+        endTime
+      );
+      processedBaseTheme.lastUpdateTimestamp = expect.any(Number);
+
       expect(themeManager.getTheme()).toMatchObject(processedBaseTheme);
       themeManager.setTheme({ foo: 'bar' });
       expect(themeManager.getTheme().foo).toBe('bar');

--- a/packages/@lightningjs/ui-components/src/globals/context/theme-manager.js
+++ b/packages/@lightningjs/ui-components/src/globals/context/theme-manager.js
@@ -420,7 +420,12 @@ class ThemeManager {
       }
     });
 
-    return { ...JSON.parse(themeString), ...themeFunctions, extensions };
+    return {
+      ...JSON.parse(themeString),
+      ...themeFunctions,
+      extensions,
+      lastUpdateTimestamp: Date.now()
+    };
   }
 }
 

--- a/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.d.ts
@@ -34,6 +34,8 @@ export interface WithExtensions {
   _instanceNeedsReset(): boolean;
   _resetPrototype(): void;
   _handleThemeChange(): void;
+  _markInstanceUpToDate(): void;
+  _markClassUpToDate(): void;
 }
 
 export interface WithExtensionsConstructor {

--- a/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.d.ts
@@ -29,6 +29,7 @@ export interface WithExtensions {
   _resetComponent(): void;
   _calculateComponentExtensionLength(): number;
   _createExtension(): void;
+  _checkAndCreateExtension(): boolean;
   _setupExtension(): void;
   _instanceNeedsReset(): boolean;
   _resetPrototype(): void;

--- a/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.d.ts
@@ -19,7 +19,8 @@
 import lng from '@lightningjs/core';
 
 export interface WithExtensions {
-  _withExtensionsApplied?: boolean;
+  _instanceLastThemeUpdateTimestamp?: number;
+
   get _prototypeChain(): Set<string>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   get _extensions(): Record<string, any>[];
@@ -29,9 +30,14 @@ export interface WithExtensions {
   _calculateComponentExtensionLength(): number;
   _createExtension(): void;
   _setupExtension(): void;
+  _instanceNeedsReset(): boolean;
+  _resetPrototype(): void;
+  _handleThemeChange(): void;
 }
 
 export interface WithExtensionsConstructor {
+  _lastThemeUpdateTimestamp?: number;
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   new (...args: any[]): WithExtensions;
 }

--- a/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.d.ts
@@ -24,16 +24,11 @@ export interface WithExtensions {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   get _extensions(): Record<string, any>[];
   get _componentExtensions(): unknown[];
-  get _extensionsApplied(): boolean;
 
   _resetComponent(): void;
   _calculateComponentExtensionLength(): number;
   _createExtension(): void;
-  _createExtensionClass(): unknown;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  _createExtensionAliases(obj: Record<string, any>): object;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  _setComponentAliases(aliasObj: Record<string, any>): void;
+  _setupExtension(): void;
 }
 
 export interface WithExtensionsConstructor {

--- a/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.d.ts
@@ -19,7 +19,7 @@
 import lng from '@lightningjs/core';
 
 export interface WithExtensions {
-  get _withExtensionsApplied(): boolean;
+  _withExtensionsApplied?: boolean;
   get _prototypeChain(): Set<string>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   get _extensions(): Record<string, any>[];

--- a/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.js
@@ -21,9 +21,6 @@ import { context } from '../../globals';
 const SUFFIX = '__original';
 
 export default function withExtensions(Base) {
-  if (Base.prototype.constructor._withExtensionsApplied) {
-    return Base;
-  }
   return class extends Base {
     static get name() {
       return Base.name;
@@ -36,11 +33,6 @@ export default function withExtensions(Base) {
         );
       }
       return super.__componentName;
-    }
-
-    static get _withExtensionsApplied() {
-      // Extensions should only be applied once per class. This prevents it running multiple times. Ex. Surface -> Tile
-      return true;
     }
 
     /**
@@ -71,7 +63,7 @@ export default function withExtensions(Base) {
      * @returns {object[]} // Array of objects
      */
     get _extensions() {
-      const extensions = context && context.theme && context.theme.extensions;
+      const extensions = context?.theme?.extensions;
       if (
         !extensions ||
         !Array.isArray(extensions) ||
@@ -124,24 +116,9 @@ export default function withExtensions(Base) {
         }, []);
     }
 
-    /**
-     * Check if theme extension mixins have already been applied
-     * @return {boolean}
-     */
-    get _extensionApplied() {
-      return (
-        this._currentComponentExtensionLength === this._appliedExtensionLength
-      );
-    }
-
     _construct() {
-      this._appliedExtensionLength = 0; // After the extensions are applied we store the length of all to determine later on if they have been applied before
-      this._extendedList = {};
-      this._extensionInstance = {}; // This will hold the extension instance once created
       this._setupExtensionBound = this._setupExtension.bind(this);
       context.on('themeUpdate', this._setupExtensionBound);
-      this._currentComponentExtensionLength =
-        this._calculateComponentExtensionLength();
       this._createExtension();
       super._construct();
     }
@@ -152,147 +129,136 @@ export default function withExtensions(Base) {
     }
 
     _setupExtension() {
-      this._currentComponentExtensionLength =
-        this._calculateComponentExtensionLength();
-      this._createExtension.call(this);
+      this._resetComponent();
+      this.constructor._withExtensionsApplied = false;
+      this._createExtension();
     }
 
     _resetComponent() {
-      this._extensionInstance._extensionCleanup &&
-        this._extensionInstance._extensionCleanup.call(this);
+      this._extensionCleanup && this._extensionCleanup();
+      const thisPrototype = Object.getPrototypeOf(this);
 
-      (Object.keys(this._extendedList) || []).forEach(prop => {
-        delete this[prop];
-        delete this[prop + SUFFIX];
-      });
+      // Cleanup added props: just delete
+      if (thisPrototype.addedProps) {
+        // Props that were just added can be deleted
+        thisPrototype.addedProps.forEach(prop => {
+          delete thisPrototype[prop];
+        });
+        delete thisPrototype.addedProps;
+      }
 
-      this._extensionInstance = {};
-      this._extendedList = {};
-    }
-
-    _calculateComponentExtensionLength() {
-      const extensionLength = this._componentExtensions.reduce(
-        (acc, extensionMixin) => {
-          acc += extensionMixin.toString().length;
-          return acc;
-        },
-        0
-      );
-      return extensionLength;
+      // Cleanup overridden props: replace saved originals then delete
+      if (thisPrototype.overRiddenProps) {
+        thisPrototype.overRiddenProps.forEach(prop => {
+          if (thisPrototype.originalDescriptors[prop]) {
+            Object.defineProperty(
+              thisPrototype,
+              prop,
+              thisPrototype.originalDescriptors[prop]
+            );
+            delete thisPrototype[prop + SUFFIX];
+          } else {
+            delete thisPrototype[prop];
+            delete thisPrototype[prop + SUFFIX];
+          }
+        });
+        delete thisPrototype.overRiddenProps;
+      }
+      if (thisPrototype.originalDescriptor) {
+        delete thisPrototype.originalDescriptors;
+      }
     }
 
     _createExtension() {
-      if (this._extensionApplied) return;
-      this._resetComponent();
-      const ExtendedClass = this._createExtensionClass();
-      const instance = new ExtendedClass();
-      this._extendedList = this._createExtensionAliases(instance);
-      this._extensionInstance = instance;
-      this._setComponentAliases(this._extendedList);
-    }
-
-    /**
-     * Create the extension class
-     * @return {class}
-     */
-    _createExtensionClass() {
-      /**
-       *
-       * This class will sit at the bottom of the prototype stack and redirect all calls to the original to prevent an infinite loop
-       *
-       */
-      function ExtensionBase() {}
-
-      /** Create a new class the represents the extensions */
-      const ExtendedClass = this._componentExtensions.reduce(
-        (acc, extension) => {
-          // Get the length of the extension and store the value. This will be used to determine if the mixin has been changed and needs to be re-applied
-          return extension(acc);
-        },
-        ExtensionBase
-      );
-
-      // Store the length of the extension to be applied
-      this._appliedExtensionLength = this._calculateComponentExtensionLength();
-
-      return ExtendedClass;
-    }
-
-    _createExtensionAliases(obj) {
-      // Find the prototype to be replaced
-      let baseProto = obj;
-      for (let i = 0; i < this._componentExtensions.length + 1; i++) {
-        baseProto = Object.getPrototypeOf(baseProto);
+      // Only setup once per component
+      if (this.constructor._withExtensionsApplied) {
+        return;
       }
+      class ExtensionBaseClass {}
 
-      /**
-       * We will create alias for all the methods, getters, setters that will be overwritten by the extension layer
-       * Create a list of properties to alias
-       */
+      const componentExtensions = this._componentExtensions;
 
-      const extended = {};
+      // create an extended class and accumulate all methods.
+      // overrides are fine b/c they're preserved in the ExtendedClass
+      const accumDescriptors = {};
+      const ExtendedClass = componentExtensions.reduce((acc, ext) => {
+        const extended = ext(acc);
+        Object.assign(
+          accumDescriptors,
+          Object.getOwnPropertyDescriptors(extended.prototype)
+        );
+        return extended;
+      }, ExtensionBaseClass);
 
-      const extensionOverrides = this._componentExtensions.reduce(
-        (acc, extension) => {
-          const extensionClass = new extension(class FakeClass {});
-          const instance = new extensionClass();
-          // Get the descriptors
-          const originalComponentDescriptors = Object.getOwnPropertyDescriptors(
-            Object.getPrototypeOf(instance)
+      const thisPrototype = Object.getPrototypeOf(this);
+      const existingDescriptors = getAllCustomDescriptors(thisPrototype);
+
+      thisPrototype.originalDescriptors =
+        Object.getOwnPropertyDescriptors(thisPrototype);
+
+      thisPrototype.addedProps = [];
+      thisPrototype.overRiddenProps = [];
+      Object.keys(accumDescriptors).forEach(prop => {
+        if (prop === 'constructor') {
+          return;
+        }
+
+        if (existingDescriptors[prop]) {
+          thisPrototype.overRiddenProps.push(prop);
+          // if prop exists on base, need to keep original method before overriding
+          Object.defineProperty(
+            thisPrototype,
+            prop + SUFFIX,
+            existingDescriptors[prop]
           );
-          Object.keys(originalComponentDescriptors).forEach(prop => {
-            if (['constructor'].includes(prop)) return;
-            if (
-              originalComponentDescriptors[prop].get ||
-              originalComponentDescriptors[prop].set
-            ) {
-              extended[prop] = { type: 'accessor' };
-              acc[prop] = {
-                get: function () {
-                  return this[prop + SUFFIX];
-                },
-                set: function (v) {
-                  this[prop + SUFFIX] = v;
-                }
-              };
-              return;
-            }
-            extended[prop] = { type: 'method' };
-            acc[prop] = {
-              value: function () {
-                this[prop + SUFFIX] && this[prop + SUFFIX]();
+
+          // then add overriding method to current class prototype
+
+          if (accumDescriptors[prop].get || accumDescriptors[prop].set) {
+            // Setup accessor
+            Object.defineProperty(thisPrototype, prop, accumDescriptors[prop]);
+
+            // Map to original accessor with suffix at ExtensionBase level
+            Object.defineProperty(ExtensionBaseClass.prototype, prop, {
+              configurable: true,
+              get: function () {
+                return this[prop + SUFFIX];
+              },
+              set: function (v) {
+                this[prop + SUFFIX] = v;
               }
-            };
-          });
-          return acc;
-        },
-        {}
-      );
+            });
+          } else {
+            // setup standard method
+            thisPrototype[prop] = ExtendedClass.prototype[prop];
 
-      Object.defineProperties(baseProto, extensionOverrides);
-      Object.setPrototypeOf(baseProto, this); // Set the bottom level prototype === the component
-
-      return extended;
-    }
-
-    _setComponentAliases(aliasObj) {
-      Object.keys(aliasObj).forEach(prop => {
-        // Create an alias for the existing component property to save the original value
-        this[prop + SUFFIX] = this[prop];
-        if (aliasObj[prop].type === 'method') {
-          this[prop] = this._extensionInstance[prop];
-        } else if (aliasObj[prop].type === 'accessor') {
-          Object.defineProperty(this, prop, {
-            configurable: true, // Allow accessors to be updated on theme change
-            get() {
-              return this._extensionInstance[prop];
-            },
-            set(v) {
-              this._extensionInstance[prop] = v;
-            }
-          });
+            // Base Extension class calls this original method with stored name
+            Object.defineProperty(ExtensionBaseClass.prototype, prop, {
+              value: function (...args) {
+                this[prop + SUFFIX] && this[prop + SUFFIX](...args);
+              }
+            });
+          }
+        } else {
+          thisPrototype.addedProps.push(prop);
+          //otherwise we can just add to the prototype
+          Object.defineProperty(thisPrototype, prop, accumDescriptors[prop]);
         }
       });
+
+      this.constructor._withExtensionsApplied = true;
     }
   };
+}
+
+export function getAllCustomDescriptors(obj) {
+  if (!obj || obj === Object.prototype) {
+    return {};
+  } else {
+    const proto = Object.getPrototypeOf(obj);
+    return {
+      ...getAllCustomDescriptors(proto),
+      ...Object.getOwnPropertyDescriptors(obj)
+    };
+  }
 }

--- a/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.js
@@ -21,18 +21,16 @@ import { context } from '../../globals';
 /**
  * Note on how instance createExtensions cleanup are handled:
  *
- * 1. If you're a new instance and prototype doesn't have extension, run createExtensions
- *  and mark instance and prototype as up to date
+ * 1. For a new instance, if the prototype doesn't have extensions applied, run createExtensions and mark the instance and the prototype as up to date
  *
  * 2. A second instance will be marked as instance up to date, and createExtension won't need to run
  *
- * 3. If theme changes with instances attached, they all run cleanup, and then each tries to run checkAndCreateExtension.
- * This will run createExtension the first time, and then mark all other instances as up to date without running createExtension
+ * 3. If the theme changes with instances attached, they all run the instance extensionCleanup cycle, and then each tries to run checkAndCreateExtension.
+ * This will run createExtension the first time, and then mark all other instances as up to date without running createExtension.
  *
- * 4. If theme changes when instances exist but are not attached, their cleanup listeners won't run.
- * Instead, on attach, we check if both the instance and prototype needs updating.
- * We don't end up repeatedly calling extensionCleanup on attach because in the _construct hook for a new instance
- * We start with the latest timestamp.
+ * 4. If the theme changes when instances exist but are not attached, their cleanup listeners won't run.
+ * Instead, on attach, we check if both the instance and its prototype need updating.
+ * We don't end up repeatedly calling extensionCleanup on attach because in the _construct hook for a new instance We start with the latest timestamp. This hook is not run when reusing an instance.
  *
  */
 

--- a/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.js
@@ -147,12 +147,13 @@ export default function withExtensions(Base) {
 
     _attach() {
       // If you have a component instance that was detached, but then reused, need to check if the extensions need to be updated
-      // Here we are assuming it's ok to run _extensionCleanup at any time, even if the extension code has never run in an update cycle
+      // Here we are assuming it's ok to run _extensionCleanup at any time, even if the extension code has never run in an update cycle.
       if (this._instanceNeedsReset()) {
         this._resetComponent();
         this._markInstanceUpToDate();
       }
 
+      // If the theme changes while there are no instances of the component attached, and a component is re-used later, we need to ensure the prototype is reset (removing old extensions), and then re-apply the new extensions.
       if (!this._classHasLatestExtensions()) {
         this._resetPrototype();
         this._checkAndCreateExtension();

--- a/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withExtensions/index.js
@@ -161,13 +161,10 @@ export default function withExtensions(Base) {
      * Triggers cleanup and creation of new extended component prototype for component instances that are attached during a theme change
      */
     _handleThemeChange() {
-      // Must run a frame after so all active instances may run extensionCleanup first
-      setTimeout(() => {
-        if (!this._prototypeHasLatestExtensions()) {
-          this._resetPrototype();
-          this._checkAndCreateExtension();
-        }
-      }, 0);
+      if (!this._prototypeHasLatestExtensions()) {
+        this._resetPrototype();
+        this._checkAndCreateExtension();
+      }
     }
 
     /**

--- a/packages/@lightningjs/ui-components/src/mixins/withExtensions/withExtensions.test.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withExtensions/withExtensions.test.js
@@ -17,10 +17,7 @@
  */
 
 import lng from '@lightningjs/core';
-import {
-  makeCreateComponent,
-  nextTick
-} from '@lightningjs/ui-components-test-utils';
+import { makeCreateComponent } from '@lightningjs/ui-components-test-utils';
 import withExtensions, { getAllCustomDescriptors } from '.';
 import { context } from '../../globals';
 import { jest } from '@jest/globals';
@@ -153,8 +150,7 @@ describe('withExtensions', () => {
     withExtensionsComponent2,
     withExtensionsComponent3,
     testRenderer,
-    renderTwoInstances,
-    testComponentType;
+    renderTwoInstances;
 
   beforeEach(async () => {
     await context.setTheme({ extensions: extensions });
@@ -292,7 +288,7 @@ describe('withExtensions', () => {
         }
       ]
     });
-    await nextTick();
+
     withExtensionsComponent._update();
     expect(extensionMock).toHaveBeenCalledWith('from string');
   });
@@ -337,7 +333,6 @@ describe('withExtensions', () => {
     const [firstInstance, secondInstance] = renderTwoInstances();
 
     await context.setTheme({ extensions: [] }); // remove extension
-    await nextTick();
     firstInstance._update();
     expect(extensionMock.mock.calls[0][0]).toBe('base component');
     expect(extensionMock).toHaveBeenCalledTimes(1);
@@ -352,14 +347,12 @@ describe('withExtensions', () => {
     const [firstInstance, secondInstance] = renderTwoInstances();
 
     await context.setTheme({ extensions: [] }); // remove extension
-    await nextTick();
     expect(firstInstance._testAddedMethod).toBeUndefined();
     expect(secondInstance._testAddedMethod).toBeUndefined();
   });
 
   it('removes extension getters and setters on theme change', async () => {
     await context.setTheme({ extensions: [] }); // remove extension
-    await nextTick();
     withExtensionsComponent.testGetter = 'test';
     expect(withExtensionsComponent.testGetter).toBe('test');
   });
@@ -374,7 +367,6 @@ describe('withExtensions', () => {
 
     // change theme
     await context.setTheme({ extensions: [] }); // remove extension
-    await nextTick();
 
     expect(firstInstance._instanceNeedsReset()).toBe(true);
     expect(secondInstance._instanceNeedsReset()).toBe(true);

--- a/packages/@lightningjs/ui-components/src/mixins/withExtensions/withExtensions.test.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withExtensions/withExtensions.test.js
@@ -18,11 +18,12 @@
 
 import lng from '@lightningjs/core';
 import { makeCreateComponent } from '@lightningjs/ui-components-test-utils';
-import withExtensions from '.';
+import withExtensions, { getAllCustomDescriptors } from '.';
 import { context } from '../../globals';
 import { jest } from '@jest/globals';
 
 const extensionMock = jest.fn();
+const cleanupMock = jest.fn();
 
 class Example extends lng.Component {
   static get __componentName() {
@@ -34,7 +35,7 @@ class Example extends lng.Component {
   }
 
   set testGetter(v) {
-    this._textGetter = v;
+    this._testGetter = v;
   }
 
   _update() {
@@ -62,6 +63,16 @@ class Example3 extends lng.Component {
   }
 }
 
+class BaseWithInit extends lng.Component {
+  static get __componentName() {
+    return 'BaseWithInit';
+  }
+
+  _init() {
+    extensionMock('base init');
+  }
+}
+
 const extensions = [
   {
     targetComponent: ['Example', 'Example2'],
@@ -79,6 +90,10 @@ const extensions = [
           extensionMock('extension 1');
           super._update();
         }
+        _extensionCleanup() {
+          cleanupMock('cleanup 1');
+          super._extensionCleanup && super._extensionCleanup();
+        }
       };
     }
   },
@@ -89,6 +104,19 @@ const extensions = [
         _update() {
           extensionMock('extension 2');
           super._update();
+        }
+
+        _testAddedMethod() {}
+
+        get testAddedAccessor() {
+          return this._testAddedAccessor;
+        }
+        set testAddedAccessor(val) {
+          this._testAddedAccessor = val;
+        }
+        _extensionCleanup() {
+          cleanupMock('cleanup 2');
+          super._extensionCleanup && super._extensionCleanup();
         }
       };
     }
@@ -103,20 +131,37 @@ const extensions = [
         }
       };
     }
+  },
+  {
+    targetComponent: ['BaseWithInit'],
+    extension: function (Base) {
+      return class extends Base {
+        _init() {
+          extensionMock('extension init');
+          super._init();
+        }
+      };
+    }
   }
 ];
 
 describe('withExtensions', () => {
   let withExtensionsComponent,
+    withExtensionsComponentSecondInstance,
     withExtensionsComponent2,
     withExtensionsComponent3;
 
-  beforeEach(() => {
-    context.setTheme({ extensions: extensions });
-    [withExtensionsComponent] = makeCreateComponent(
+  beforeEach(async () => {
+    await context.setTheme({ extensions: extensions });
+
+    const firstComponentMaker = makeCreateComponent(
       withExtensions(Example),
       {}
-    )();
+    );
+
+    [withExtensionsComponent] = firstComponentMaker();
+    [withExtensionsComponentSecondInstance] = firstComponentMaker();
+
     [withExtensionsComponent2] = makeCreateComponent(
       withExtensions(Example2),
       {}
@@ -144,6 +189,17 @@ describe('withExtensions', () => {
     expect(extensionMock.mock.calls[2][0]).toBe('extension 3');
     expect(extensionMock.mock.calls[3][0]).toBe('base component');
     expect(withExtensionsComponent.testGetter).toBe(
+      'extension layer + test getter'
+    );
+  });
+
+  it('returns the proper extensions for a second instance of component1', () => {
+    withExtensionsComponentSecondInstance._update();
+    expect(extensionMock.mock.calls[0][0]).toBe('extension 1');
+    expect(extensionMock.mock.calls[1][0]).toBe('extension 2');
+    expect(extensionMock.mock.calls[2][0]).toBe('extension 3');
+    expect(extensionMock.mock.calls[3][0]).toBe('base component');
+    expect(withExtensionsComponentSecondInstance.testGetter).toBe(
       'extension layer + test getter'
     );
   });
@@ -194,5 +250,112 @@ describe('withExtensions', () => {
   it('allows getters and setters to be overwritten at the extension level', () => {
     withExtensionsComponent.testGetter = 'test';
     expect(withExtensionsComponent.testGetter).toBe('test from setter');
+  });
+
+  it('calls _init hook of the extension and base class for both the first instance and later instances', () => {
+    extensionMock.mockClear();
+
+    makeCreateComponent(withExtensions(BaseWithInit), {})();
+    expect(extensionMock.mock.calls[0][0]).toBe('extension init');
+    expect(extensionMock.mock.calls[1][0]).toBe('base init');
+
+    extensionMock.mockClear();
+
+    makeCreateComponent(withExtensions(BaseWithInit), {})();
+    expect(extensionMock.mock.calls[0][0]).toBe('extension init');
+    expect(extensionMock.mock.calls[1][0]).toBe('base init');
+  });
+
+  it('tracks added and overridden props', () => {
+    expect(withExtensionsComponent.addedProps.sort()).toEqual(
+      ['_testAddedMethod', 'testAddedAccessor', '_extensionCleanup'].sort()
+    );
+
+    expect(withExtensionsComponent.overRiddenProps.sort()).toEqual(
+      ['_update', 'testGetter'].sort()
+    );
+  });
+
+  it('calls cleanup functions in proper order', async () => {
+    await context.setTheme({ extensions: [] }); // remove extension
+
+    expect(cleanupMock.mock.calls[0][0]).toBe('cleanup 1');
+    expect(cleanupMock.mock.calls[1][0]).toBe('cleanup 2');
+  });
+
+  it('removes overridden extension functions on theme change from all instances', async () => {
+    await context.setTheme({ extensions: [] }); // remove extension
+
+    withExtensionsComponent._update();
+    expect(extensionMock.mock.calls[0][0]).toBe('base component');
+    expect(extensionMock).toHaveBeenCalledTimes(1);
+    extensionMock.mockClear();
+
+    withExtensionsComponentSecondInstance._update();
+    expect(extensionMock.mock.calls[0][0]).toBe('base component');
+    expect(extensionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes added methods on theme chage from all instances', async () => {
+    await context.setTheme({ extensions: [] }); // remove extension
+    expect(withExtensionsComponent._testAddedMethod).toBeUndefined();
+    expect(
+      withExtensionsComponentSecondInstance._testAddedMethod
+    ).toBeUndefined();
+  });
+  it('removes extension getters and setters on theme chage', async () => {
+    await context.setTheme({ extensions: [] }); // remove extension
+    withExtensionsComponent.testGetter = 'test';
+    expect(withExtensionsComponent.testGetter).toBe('test');
+  });
+});
+
+describe('getAllCustomDescriptors', () => {
+  it('Does not return base Object or Object.prototype property descriptors', () => {
+    class TestClass {}
+    const testClassInstance = new TestClass();
+
+    expect(getAllCustomDescriptors(testClassInstance)).toEqual({
+      constructor: {
+        writable: true,
+        enumerable: false,
+        configurable: true,
+        value: TestClass
+      }
+    });
+  });
+
+  it('Aggregates property descriptors throughout the prototype chain', () => {
+    class BaseClass {
+      constructor() {}
+      baseMethod() {}
+    }
+
+    class TestClass extends BaseClass {
+      testMethod() {}
+    }
+
+    const testClassInstance = new TestClass();
+
+    expect(getAllCustomDescriptors(testClassInstance)).toMatchObject({
+      constructor: {
+        writable: true,
+        enumerable: false,
+        configurable: true,
+        value: TestClass
+      },
+      baseMethod: {
+        writable: true,
+        enumerable: false,
+        configurable: true,
+        value: BaseClass.prototype.baseMethod
+      },
+      testMethod: {
+        writable: true,
+        enumerable: false,
+        configurable: true,
+        value: TestClass.prototype.testMethod
+      }
+    });
   });
 });


### PR DESCRIPTION
## Description

 withExtensions currently runs on `_construct` for every instance of a component class. This updates the extension creation process to only modify component prototypes, so the createExtensions workflow only needs to run once for all instances of a component class.

- Adds additional tests
- Adds a note to the readme about the `_construct` hook not being supported in extensions. This is not a new limitation, it was just previously not documented. 
- Adds timestamp to theme when processed for tracking purposes
- **Also question**: there are technically some type changes, but only on underscored methods. Let me know how we semver that?
- Note on **subtheme**: I don't believe the current versions handles running the cleanup methods on subtheme events, so I haven't gotten into that. May be an outstanding feature?

## Testing

Tricky to test this in open source repo... Need to apply some extensions and make sure they are functioning properly. 


## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
