### PR TITLE
fix(Tooltip): adds updateBackground to _update

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.js
+++ b/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.js
@@ -64,6 +64,7 @@ export default class Tooltip extends Base {
 
   _update() {
     this._updateText();
+    this._updateBackground(); //NOTE: adding _updateBackground() here fixes the issue
   }
 
   _updateText() {
@@ -80,7 +81,7 @@ export default class Tooltip extends Base {
     this._updateTextPosition();
   }
 
-  //NOTE: this only runs on initial load of story
+  //REVIEW: this only runs on initial load the story or when clicking another story and coming back to this story, may be the issue with the tone render issue
   _updateBackground() {
     const backgroundH =
       this._Text.finalH + this.style.paddingY * 2 + this.style.pointerHeight;

--- a/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.js
+++ b/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.js
@@ -64,7 +64,7 @@ export default class Tooltip extends Base {
 
   _update() {
     this._updateText();
-    this._updateBackground(); //NOTE: adding _updateBackground() here fixes the issue
+    this._updateBackground();
   }
 
   _updateText() {
@@ -77,12 +77,35 @@ export default class Tooltip extends Base {
   }
 
   _textLoaded() {
-    this._updateBackground();
+    this._updateBackgroundHeight();
     this._updateTextPosition();
   }
 
-  //REVIEW: this only runs on initial load the story or when clicking another story and coming back to this story, may be the issue with the tone render issue
+  /**
+   * patches Background prop updates
+   */
   _updateBackground() {
+    this.patch({
+      Background: {
+        w: this._Background.w,
+        h: this._Background.h,
+        texture: {
+          type: Bubble,
+          w: this._Background.w,
+          h: this._Background.h,
+          radius: this.style.radius,
+          pointerWidth: this.style.pointerWidth,
+          pointerHeight: this.style.pointerHeight,
+          color: this.style.backgroundColor
+        }
+      }
+    });
+  }
+
+  /**
+   * updates height of background when text height or width is changed
+   */
+  _updateBackgroundHeight() {
     const backgroundH =
       this._Text.finalH + this.style.paddingY * 2 + this.style.pointerHeight;
     const backgroundW = this._Text.finalW + this.style.paddingX * 2;
@@ -97,11 +120,7 @@ export default class Tooltip extends Base {
         texture: {
           type: Bubble,
           w: backgroundW,
-          h: backgroundH,
-          radius: this.style.radius,
-          pointerWidth: this.style.pointerWidth,
-          pointerHeight: this.style.pointerHeight,
-          color: this.style.backgroundColor
+          h: backgroundH
         }
       }
     });

--- a/packages/apps/lightning-ui-docs/.storybook/addons/components/ComponentStylesContent.js
+++ b/packages/apps/lightning-ui-docs/.storybook/addons/components/ComponentStylesContent.js
@@ -15,7 +15,6 @@ function createStyleRows(component, updateGlobals) {
   let version;
 
   const style = component._style;
-
   const theme = globalTheme();
   const componentName = component.constructor.__componentName;
 
@@ -61,6 +60,7 @@ function createStyleRows(component, updateGlobals) {
     }
     return acc;
   }, []);
+
   // NOTE: logic needed otherwise Tone Row will be added to all stories
   if (rows && rows.length) {
     rows.unshift(

--- a/packages/apps/lightning-ui-docs/.storybook/addons/components/ToneRow.js
+++ b/packages/apps/lightning-ui-docs/.storybook/addons/components/ToneRow.js
@@ -30,7 +30,6 @@ export default function ToneRow({ defaultTone, componentName }) {
       control={
         <OptionsControl
           name="tones"
-          key={`Tones-${componentName}`}
           type="inline-radio"
           value={tone}
           argType={{ options: ['neutral', 'inverse', 'brand'] }}


### PR DESCRIPTION
## Description

this PR fixes Tooltip tone updating when the tone control is changed in Component Style Panel
- creates two different methods for updating Background, one to update width and height when text is changed, and one just for updates like radius, background color, etc.

## References

LUI-1278

## Testing

clone & cd branch
go to Tooltip story => Component Style Panel => change tone 
Tooltip should update with the correct styles for that tone

## Automation
no changes that should affect automation

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
