### PR TITLE
fix(Storybook): updates ResetButton to reset back to theme selected

### DIFF
--- a/packages/apps/lightning-ui-docs/.storybook/addons/components/ResetButton.js
+++ b/packages/apps/lightning-ui-docs/.storybook/addons/components/ResetButton.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useGlobals } from '@storybook/manager-api';
 import { IconButton, Icons } from '@storybook/components';
-import { setGlobalTheme } from '../../utils/themeUtils';
+import { setGlobalTheme, globalTheme } from '../../utils/themeUtils';
 
 /**
  * @returns a reset button that when clicked will reset component style panel back to default style props of component base on theme
@@ -9,11 +9,12 @@ import { setGlobalTheme } from '../../utils/themeUtils';
 
 export default function ResetButton() {
   const [{ LUITheme }, updateGlobals] = useGlobals();
+  const theme = globalTheme();
+  const themeName = theme.name;
 
   /** resets theme globals & controls */
   const handleReset = () => {
-    //FIXME: resets to Base but needs logic to set to what ever theme is selected in ThemePicker
-    return setGlobalTheme('base', updateGlobals);
+    return setGlobalTheme(themeName, updateGlobals);
   };
 
   return (


### PR DESCRIPTION
## Description

this PR fixes the new ResetButton added in Components Style Panel to update to the prior theme before custom theme was created by adjusting controls.

## References

LUI-1285

## Testing

- clone and cd branch
- go to any story => Component Style Panel
- change a few styles,  the theme should change to "Current Theme: Custom"
- click on reset button in Component Style Panel,  the theme should change back to "Current Theme: Base"


## Automation

no updates that should affect automation

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
