### PR TITLE
docs(InlineContent): apply all args on first render

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.stories.js
@@ -192,12 +192,13 @@ export const WithParsing = args =>
     }
   };
 
-export const WithTruncation = () =>
+export const WithTruncation = args =>
   class Basic extends lng.Component {
     static _template() {
       return {
         InlineContent: {
           type: InlineContentComponent,
+          ...args,
           w: 500,
           content: [
             'Text',
@@ -220,8 +221,7 @@ export const WithTruncation = () =>
             { badge: 'HD', title: 'HD' },
             { badge: 'SD', title: 'SD' },
             ', and this should truncate before going on to a third line.'
-          ],
-          contentWrap: true
+          ]
         }
       };
     }


### PR DESCRIPTION
## Description
Prior to this change, the InlineContent / With Truncation story would flash the full content before truncating to the maxLines specified by the storybook args. This was due to the args not all being applied in one render, so either contentWrap or maxLines could be undefined  resulting in truncation not being enabled. This change makes sure both those props are applied on the first render so truncation is enabled.
<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

## References
LUI-1170
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing
Navigate to/from the InlineContent / With Truncation story. The component should render with truncation with the correct number of lines on the first render.
<!-- step by step instructions to review this PR's changes -->

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
