### PR TITLE
fix(Tile): remove extra patch call before calling animate to avoid stutter effect

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
@@ -598,9 +598,6 @@ export default class Tile extends Surface {
 
       return;
     }
-    // if none of the above apply patch in metadataPatch
-    this._Metadata.patch(this._metadataPatch); // Metadata should never be patched with smooth
-    // then call animateMetadata
     this._animateMetadata();
   }
 

--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
@@ -515,9 +515,7 @@ export default class Tile extends Surface {
   get _metadataTransitions() {
     return {
       y: [
-        this._shouldShowMetadata
-          ? this._metadataY
-          : this._h + this.style.paddingY,
+        this._metadataY,
         this._shouldShowMetadata
           ? this.style.animationEntrance
           : this.style.animationExit
@@ -538,11 +536,14 @@ export default class Tile extends Surface {
   }
 
   get _metadataY() {
-    return this._isInsetMetadata
-      ? this._progressBarY
-        ? this._progressBarY - this.style.paddingYBetweenContent
-        : this._h - this.style.paddingY
-      : this._h + this.style.paddingY;
+    if (this._shouldShowMetadata) {
+      if (this._isInsetMetadata) {
+        return this._progressBarY
+          ? this._progressBarY - this.style.paddingYBetweenContent
+          : this._h - this.style.paddingY;
+      }
+    }
+    return this._h + this.style.paddingY;
   }
 
   get _metadataAlpha() {
@@ -551,19 +552,20 @@ export default class Tile extends Surface {
 
   get _metadataPatch() {
     return {
-      mode: this.mode,
       alpha: this._metadataAlpha,
-      mountX: 0.5,
-      mountY: this._isInsetMetadata ? 1 : 0,
-      marquee: this._isFocusedMode,
       w: this._w - this.style.paddingX * 2,
       x: this._w / 2,
-      y:
-        this.persistentMetadata ||
-        !(this._isInsetMetadata && this._isFocusedMode)
-          ? this._metadataY
-          : this._h + this.style.paddingY,
+      y: this._metadataY,
       ...(this.metadata || {})
+    };
+  }
+
+  get _nonSmoothingMetadataPatch() {
+    return {
+      mode: this.mode,
+      mountX: 0.5,
+      mountY: this._isInsetMetadata ? 1 : 0,
+      marquee: this._isFocusedMode
     };
   }
 
@@ -592,12 +594,14 @@ export default class Tile extends Surface {
           signals: {
             updateComponentDimensions: '_metadataLoaded'
           },
+          ...this._nonSmoothingMetadataPatch,
           ...this._metadataPatch
         }
       });
 
       return;
     }
+    this._Metadata.patch(this._nonSmoothingMetadataPatch);
     this._animateMetadata();
   }
 

--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
@@ -197,16 +197,22 @@ export default class Tile extends Surface {
       h: this.style.logoHeight,
       icon: this.logo,
       alpha: this.style.alpha,
-      mountY: 1,
       x: this.style.paddingX,
       y: this._calculateLogoYPosition()
     };
 
     if (this.logo && (this.persistentMetadata || this._isFocusedMode)) {
       if (!this._Logo) {
-        logoObject.type = Icon;
+        this.patch({
+          Logo: {
+            type: Icon,
+            mountY: 1,
+            ...logoObject
+          }
+        });
+      } else {
+        this.applySmooth(this._Logo, logoObject);
       }
-      this.patch({ Icon: logoObject });
     } else {
       this.patch({ Icon: undefined });
     }
@@ -215,11 +221,10 @@ export default class Tile extends Surface {
   _calculateLogoYPosition() {
     if (this._isInsetMetadata) {
       return this._metadataY - (this._Metadata ? this._Metadata.h : 0);
-    } else {
-      return this._progressBarY
-        ? this._progressBarY - this.style.paddingYBetweenContent
-        : this._h - this.style.paddingY;
     }
+    return this._progressBarY
+      ? this._progressBarY - this.style.paddingYBetweenContent
+      : this._h - this.style.paddingY;
   }
   /* ------------------------------ Artwork ------------------------------ */
 

--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.test.js
@@ -348,7 +348,8 @@ describe('Tile', () => {
       tile.patch({
         progressBar: { progress: 0.5 },
         metadataLocation: 'inset',
-        metadata: { title: 'test ' }
+        metadata: { title: 'test ' },
+        mode: 'focused'
       });
       testRenderer.forceAllUpdates();
       expect(tile._metadataY).toBe(


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Calling the patch, then animating was causing the text to jump when inset. This video shows the before and after.

https://github.com/rdkcentral/Lightning-UI-Components/assets/15019089/d36abacc-a5b8-4d7a-b67a-da1c70f6cd47


## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
You would have to test with inset metadata, potentially only in IS LUI on the new Metadata component.

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
