### PR TITLE
fix(Typography): revert typography reset until we can figure out alternative

### DIFF
--- a/packages/@lightningjs/ui-components-theme-base/index.js
+++ b/packages/@lightningjs/ui-components-theme-base/index.js
@@ -20,78 +20,78 @@ export default {
   name: 'Base Lightning TV',
   alpha: {
     primary: 1,
-    secondary: 0.7,
-    tertiary: 0.1,
-    inactive: 0.5,
+    secondary: 0.6,
+    tertiary: 0.15,
+    inactive: 0.3,
     full: 1,
     none: 0,
     alpha1: 0.1,
-    alpha2: 0.3,
-    alpha3: 0.5,
-    alpha4: 0.7,
-    alpha5: 0.9
+    alpha2: 0.15,
+    alpha3: 0.2,
+    alpha4: 0.3,
+    alpha5: 0.6
   },
   animation: {
     duration: {
       none: 0,
-      xfast: 0.1,
-      fast: 0.25,
-      normal: 0.5,
-      slow: 0.75,
-      xslow: 0.9
+      xfast: 0.2,
+      fast: 0.4,
+      normal: 0.6,
+      slow: 0.8,
+      xslow: 1
     },
     delay: {
       none: 0,
-      xfast: 0.01,
-      fast: 0.025,
-      normal: 0.05,
-      slow: 0.075,
-      xslow: 0.09
+      xfast: 0.02,
+      fast: 0.04,
+      normal: 0.06,
+      slow: 0.08,
+      xslow: 0.1
     },
     expressive: {
-      timingFunction: 'cubic-bezier(0, 0, 1, 1)',
+      timingFunction: 'cubic-bezier(0.8, -0.4, 0.2, 1.4)',
       delay: 0,
-      duration: 0.25
+      duration: 0.6
     },
     expressiveEntrance: {
-      timingFunction: 'cubic-bezier(0, 0, 1, 1)',
+      timingFunction: 'cubic-bezier(0.1, 0.4, 0.16, 1.4)',
       delay: 0,
-      duration: 0.25
+      duration: 0.4
     },
     expressiveExit: {
-      timingFunction: 'cubic-bezier(0, 0, 1, 1)',
+      timingFunction: 'cubic-bezier(0.8, -0.4, 0.8, 0.4)',
       delay: 0,
-      duration: 0.25
+      duration: 0.2
     },
     standard: {
-      timingFunction: 'cubic-bezier(0, 0, 1, 1)',
+      timingFunction: 'cubic-bezier(0.6, 0, 0.1, 1)',
       delay: 0,
-      duration: 0.25
+      duration: 0.6
     },
     standardEntrance: {
-      timingFunction: 'cubic-bezier(0, 0, 1, 1)',
+      timingFunction: 'cubic-bezier(0, 0, 0.15, 1)',
       delay: 0,
-      duration: 0.25
+      duration: 0.2
     },
     standardExit: {
-      timingFunction: 'cubic-bezier(0, 0, 1, 1)',
+      timingFunction: 'cubic-bezier(0.9, 0, 1, 1)',
       delay: 0,
-      duration: 0.25
+      duration: 0.2
     },
     utility: {
-      timingFunction: 'cubic-bezier(0, 0, 1, 1)',
+      timingFunction: 'cubic-bezier(0.4, 0.15, 0.1, 1)',
       delay: 0,
-      duration: 0.25
+      duration: 0.4
     },
     utilityEntrance: {
-      timingFunction: 'cubic-bezier(0, 0, 1, 1)',
+      timingFunction: 'cubic-bezier(0, 0, 0.4, 1)',
       delay: 0,
-      duration: 0.25
+      duration: 0.6
     },
     utilityExit: {
-      timingFunction: 'cubic-bezier(0, 0, 1, 1)',
+      timingFunction: 'cubic-bezier(0.4, 0, 1, 1)',
       delay: 0,
-      duration: 0.25
+      duration: 0.6
     }
   },
   asset: {
@@ -105,97 +105,161 @@ export default {
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAYAAAAi2ky3AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAACtSURBVHgBvdPdDcIgEAfwoy8Nb45QN3AGF2s36Ahu4gpuIDoBfSgfpdoTlCbEWEMh6T8hFzjyg5AAkBHOcQe5UWqspRx435sDpMYj6IYQwwVSEiJ2MKVUBWuzLSLl2HL+uxmNCGFO8yaL7RHxve6qRZoAuS4hxac8735elWVx7jrtMKL1o0Gcat9jhExHSukN/kUIFZ7MpDRtzE1isDRkAUtDvrA8ZI597FUf8gWH9P0b4gko9wAAAABJRU5ErkJggg=='
   },
   color: {
-    white: ['#ffffff', 1],
+    white: ['#FFFFFF', 1],
     black: ['#000000', 1],
-    grey: ['#929096', 1],
-    red: ['#e74c3c', 1],
-    orange: ['#dc7633', 1],
-    yellow: ['#f7dc6f', 1],
-    green: ['#2Ecc71', 1],
-    blue: ['#93a9fd', 1],
-    purple: ['#663399', 1],
+    grey: ['#8B8B8B', 1],
+    red: ['#F0004D', 1],
+    orange: ['#F95600', 1],
+    yellow: ['#FFAA00', 1],
+    green: ['#119911', 1],
+    blue: ['#2970FF', 1],
+    purple: '#704BF7',
     palette: {
-      'grey-05': ['#f8f7fa', 1],
-      'grey-40': ['#929096', 1],
-      'grey-70': ['#48474b', 1],
-      'grey-90': ['#181819', 1],
-      'blue-20': ['#becffe', 1],
-      'blue-40': ['#93a9fd', 1],
-      'blue-90': ['#000033', 1]
+      'grey-05': ['#F5F5F5', 1],
+      'grey-40': ['#8B8B8B', 1],
+      'grey-70': ['#494949', 1],
+      'grey-90': ['#1A1A1A', 1],
+      'blue-20': ['#4784FF', 1],
+      'blue-40': ['#2970FF', 1],
+      'blue-90': ['#131E34', 1],
+      'grey-10': ['#E3E3E3', 1],
+      'grey-20': ['#C2C2C2', 1],
+      'grey-30': ['#A1A1A0', 1],
+      'grey-50': ['#757575', 1],
+      'grey-60': ['#555555', 1],
+      'grey-80': ['#333333', 1],
+      'red-10': ['#FF99BA', 1],
+      'red-20': ['#FF6194', 1],
+      'red-30': ['#FF3878', 1],
+      'red-40': ['#F0004D', 1],
+      'red-50': ['#E6004A', 1],
+      'red-60': ['#B7023C', 1],
+      'red-70': ['#8F002F', 1],
+      'red-80': ['#660021', 1],
+      'red-90': ['#31111B', 1],
+      'red-05': ['#F2D9E1', 1],
+      'orange-10': ['#FFB68F', 1],
+      'orange-20': ['#FF8D52', 1],
+      'orange-30': ['#FF6F24', 1],
+      'orange-40': ['#F95600', 1],
+      'orange-50': ['#E64F00', 1],
+      'orange-60': ['#B33D00', 1],
+      'orange-70': ['#A33800', 1],
+      'orange-80': ['#8F3100', 1],
+      'orange-90': ['#392014', 1],
+      'orange-05': ['#F2E1D9', 1],
+      'yellow-10': ['#FFD88A', 1],
+      'yellow-20': ['#FFC95C', 1],
+      'yellow-30': ['#FFB829', 1],
+      'yellow-40': ['#FFAA00', 1],
+      'yellow-50': ['#B87700', 1],
+      'yellow-60': ['#8F5D00', 1],
+      'yellow-70': ['#7A5000', 1],
+      'yellow-80': ['#664200', 1],
+      'yellow-90': ['#352913', 1],
+      'yellow-05': ['#F2EAD9', 1],
+      'green-10': ['#B3E6B3', 1],
+      'green-20': ['#71CC71', 1],
+      'green-30': ['#3CB33C', 1],
+      'green-40': ['#119911', 1],
+      'green-50': ['#008000', 1],
+      'green-60': ['#006600', 1],
+      'green-70': ['#004C00', 1],
+      'green-80': ['#003300', 1],
+      'green-90': ['#001900', 1],
+      'green-05': ['#D7F2D7', 1],
+      'blue-10': ['#8BAFF9', 1],
+      'blue-30': ['#3376FF', 1],
+      'blue-50': ['#1F69FF', 1],
+      'blue-60': ['#0051D0', 1],
+      'blue-70': ['#0040A3', 1],
+      'blue-80': ['#003485', 1],
+      'blue-05': ['#D9E1F2', 1],
+      'teal-10': ['#9CE7E9', 1],
+      'teal-20': ['#52CED2', 1],
+      'teal-30': ['#05B2B6', 1],
+      'teal-40': ['#009A9F', 1],
+      'teal-50': ['#007C85', 1],
+      'teal-60': ['#00666A', 1],
+      'teal-70': ['#004C4F', 1],
+      'teal-80': ['#003334', 1],
+      'teal-90': ['#001919', 1],
+      'teal-05': ['#CCF3F4', 1]
     },
-    material: ['#181819', 1],
-    materialBrand: ['#000033', 1],
-    overlay: ['#181819', 0.7],
-    textNeutral: ['#f8f7fa', 1],
-    textNeutralSecondary: ['#f8f7fa', 0.7],
-    textNeutralTertiary: ['#f8f7fa', 0.1],
-    textNeutralDisabled: ['#f8f7fa', 0.5],
-    textInverse: ['#181819', 1],
-    textInverseSecondary: ['#181819', 0.7],
-    textInverseTertiary: ['#181819', 0.1],
-    textInverseDisabled: ['#181819', 0.5],
-    textBrand: ['#93a9fd', 1],
-    textBrandSecondary: ['#93a9fd', 0.7],
-    textBrandTertiary: ['#93a9fd', 0.1],
-    textBrandDisabled: ['#93a9fd', 0.5],
-    textPositive: ['#2Ecc71', 1],
-    textNegative: ['#e74c3c', 1],
-    textInfo: ['#93a9fd', 1],
-    textCaution: ['#dc7633', 1],
-    fillTransparent: ['#ffffff', 0],
-    fillNeutral: ['#f8f7fa', 1],
-    fillNeutralSecondary: ['#f8f7fa', 0.7],
-    fillNeutralTertiary: ['#f8f7fa', 0.1],
-    fillNeutralDisabled: ['#f8f7fa', 0.5],
-    fillInverse: ['#181819', 1],
-    fillInverseSecondary: ['#181819', 0.7],
-    fillInverseTertiary: ['#181819', 0.1],
-    fillInverseDisabled: ['#181819', 0.5],
-    fillBrand: ['#93a9fd', 1],
-    fillBrandSecondary: ['#93a9fd', 0.7],
-    fillBrandTertiary: ['#93a9fd', 0.1],
-    fillBrandDisabled: ['#93a9fd', 0.5],
-    fillPositive: ['#2Ecc71', 1],
-    fillNegative: ['#e74c3c', 1],
-    fillInfo: ['#93a9fd', 1],
-    fillCaution: ['#dc7633', 1],
-    strokeNeutral: ['#f8f7fa', 1],
-    strokeNeutralSecondary: ['#f8f7fa', 0.7],
-    strokeNeutralTertiary: ['#f8f7fa', 0.1],
-    strokeNeutralDisabled: ['#f8f7fa', 0.5],
-    strokeInverse: ['#181819', 1],
-    strokeInverseSecondary: ['#181819', 0.7],
-    strokeInverseTertiary: ['#181819', 0.1],
-    strokeInverseDisabled: ['#181819', 0.5],
-    strokeBrand: ['#93a9fd', 1],
-    strokeBrandSecondary: ['#93a9fd', 0.7],
-    strokeBrandTertiary: ['#93a9fd', 0.1],
-    strokeBrandDisabled: ['#93a9fd', 0.5],
-    strokePositive: ['#2Ecc71', 1],
-    strokeNegative: ['#e74c3c', 1],
-    strokeInfo: ['#93a9fd', 1],
-    strokeCaution: ['#dc7633', 1],
-    interactiveNeutral: ['#ffffff', 0.1],
-    interactiveNeutralFocus: ['#ffffff', 1],
-    interactiveNeutralFocusSoft: ['#ffffff', 0.1],
-    interactiveInverse: ['#48474b', undefined],
-    interactiveInverseFocus: ['#48474b', 1],
-    interactiveInverseFocusSoft: ['#48474b', 0.1],
-    interactiveBrand: ['#becffe', 0.1],
-    interactiveBrandFocus: ['#becffe', 1],
-    interactiveBrandFocusSoft: ['#becffe', 0.1],
-    shadowNeutral: ['#000000', 0.7],
-    shadowNeutralFocus: ['#000000', 0.7],
-    shadowNeutralFocusSoft: ['#000000', 0.7],
-    shadowNeutralText: ['#000000', 1],
-    shadowInverse: ['#000000', 0.7],
-    shadowInverseFocus: ['#000000', 0.7],
-    shadowInverseFocusSoft: ['#000000', 0.7],
-    shadowInverseText: ['#000000', 1],
-    shadowBrand: ['#000000', 0.7],
-    shadowBrandFocus: ['#000000', 0.7],
-    shadowBrandFocusSoft: ['#000000', 0.7],
-    shadowBrandText: ['#000000', 1]
+    material: ['#1A1A1A', 1],
+    materialBrand: ['#001919', 1],
+    overlay: ['#1A1A1A', 0.6],
+    textNeutral: ['#F5F5F5', 1],
+    textNeutralSecondary: ['#F5F5F5', 0.6],
+    textNeutralTertiary: ['#F5F5F5', 0.15],
+    textNeutralDisabled: ['#F5F5F5', 0.3],
+    textInverse: ['#1A1A1A', 1],
+    textInverseSecondary: ['#1A1A1A', 0.6],
+    textInverseTertiary: ['#1A1A1A', 0.15],
+    textInverseDisabled: ['#1A1A1A', 0.3],
+    textBrand: ['#52CED2', 1],
+    textBrandSecondary: ['#52CED2', 0.6],
+    textBrandTertiary: ['#52CED2', 0.15],
+    textBrandDisabled: ['#52CED2', 0.3],
+    textPositive: ['#0AC284', 1],
+    textNegative: ['#F0004D', 1],
+    textInfo: ['#2970FF', 1],
+    textCaution: ['#F95600', 1],
+    fillTransparent: ['#FFFFFF', 0],
+    fillNeutral: ['#F5F5F5', 1],
+    fillNeutralSecondary: ['#F5F5F5', 0.6],
+    fillNeutralTertiary: ['#F5F5F5', 0.15],
+    fillNeutralDisabled: ['#F5F5F5', 0.3],
+    fillInverse: ['#1A1A1A', 1],
+    fillInverseSecondary: ['#1A1A1A', 0.6],
+    fillInverseTertiary: ['#1A1A1A', 0.15],
+    fillInverseDisabled: ['#1A1A1A', 0.3],
+    fillBrand: ['#05B2B6', 1],
+    fillBrandSecondary: ['#05B2B6', 0.6],
+    fillBrandTertiary: ['#05B2B6', 0.15],
+    fillBrandDisabled: ['#05B2B6', 0.3],
+    fillPositive: ['#0AC284', 1],
+    fillNegative: ['#F0004D', 1],
+    fillInfo: ['#2970FF', 1],
+    fillCaution: ['#F95600', 1],
+    strokeNeutral: ['#F5F5F5', 1],
+    strokeNeutralSecondary: ['#F5F5F5', 0.6],
+    strokeNeutralTertiary: ['#F5F5F5', 0.15],
+    strokeNeutralDisabled: ['#F5F5F5', 0.3],
+    strokeInverse: ['#1A1A1A', 1],
+    strokeInverseSecondary: ['#1A1A1A', 0.6],
+    strokeInverseTertiary: ['#1A1A1A', 0.15],
+    strokeInverseDisabled: ['#1A1A1A', 0.3],
+    strokeBrand: ['#05B2B6', 1],
+    strokeBrandSecondary: ['#05B2B6', 0.6],
+    strokeBrandTertiary: ['#05B2B6', 0.15],
+    strokeBrandDisabled: ['#05B2B6', 0.3],
+    strokePositive: ['#0AC284', 1],
+    strokeNegative: ['#F0004D', 1],
+    strokeInfo: ['#2970FF', 1],
+    strokeCaution: ['#F95600', 1],
+    interactiveNeutral: ['#FFFFFF', 0.1],
+    interactiveNeutralFocus: ['#FFFFFF', 0.2],
+    interactiveNeutralFocusSoft: ['#FFFFFF', 0.15],
+    interactiveInverse: ['#1A1A1A', 0.1],
+    interactiveInverseFocus: ['#1A1A1A', 0.2],
+    interactiveInverseFocusSoft: ['#1A1A1A', 0.15],
+    interactiveBrand: ['#05B2B6', 0.1],
+    interactiveBrandFocus: ['#05B2B6', 0.2],
+    interactiveBrandFocusSoft: ['#05B2B6', 0.15],
+    shadowNeutral: ['#000000', 0.6],
+    shadowNeutralFocus: ['#000000', 0.6],
+    shadowNeutralFocusSoft: ['#000000', 0.6],
+    shadowNeutralText: ['#000000', 0],
+    shadowInverse: ['#000000', 0.6],
+    shadowInverseFocus: ['#000000', 0.6],
+    shadowInverseFocusSoft: ['#000000', 0.6],
+    shadowInverseText: ['#000000', 0],
+    shadowBrand: ['#000000', 0.6],
+    shadowBrandFocus: ['#000000', 0.6],
+    shadowBrandFocusSoft: ['#000000', 0.6],
+    shadowBrandText: ['#000000', 0],
+    teal: ['#009A9F', 1]
   },
   componentConfig: {
     Keyboard: {
@@ -207,145 +271,716 @@ export default {
           }
         }
       }
+    },
+    Distractor: { tone: 'brand' },
+    FocusRing: {
+      tone: 'brand',
+      style: {
+        borderWidth: 4,
+        color: '0x4dd9d9d9',
+        spacing: -4,
+        shouldAnimate: false,
+        transitionColor: '0x33d9d9d9',
+        secondaryColor: '0xdd9d9d9'
+      }
+    },
+    Label: {
+      tone: 'brand',
+      style: {
+        radius: 4,
+        tone: { brand: { backgroundColor: ['#52CED2', 0.6] } }
+      }
+    },
+    Lozenge: {
+      tone: 'brand',
+      style: {
+        backgroundColor: '0x33f6f6f9',
+        radius: 6,
+        highlightRadius: [6, 6, 0, 0],
+        mode: {
+          focused: {
+            radius: 10,
+            highlightRadius: [10, 10, 0, 0],
+            backgroundColor: '0x33f6f6f9'
+          }
+        }
+      }
+    },
+    ProgressBar: { tone: 'brand', style: { h: 4, radius: 4 } },
+    Wave: { tone: 'brand' },
+    Button: {
+      style: {
+        radius: 6,
+        textStyle: { textColor: ['#f6f6f9', 1] },
+        mode: { focused: { radius: 10 } }
+      }
+    },
+    Card: {
+      style: { radius: 6, mode: { focused: { radius: 10 } } }
+    },
+    Key: { style: { baseWidth: 61, height: 61, minWidth: 61 } },
+    KeyboardSpacing: { style: { keySpacing: 4 } },
+    // MetadataTile: {
+    //   style: {
+    //     titleTextStyle: {
+    //       verticalAlign: 'middle',
+    //       maxLineSuffix: '...',
+    //       shadow: true,
+    //       shadowOffsetX: 1,
+    //       shadowOffsetY: 2,
+    //       shadowBlur: 0,
+    //       shadowColor: 4279505943,
+    //       fontFamily: 'WorkSans',
+    //       fontSize: 30,
+    //       fontStyle: '400',
+    //       lineHeight: 40,
+    //       letterSpacing: -0.2
+    //     },
+    //     descriptionTextStyle: {
+    //       verticalAlign: 'middle',
+    //       maxLineSuffix: '...',
+    //       shadow: true,
+    //       shadowOffsetX: 1,
+    //       shadowOffsetY: 2,
+    //       shadowBlur: 0,
+    //       shadowColor: 4279505943,
+    //       fontFamily: 'WorkSans',
+    //       fontSize: 27,
+    //       fontStyle: '400',
+    //       lineHeight: 40
+    //     },
+    //     mode: {
+    //       focused: {
+    //         titleTextStyle: {
+    //           verticalAlign: 'middle',
+    //           maxLineSuffix: '...',
+    //           shadow: true,
+    //           shadowOffsetX: 1,
+    //           shadowOffsetY: 2,
+    //           shadowBlur: 0,
+    //           shadowColor: 4279505943,
+    //           fontFamily: 'WorkSans',
+    //           fontSize: 30,
+    //           lineHeight: 40,
+    //           letterSpacing: -0.2
+    //         },
+    //         descriptionTextStyle: {
+    //           verticalAlign: 'middle',
+    //           maxLineSuffix: '...',
+    //           shadow: true,
+    //           shadowOffsetX: 1,
+    //           shadowOffsetY: 2,
+    //           shadowBlur: 0,
+    //           shadowColor: 4279505943,
+    //           fontFamily: 'WorkSans',
+    //           fontSize: 27,
+    //           fontStyle: '400',
+    //           lineHeight: 40
+    //         }
+    //       }
+    //     }
+    //   }
+    // },
+    Surface: { radius: 6, mode: { focused: { radius: 10 } } },
+    Tile: {
+      style: {
+        radius: 6,
+        metadataLocation: 'inset',
+        mode: { focused: { paddingY: 24, radius: 10 } },
+        backgroundColor: ['#604056', 100],
+        tone: { offline: { backgroundColor: ['#454044', 100] } }
+      }
+    },
+    CardTitle: {
+      style: {
+        titleTextStyle: {
+          verticalAlign: 'middle',
+          maxLineSuffix: '...',
+          shadow: true,
+          shadowOffsetX: 1,
+          shadowOffsetY: 2,
+          shadowBlur: 0,
+          shadowColor: 4279505943,
+          fontFamily: 'WorkSans',
+          fontSize: 32,
+          lineHeight: 40
+        },
+        descriptionTextStyle: {
+          verticalAlign: 'middle',
+          maxLineSuffix: '...',
+          shadow: true,
+          shadowOffsetX: 1,
+          shadowOffsetY: 2,
+          shadowBlur: 0,
+          shadowColor: 4279505943,
+          fontFamily: 'WorkSans',
+          fontSize: 28,
+          lineHeight: 40
+        }
+      }
+    },
+    // CardContentVertical: {
+    //   style: {
+    //     metadata: {
+    //       titleTextStyle: {
+    //         verticalAlign: 'middle',
+    //         maxLineSuffix: '...',
+    //         shadow: true,
+    //         shadowOffsetX: 1,
+    //         shadowOffsetY: 2,
+    //         shadowBlur: 0,
+    //         shadowColor: 4279505943,
+    //         fontFamily: 'WorkSans',
+    //         fontSize: 30,
+    //         lineHeight: 40,
+    //         letterSpacing: -0.2,
+    //         maxLines: 1
+    //       },
+    //       descriptionTextStyle: {
+    //         verticalAlign: 'middle',
+    //         maxLineSuffix: '...',
+    //         shadow: true,
+    //         shadowOffsetX: 1,
+    //         shadowOffsetY: 2,
+    //         shadowBlur: 0,
+    //         shadowColor: 4279505943,
+    //         fontFamily: 'WorkSans',
+    //         fontSize: 27,
+    //         lineHeight: 40,
+    //         maxLines: 3
+    //       }
+    //     }
+    //   }
+    // },
+    // CardContentVerticalSmall: {
+    //   style: {
+    //     metadata: {
+    //       titleTextStyle: {
+    //         verticalAlign: 'middle',
+    //         maxLineSuffix: '...',
+    //         shadow: true,
+    //         shadowOffsetX: 1,
+    //         shadowOffsetY: 2,
+    //         shadowBlur: 0,
+    //         shadowColor: 4279505943,
+    //         fontFamily: 'WorkSans',
+    //         fontSize: 30,
+    //         lineHeight: 40,
+    //         letterSpacing: -0.2,
+    //         maxLines: 1
+    //       },
+    //       descriptionTextStyle: {
+    //         verticalAlign: 'middle',
+    //         maxLineSuffix: '...',
+    //         shadow: true,
+    //         shadowOffsetX: 1,
+    //         shadowOffsetY: 2,
+    //         shadowBlur: 0,
+    //         shadowColor: 4279505943,
+    //         fontFamily: 'WorkSans',
+    //         fontSize: 27,
+    //         lineHeight: 40,
+    //         maxLines: 1
+    //       }
+    //     }
+    //   }
+    // },
+    ContentBlock: {
+      style: {
+        detailsStyle: {
+          textStyle: {
+            verticalAlign: 'middle',
+            maxLineSuffix: '...',
+            shadow: true,
+            shadowOffsetX: 1,
+            shadowOffsetY: 2,
+            shadowBlur: 0,
+            shadowColor: 4279505943,
+            fontFamily: 'WorkSansBold',
+            fontSize: 28,
+            lineHeight: 40
+          }
+        }
+      }
+    },
+    Hero: { style: { contentBlockMarginY: 218 } },
+    Metadata: {
+      style: {
+        titleTextStyle: {
+          verticalAlign: 'middle',
+          maxLineSuffix: '...',
+          shadow: true,
+          shadowOffsetX: 1,
+          shadowOffsetY: 2,
+          shadowBlur: 0,
+          shadowColor: 4279505943,
+          fontFamily: 'WorkSans',
+          fontSize: 30,
+          lineHeight: 40,
+          letterSpacing: -0.2,
+          maxLines: 1
+        },
+        descriptionTextStyle: {
+          verticalAlign: 'middle',
+          maxLineSuffix: '...',
+          shadow: true,
+          shadowOffsetX: 1,
+          shadowOffsetY: 2,
+          shadowBlur: 0,
+          shadowColor: 4279505943,
+          fontFamily: 'WorkSans',
+          fontSize: 27,
+          lineHeight: 40,
+          maxLines: 3
+        },
+        mode: {
+          focused: {
+            titleTextStyle: {
+              verticalAlign: 'middle',
+              maxLineSuffix: '...',
+              shadow: true,
+              shadowOffsetX: 1,
+              shadowOffsetY: 2,
+              shadowBlur: 0,
+              shadowColor: 4279505943,
+              fontFamily: 'WorkSans',
+              fontSize: 30,
+              lineHeight: 40,
+              letterSpacing: -0.2,
+              maxLines: 1
+            },
+            descriptionTextStyle: {
+              verticalAlign: 'middle',
+              maxLineSuffix: '...',
+              shadow: true,
+              shadowOffsetX: 1,
+              shadowOffsetY: 2,
+              shadowBlur: 0,
+              shadowColor: 4279505943,
+              fontFamily: 'WorkSans',
+              fontSize: 27,
+              lineHeight: 40,
+              maxLines: 3
+            }
+          }
+        }
+      }
+    },
+    MetadataBase: {
+      style: {
+        titleTextStyle: {
+          verticalAlign: 'middle',
+          maxLineSuffix: '...',
+          shadow: true,
+          shadowOffsetX: 1,
+          shadowOffsetY: 2,
+          shadowBlur: 0,
+          shadowColor: 4279505943,
+          fontFamily: 'WorkSans',
+          fontSize: 30,
+          lineHeight: 40,
+          letterSpacing: -0.2
+        },
+        descriptionTextStyle: {
+          verticalAlign: 'middle',
+          maxLineSuffix: '...',
+          shadow: true,
+          shadowOffsetX: 1,
+          shadowOffsetY: 2,
+          shadowBlur: 0,
+          shadowColor: 4279505943,
+          fontFamily: 'WorkSans',
+          fontSize: 27,
+          lineHeight: 40
+        },
+        mode: {
+          focused: {
+            titleTextStyle: {
+              verticalAlign: 'middle',
+              maxLineSuffix: '...',
+              shadow: true,
+              shadowOffsetX: 1,
+              shadowOffsetY: 2,
+              shadowBlur: 0,
+              shadowColor: 4279505943,
+              fontFamily: 'WorkSans',
+              fontSize: 30,
+              lineHeight: 40,
+              letterSpacing: -0.2
+            },
+            descriptionTextStyle: {
+              verticalAlign: 'middle',
+              maxLineSuffix: '...',
+              shadow: true,
+              shadowOffsetX: 1,
+              shadowOffsetY: 2,
+              shadowBlur: 0,
+              shadowColor: 4279505943,
+              fontFamily: 'WorkSans',
+              fontSize: 27,
+              lineHeight: 40
+            }
+          }
+        }
+      }
+    },
+    MetadataCard: {
+      style: {
+        titleTextStyle: {
+          verticalAlign: 'middle',
+          maxLineSuffix: '...',
+          shadow: true,
+          shadowOffsetX: 1,
+          shadowOffsetY: 2,
+          shadowBlur: 0,
+          shadowColor: 4279505943,
+          fontFamily: 'WorkSans',
+          fontSize: 30,
+          lineHeight: 40,
+          letterSpacing: -0.2
+        },
+        descriptionTextStyle: {
+          verticalAlign: 'middle',
+          maxLineSuffix: '...',
+          shadow: true,
+          shadowOffsetX: 1,
+          shadowOffsetY: 2,
+          shadowBlur: 0,
+          shadowColor: 4279505943,
+          fontFamily: 'WorkSans',
+          fontSize: 27,
+          lineHeight: 40
+        },
+        mode: {
+          focused: {
+            titleTextStyle: {
+              verticalAlign: 'middle',
+              maxLineSuffix: '...',
+              shadow: true,
+              shadowOffsetX: 1,
+              shadowOffsetY: 2,
+              shadowBlur: 0,
+              shadowColor: 4279505943,
+              fontFamily: 'WorkSans',
+              fontSize: 30,
+              lineHeight: 40,
+              letterSpacing: -0.2
+            },
+            descriptionTextStyle: {
+              verticalAlign: 'middle',
+              maxLineSuffix: '...',
+              shadow: true,
+              shadowOffsetX: 1,
+              shadowOffsetY: 2,
+              shadowBlur: 0,
+              shadowColor: 4279505943,
+              fontFamily: 'WorkSans',
+              fontSize: 27,
+              lineHeight: 40
+            }
+          }
+        }
+      }
+    },
+    MetadataCardContent: {
+      style: {
+        titleTextStyle: {
+          verticalAlign: 'middle',
+          maxLineSuffix: '...',
+          shadow: true,
+          shadowOffsetX: 1,
+          shadowOffsetY: 2,
+          shadowBlur: 0,
+          shadowColor: 4279505943,
+          fontFamily: 'WorkSans',
+          fontSize: 30,
+          lineHeight: 40,
+          letterSpacing: -0.2
+        },
+        descriptionTextStyle: {
+          verticalAlign: 'middle',
+          maxLineSuffix: '...',
+          shadow: true,
+          shadowOffsetX: 1,
+          shadowOffsetY: 2,
+          shadowBlur: 0,
+          shadowColor: 4279505943,
+          fontFamily: 'WorkSans',
+          fontSize: 27,
+          lineHeight: 40
+        },
+        mode: {
+          focused: {
+            titleTextStyle: {
+              verticalAlign: 'middle',
+              maxLineSuffix: '...',
+              shadow: true,
+              shadowOffsetX: 1,
+              shadowOffsetY: 2,
+              shadowBlur: 0,
+              shadowColor: 4279505943,
+              fontFamily: 'WorkSans',
+              fontSize: 30,
+              lineHeight: 40,
+              letterSpacing: -0.2
+            },
+            descriptionTextStyle: {
+              verticalAlign: 'middle',
+              maxLineSuffix: '...',
+              shadow: true,
+              shadowOffsetX: 1,
+              shadowOffsetY: 2,
+              shadowBlur: 0,
+              shadowColor: 4279505943,
+              fontFamily: 'WorkSans',
+              fontSize: 27,
+              lineHeight: 40
+            }
+          }
+        }
+      }
     }
   },
-  font: [],
+  font: [
+    {
+      family: 'WorkSans',
+      src: 'https://static.cimcontent.net/common-web-assets/fonts/work-sans/worksans-regular.woff2'
+    },
+    {
+      family: 'WorkSansMedium',
+      src: 'https://static.cimcontent.net/common-web-assets/fonts/work-sans/worksans-medium.woff2'
+    },
+    {
+      family: 'WorkSansBold',
+      src: 'https://static.cimcontent.net/common-web-assets/fonts/work-sans/worksans-semibold.woff2'
+    }
+  ],
   layout: {
-    columnCount: 10,
-    focusScale: 1.2,
-    gutterX: 20,
-    gutterY: 20,
-    marginX: 150,
-    marginY: 150,
-    safe: 50,
+    columnCount: 12,
+    focusScale: 1.08,
+    gutterX: 24,
+    gutterY: 88,
+    marginX: 96,
+    marginY: 48,
+    safe: 48,
     screenW: 1920,
     screenH: 1080
   },
-  radius: { none: 0, xs: 2, sm: 4, md: 8, lg: 16, xl: 24 },
+  radius: { none: 0, xs: 4, sm: 8, md: 16, lg: 24, xl: 32 },
   spacer: {
     none: 0,
     xxs: 2,
     xs: 4,
-    sm: 8,
-    md: 10,
-    lg: 20,
-    xl: 30,
-    xxl: 40,
-    xxxl: 50
+    sm: 6,
+    md: 8,
+    lg: 16,
+    xl: 24,
+    xxl: 32,
+    xxxl: 48
   },
   stroke: { none: 0, sm: 2, md: 4, lg: 6, xl: 8 },
   typography: {
     display1: {
-      fontFamily: 'Arial',
-      fontSize: 75,
-      lineHeight: 85,
-      fontStyle: '500',
+      fontFamily: 'WorkSans',
+      fontSize: 45,
+      lineHeight: 72,
+      fontStyle: '600',
       verticalAlign: 'middle',
-      textBaseline: 'bottom'
+      textBaseline: 'bottom',
+      maxLineSuffix: '...',
+      shadow: true,
+      shadowOffsetX: 1,
+      shadowOffsetY: 2,
+      shadowBlur: 0,
+      shadowColor: 4279505943,
+      letterSpacing: -0.4
     },
     display2: {
-      fontFamily: 'Arial',
-      fontSize: 50,
-      lineHeight: 60,
-      fontStyle: '500',
+      fontFamily: 'WorkSans',
+      fontSize: 45,
+      lineHeight: 72,
+      fontStyle: '600',
       verticalAlign: 'middle',
-      textBaseline: 'bottom'
+      textBaseline: 'bottom',
+      maxLineSuffix: '...',
+      shadow: true,
+      shadowOffsetX: 1,
+      shadowOffsetY: 2,
+      shadowBlur: 0,
+      shadowColor: 4279505943,
+      letterSpacing: -0.4
     },
     headline1: {
-      fontFamily: 'Arial',
-      fontSize: 35,
-      fontStyle: '500',
-      lineHeight: 48,
+      fontFamily: 'WorkSans',
+      fontSize: 32,
+      fontStyle: '600',
+      lineHeight: 40,
       verticalAlign: 'middle',
-      textBaseline: 'bottom'
+      textBaseline: 'bottom',
+      maxLineSuffix: '...',
+      shadow: true,
+      shadowOffsetX: 1,
+      shadowOffsetY: 2,
+      shadowBlur: 0,
+      shadowColor: 4279505943
     },
     headline2: {
-      fontFamily: 'Arial',
-      fontSize: 30,
-      fontStyle: '500',
+      fontFamily: 'WorkSans',
+      fontSize: 32,
+      fontStyle: '600',
       lineHeight: 40,
       verticalAlign: 'middle',
-      textBaseline: 'bottom'
+      textBaseline: 'bottom',
+      maxLineSuffix: '...',
+      shadow: true,
+      shadowOffsetX: 1,
+      shadowOffsetY: 2,
+      shadowBlur: 0,
+      shadowColor: 4279505943,
+      letterSpacing: -0.2
     },
     headline3: {
-      fontFamily: 'Arial',
-      fontSize: 25,
-      fontStyle: '500',
-      lineHeight: 36,
-      verticalAlign: 'middle',
-      textBaseline: 'bottom'
-    },
-    body1: {
-      fontFamily: 'Arial',
-      fontSize: 25,
-      fontStyle: '300',
+      fontFamily: 'WorkSans',
+      fontSize: 32,
+      fontStyle: '600',
       lineHeight: 40,
       verticalAlign: 'middle',
-      textBaseline: 'bottom'
+      textBaseline: 'bottom',
+      maxLineSuffix: '...',
+      shadow: true,
+      shadowOffsetX: 1,
+      shadowOffsetY: 2,
+      shadowBlur: 0,
+      shadowColor: 4279505943
+    },
+    body1: {
+      fontFamily: 'WorkSans',
+      fontSize: 30,
+      fontStyle: '400',
+      lineHeight: 40,
+      verticalAlign: 'middle',
+      textBaseline: 'bottom',
+      maxLineSuffix: '...',
+      shadow: true,
+      shadowOffsetX: 1,
+      shadowOffsetY: 2,
+      shadowBlur: 0,
+      shadowColor: 4279505943,
+      letterSpacing: -0.2
     },
     body2: {
-      fontFamily: 'Arial',
-      fontSize: 22,
-      fontStyle: '300',
-      lineHeight: 32,
+      fontFamily: 'WorkSans',
+      fontSize: 28,
+      fontStyle: '400',
+      lineHeight: 40,
       verticalAlign: 'middle',
-      textBaseline: 'bottom'
+      textBaseline: 'bottom',
+      maxLineSuffix: '...',
+      shadow: true,
+      shadowOffsetX: 1,
+      shadowOffsetY: 2,
+      shadowBlur: 0,
+      shadowColor: 4279505943
     },
     body3: {
-      fontFamily: 'Arial',
-      fontSize: 20,
-      fontStyle: '300',
-      lineHeight: 32,
+      fontFamily: 'WorkSans',
+      fontSize: 27,
+      fontStyle: '400',
+      lineHeight: 40,
       verticalAlign: 'middle',
-      textBaseline: 'bottom'
+      textBaseline: 'bottom',
+      maxLineSuffix: '...',
+      shadow: true,
+      shadowOffsetX: 1,
+      shadowOffsetY: 2,
+      shadowBlur: 0,
+      shadowColor: 4279505943
     },
     button1: {
-      fontFamily: 'Arial',
-      fontSize: 25,
-      fontStyle: '500',
-      lineHeight: 32,
+      fontFamily: 'WorkSans',
+      fontSize: 30,
+      fontStyle: '600',
+      lineHeight: 36,
       verticalAlign: 'middle',
-      textBaseline: 'bottom'
+      textBaseline: 'bottom',
+      maxLineSuffix: '...',
+      shadow: true,
+      shadowOffsetX: 1,
+      shadowOffsetY: 2,
+      shadowBlur: 0,
+      shadowColor: 4279505943,
+      letterSpacing: -0.2
     },
     button2: {
-      fontFamily: 'Arial',
-      fontSize: 20,
-      fontStyle: '500',
+      fontFamily: 'WorkSans',
+      fontSize: 28,
+      fontStyle: '600',
       lineHeight: 32,
       verticalAlign: 'middle',
-      textBaseline: 'bottom'
+      textBaseline: 'bottom',
+      maxLineSuffix: '...',
+      shadow: true,
+      shadowOffsetX: 1,
+      shadowOffsetY: 2,
+      shadowBlur: 0,
+      shadowColor: 4279505943,
+      letterSpacing: -0.2
     },
     callout1: {
-      fontFamily: 'Arial',
-      fontSize: 20,
-      fontStyle: '500',
+      fontFamily: 'WorkSans',
+      fontSize: 24,
+      fontStyle: '400',
       lineHeight: 32,
       verticalAlign: 'middle',
-      textBaseline: 'bottom'
+      textBaseline: 'bottom',
+      maxLineSuffix: '...',
+      shadow: true,
+      shadowOffsetX: 1,
+      shadowOffsetY: 2,
+      shadowBlur: 0,
+      shadowColor: 4279505943
     },
     caption1: {
-      fontFamily: 'Arial',
-      fontSize: 15,
-      fontStyle: '500',
+      fontFamily: 'WorkSansMedium',
+      fontSize: 20,
+      fontStyle: '400',
       lineHeight: 24,
       verticalAlign: 'middle',
-      textBaseline: 'bottom'
+      textBaseline: 'bottom',
+      maxLineSuffix: '...',
+      shadow: true,
+      shadowOffsetX: 1,
+      shadowOffsetY: 2,
+      shadowBlur: 0,
+      shadowColor: 4279505943
     },
     tag1: {
-      fontFamily: 'Arial',
+      fontFamily: 'WorkSansMedium',
       fontSize: 20,
-      fontStyle: '500',
+      fontStyle: '600',
       lineHeight: 24,
       verticalAlign: 'middle',
-      textBaseline: 'bottom'
+      textBaseline: 'bottom',
+      maxLineSuffix: '...',
+      shadow: true,
+      shadowOffsetX: 1,
+      shadowOffsetY: 2,
+      shadowBlur: 0,
+      shadowColor: 4279505943
     },
     footnote1: {
-      fontFamily: 'Arial',
-      fontSize: 22,
-      fontStyle: '300',
-      lineHeight: 30,
+      fontFamily: 'WorkSans',
+      fontSize: 20,
+      fontStyle: '400',
+      lineHeight: 28,
       verticalAlign: 'middle',
-      textBaseline: 'bottom'
+      textBaseline: 'bottom',
+      maxLineSuffix: '...',
+      shadow: true,
+      shadowOffsetX: 1,
+      shadowOffsetY: 2,
+      shadowBlur: 0,
+      shadowColor: 4279505943
     }
   }
 };

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
@@ -613,7 +613,10 @@ export const themeParser = (targetObject, styleObj) => {
     // Ensure text styles contain all default values from Text texture.
     // This prevents properties that exist on a previous theme persisting on the current theme when switching themes by creating a new object each time.
     if (typeof value === 'object' && isTextStyleObject(value)) {
-      return { ...lightningTextDefaults, ...value };
+      // TODO: Figure out alternate approach to resetting typography defaults
+      // otherwise these properties are getting carried through the deep-merging process
+      // and causing unexpected behavior for subcomponents, like the Metadata inside of CardContent
+      return { /*...lightningTextDefaults,*/ ...value };
     }
     return value;
   });


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
A bug was introduced in #432 that breaks the text deep merging of nested components (like MetadataCardContent inside of CardContentVertical). Until we can work out those edge-cases, this will revert the change and bring back the expected styles.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
You can see the difference by checking out the CardContentVertical (and similar) stories locally versus the [deployed storybook](https://rdkcentral.github.io/Lightning-UI-Components/?path=/story/components-cardcontent-cardcontentvertical--card-content-vertical).


## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
