### PR TITLE
fix(Tile): if there is no metadata, position logo off of progress bar

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
@@ -219,8 +219,8 @@ export default class Tile extends Surface {
   }
 
   _calculateLogoYPosition() {
-    if (this._isInsetMetadata) {
-      return this._metadataY - (this._Metadata ? this._Metadata.h : 0);
+    if (this._isInsetMetadata && this._Metadata) {
+      return this._metadataY - this._Metadata.h;
     }
     return this._progressBarY
       ? this._progressBarY - this.style.paddingYBetweenContent


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
If no metadata is passed into the Tile by default, and the location is inset and there is a logo, the position was off.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
Compare the deployed Tile story to this locally. On first load in the Tile story, if no metadata is passed in and the position is inset, the logo is offset, now it should be good to go.

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
