### PR TITLE
fix(TitleRow): animate row repositioning for title instead of popping

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.js
+++ b/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.js
@@ -90,7 +90,7 @@ export default class TitleRow extends Row {
   }
 
   _updateRow() {
-    this.Items.patch({
+    this.applySmooth(this.Items, {
       y: this.title ? this._Title.finalH + this.style.titleMarginBottom : 0
     });
   }


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
In the internal Rail component where the row moves up and down on focus/unfocus to account for the scaling tiles, the reposition was happening automatically and not animating.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
