### PR TITLE
docs(Storybook): updates references of Storybook in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -368,7 +368,7 @@ Storybook will generate an ID for each story that follows the pattern `component
 **Storybook**
 <a id="storybook" />
 
-This section is dedicated to some specifics around our implementation of [Storybook](https://storybook.js.org), which is using Storybook v6.0. If you are new to Storybook (or even 6.0), we highly recommend you check out their [updated documentation](https://storybook.js.org/docs/react/writing-stories/introduction).
+This section is dedicated to some specifics around our implementation of [Storybook](https://storybook.js.org), which is using Storybook v7.5. If you are new to Storybook (or even 7), we highly recommend you check out their [Get Started documentation](https://storybook.js.org/docs/7.5/get-started/whats-a-story).
 
 You can add interactivity to your documentation with **args**. For the purposes of this project, you will likely only encounter **actions** and **controls**. We're going to walk through a simple example to illustrate the concepts that are necessary to understand for writing stories in the project.
 
@@ -434,7 +434,7 @@ Let's break down **argTypes** first. Defining **argTypes** on the story function
 
 Shifting focus to **args**, we can see that we have a definition for `'title'` but not for `'onEnter'`. Setting the **args** object on a story function tells Storybook what the _default values_ will be for controls defined in **argTypes**.
 
-Check out the [args docs](https://storybook.js.org/docs/react/writing-stories/args) and [essential addons docs](https://storybook.js.org/docs/react/essentials/introduction) for additional details.
+Check out the [args docs](https://storybook.js.org/docs/7.5/writing-stories/args) and [Controls Essential addon docs](https://storybook.js.org/docs/7.5/essentials/controls) for additional details.
 
 Now, let's say you want to execute some side effect when an arg value changes. To do this, we're going to introduce a new concept that _is not explicitly a part of Storybook_, `parameters.argActions`.
 
@@ -469,15 +469,18 @@ Usage documentation lives in `<Type>/<Component>/<Component>.mdx`. [MDX](https:/
 If you generated a new component with `yarn createComponent`, a template layout should exist for your component. If you are contributing to an existing component, follow the patterns established there. Adding usage steps should look like this example:
 
 ```js
-import { Canvas, Story } from '@storybook/addon-docs';
-import <Component> from '.';
+import { Meta, Title, ArgTypes, Description } from '@storybook/blocks';
+import * as ComponentNameStories from './ComponentNameStories.stories';
 
-// title, description, etc. (eg # <Component>)
+<Meta of={ComponentNameStories} />
+
+<Title /> /* this will be the H1 on the page */
+
+<Description /> /* taken from JS Doc in Story */
 
 ## Usage
 
 Implementation description here
-
 
 // example implementation
 import lng from '@lightningjs/core';
@@ -490,20 +493,12 @@ class Example extends lng.Component {
     };
   }
 }
-
-// Embed live example from Storybook
-<Canvas>
-  <Story id="mycomponent--basic" />
-</Canvas>
 ```
-
-The `<Canvas>` component will supply the source code for the `<Story>` inside, so only use code blocks when you want to illustrate something explicit without an example. The `id` value for `<Story>` can be derived from the URL path of the story you are trying to embed.
 
 In summary, documenting usage is as follows:
 
 - description of usage
-- [optional] implementation code block and/or
-- [optional] Storybook example
+- [optional] implementation code block
 
 Repeat this pattern for as many usage variations as you see fit.
 
@@ -514,22 +509,23 @@ API documentation lives in `<Type>/<Component>/<Component>.mdx`, below [usage do
 
 If you generated a new component with `yarn createComponent`, a template layout should exist for your component. If you are contributing to an existing component, follow the patterns established there. Adding API documentation should follow this pattern:
 
-```
+```js
 ## API
+
+### Parent Properties
+ComponentName has the same properties as [ParentComponentName](?path=/docs/components-${parentName}--docs)
+
+<ArgTypes of={ParentNameStories.parentName} />
 
 ### Properties
 
-name|type|required|default|description
--|-|-|-
--|-|-|-
+<ArgTypes of={ComponentNameStories.Basic} />
 
 ### Methods
 
 #### methodName(argument:type): returnValue | void
 
-description
-
-##### Arguments
+### Style Properties
 
 name|type|required|default|description
 -|-|-|-|-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -513,7 +513,7 @@ If you generated a new component with `yarn createComponent`, a template layout 
 ## API
 
 ### Parent Properties
-ComponentName has the same properties as [ParentComponentName](?path=/docs/components-${parentName}--docs)
+ComponentName has the same properties as [ParentComponentName](?path=/docs/components-parentName--docs)
 
 <ArgTypes of={ParentNameStories.parentName} />
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,11 +173,14 @@ yarn createComponent <packageName> <componentName> <parentName>
 
 - `packageName`: name of which package the component will be published to (`@lightningjs/ui-components` or `@lightningjs/ui-components`)
 - `componentName`: name of component to be added
+- `parentName`: name of parent component the new components extends
+
+If `parentName` is left out, the component's doc will reference an `undefined` component which can either be changed to reference another component or deleted
 
 Example: add a new component, `MyComponent`, to the `@lightningjs/ui-components` package
 
 ```sh
-yarn createComponent @lightningjs/ui-components MyComponent
+yarn createComponent @lightningjs/ui-components MyComponent ParentComponent
 ```
 
 This will create the following files:
@@ -509,17 +512,18 @@ API documentation lives in `<Type>/<Component>/<Component>.mdx`, below [usage do
 
 If you generated a new component with `yarn createComponent`, a template layout should exist for your component. If you are contributing to an existing component, follow the patterns established there. Adding API documentation should follow this pattern:
 
-```js
+```mdx
 ## API
 
 ### Parent Properties
+
 ComponentName has the same properties as [ParentComponentName](?path=/docs/components-parentName--docs)
 
-<ArgTypes of={ParentNameStories.parentName} />
+<ArgTypes of={ParentNameStories.parentName} exclude={['mode']} />
 
 ### Properties
 
-<ArgTypes of={ComponentNameStories.Basic} />
+<ArgTypes of={ComponentNameStories.Basic} exclude={['mode']} />
 
 ### Methods
 
@@ -527,7 +531,7 @@ ComponentName has the same properties as [ParentComponentName](?path=/docs/compo
 
 ### Style Properties
 
-name|type|required|default|description
--|-|-|-|-
--|-|-|-|-
+| name | type | required | default | description |
+| ---- | ---- | -------- | ------- | ----------- |
+| -    | -    | -        | -       | -           |
 ```

--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -156,34 +156,6 @@ not this:
 import { Base, Checkbox, TextBox } from '..';
 ```
 
-## Storybook Config
-
-Notes from exploring LUI's current Storybook config and how Storybook config works.
-Take aways:
-- We are doing a lot of custom configs for panels, more of an observation than a critique.
-- For the most part the standard Storybook config files look to be in order except `preview.js`
-- We should refactor the code in `main.js`. The stories glob could probably be simplified, to keep things DRY
-- `preview.js` and `argActions` is where we should dedicate our refactoring and research time.
-- further research needs to be done decorators and figuring out how to rewrite the custom one we have in `preview.js`
-
-
-| File                                     | Description                                                                                                                                                                 | Storybook Description                                                                                                                                         |
-| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `.storybook/addons/Announce`             | custom config for screen readers                                                                                                                                            |
-| `.storybook/addons/ComponentStylesPanel` | creates panel specfic component style controls                                                                                                                              |
-| `.storybook/addons/GridOverlay `         | creates panel grid overlay controls                                                                                                                                         |
-| `.storybook/addons/ThemeDownload`        | creates the theme download function & button the lives on the Storybook Toolbar                                                                                             |
-| `.storybook/addons/ThemePanel`           | creates Global Theme values panel with controls to adjust global values                                                                                                     |
-| `.storybook/addons/ThemePicker`          | creates Theme picker dropdown that is located in the toolbar                                                                                                                |
-| `.storybook/addons/Register`             | imports all the addons                                                                                                                                                      |
-| `.storybook/addons/components`           | folder containing table and table row components used in Component Style Panel, Grid Overlay Panel, and Global Theme Values                                                 |
-| `.storybook/utils/index.js`              | various custom Storybook utility functions                                                                                                                                  |
-| `.storybook/constants.js`                | creates variables used through out the Storybook config files (ex. `THEMES`)                                                                                                |
-| `.storybook/main.js`                     | in general this file lines up with Storybook expected usage, should examine the way we are loading stories for `Development` vs  `Production`, the code could be simplified | controls Storybook server's behavior, contains the location of stories to load, webpack and babel custom configs, add-ons, and any framework specific configs |
-| `.storybook/manager-head.html`           | grid overlay styles                                                                                                                                                         |                                                                                                                                                               |
-| `.storybook/manager.js`                  | Config for Storybook theme                                                                                                                                                  | controls the behavior of the Storybook UI, the place to set UI options and configure the Storybook theme                                                      |
-| `.storybook/preview-head.html`           | docs style overrides                                                                                                                                                        | add extra elements to the head of the preview iframe, for instance, to load static stylesheets, font files                                                    | `.storybook/preview.js` | has a custom decorator function so Lightning and Storybook work together , case logic for which theme is loaded when the ThemePicker is used. NOTE: `argActions` (LUI specific) used to define functions to execute on changes to an arg. See `Contributing.md` for more detail | config to render components in Canvas (preview iframe). The JavaScript build configuration of the preview is controlled by a webpack config |
-
 ## Rewriting Git History to Change Committers from GHE name/email to Public GitHub name/email
 
 This was done as we were getting ready to release version 2.x of the open-sourced version of LUI, [Lightning-UI-Components](https://github.com/rdkcentral/Lightning-UI-Components).
@@ -296,12 +268,12 @@ Clone the `add-copyright` repo: https://github.com/atapas/add-copyright/ and fol
 
 Additionally, here is a write-up on the tool: https://blog.greenroots.info/add-copyright-or-license-text-to-the-source-files-recursively.
 
-
 ```bash
 find "PATH TO FOLDER" -type d -name "FOLDER TO IGNORE" -prune -o -name "EXTENSION" -print0 | xargs -0 ./addcopyright.sh
 ```
 
 Ignore the following folders before running the script:
+
 - node_modules
 - .husky
 - .vscode
@@ -309,17 +281,20 @@ Ignore the following folders before running the script:
 - dist
 
 For example:
+
 ```bash
 find ~/Sites/lightning-ui -type d -name "node_modules" -prune -o -type d -name ".husky" -prune -o -type d -name ".vscode" -prune -o -type d -name ".yarn" -prune -o -type d -name "dist" -prune -o -name "*.js" -print0 | xargs -0 ./addcopyright.sh
 ```
 
 Use the `LICENSEHEADER.js` file for use with the following extensions:
+
 - .js
 - .cjs
 - .mjs
 - .ts
 
 Use the `LICENSEHEADER.html` file for use with the following extensions:
+
 - .md
 - .mdx
 - .html

--- a/bin/create.js
+++ b/bin/create.js
@@ -56,7 +56,7 @@ if (fs.existsSync(workingDir)) {
   throw new Error(message);
 }
 
-const componentContent = componentTemplate(componentName, componentDir);
+const componentContent = componentTemplate(componentName, parentName, componentDir);
 const storyContent = storyTemplate(componentName, componentDir);
 const mdxContent = docsTemplate(componentName, parentName, componentDir);
 const testContent = testTemplate(componentName, componentDir);

--- a/bin/templates/component.template.js
+++ b/bin/templates/component.template.js
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-module.exports = name => {
+module.exports = (name, parentName) => {
   return `/**
  * Copyright 2023 Comcast Cable Communications Management, LLC
  *
@@ -35,10 +35,10 @@ module.exports = name => {
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import Base from '../Base';
+import ${parentName} from '../${parentName}';
 import * as styles from './${name}.styles.js';
 
-export default class ${name} extends Base {
+export default class ${name} extends ${parentName} {
   static get __componentName() {
     return '${name}';
   }

--- a/bin/templates/component.template.js
+++ b/bin/templates/component.template.js
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-module.exports = (name, parentName) => {
+module.exports = (name, parentName='Base') => {
   return `/**
  * Copyright 2023 Comcast Cable Communications Management, LLC
  *

--- a/bin/templates/docs.template.js
+++ b/bin/templates/docs.template.js
@@ -76,11 +76,11 @@ class Basic extends lng.Component {
 ${name} has the same properties as [${parentName}](?path=/docs/components-${parentName}--docs)
 
 {/**TODO: check the name of the story of the parent component matches the name here. **/}
-<ArgTypes of={${parentName}Stories.${parentName}} />
+<ArgTypes of={${parentName}Stories.${parentName}} exclude={['mode']} />
 
 ### Properties
 {/** TODO: if you change the name of the story from Basic to something else, also update then name here **/}
-<ArgTypes of={${name}Stories.Basic} /> 
+<ArgTypes of={${name}Stories.Basic} exclude={['mode']} /> 
 
 ### Style Properties
 

--- a/bin/templates/story.template.js
+++ b/bin/templates/story.template.js
@@ -68,7 +68,7 @@ Basic.argTypes = {
   //   description: '',
   //   table: {
   //     defaultValue: { summary: undefined },
-  //     type: {summary: 'string'}
+  //     type: {summary: 'string'} //TODO: update this with the appropriate type if not string
   //   }
   // }
 };

--- a/packages/apps/lightning-ui-docs/src/Contributing.mdx
+++ b/packages/apps/lightning-ui-docs/src/Contributing.mdx
@@ -18,7 +18,6 @@ SPDX-License-Identifier: Apache-2.0
 \*/}
 
 import { Meta, Markdown } from '@storybook/blocks';
-import Contributing from '../../../../CONTRIBUTING.md?raw';
 
 <Meta title="Docs / Contributing" />
 
@@ -171,10 +170,10 @@ Before a new component will be reviewed, it must meet the following prerequisite
 If you are creating a new component, you can bootstrap the required file structure with:
 
 ```sh
-yarn createComponent <packageName> <componentName>
+yarn createComponent <packageName> <componentName> <parentName>
 ```
 
-- `packageName`: name of which package the component will be published to (`@lightningjs/ui-components` or `@lightningjs/ui-components`)
+- `packageName`: name of which package the component will be published to ( example `@lightningjs/ui-components`)
 - `componentName`: name of component to be added
 - `parentName`: name of parent component the new components extends
 
@@ -478,15 +477,18 @@ Usage documentation lives in `<Type>/<Component>/<Component>.mdx`. [MDX](https:/
 If you generated a new component with `yarn createComponent`, a template layout should exist for your component. If you are contributing to an existing component, follow the patterns established there. Adding usage steps should look like this example:
 
 ```js
-import { Canvas, Story } from '@storybook/addon-docs';
-import <Component> from '.';
+import { Meta, Title, ArgTypes, Description } from '@storybook/blocks';
+import * as ComponentNameStories from './ComponentNameStories.stories';
 
-// title, description, etc. (eg # <Component>)
+<Meta of={ComponentNameStories} />
+
+<Title /> /* this will be the H1 on the page */
+
+<Description /> /* taken from JS Doc in Story */
 
 ## Usage
 
 Implementation description here
-
 
 // example implementation
 import lng from '@lightningjs/core';
@@ -499,20 +501,12 @@ class Example extends lng.Component {
     };
   }
 }
-
-// Embed live example from Storybook
-<Canvas>
-  <Story id="mycomponent--basic" />
-</Canvas>
 ```
-
-The `<Canvas>` component will supply the source code for the `<Story>` inside, so only use code blocks when you want to illustrate something explicit without an example. The `id` value for `<Story>` can be derived from the URL path of the story you are trying to embed.
 
 In summary, documenting usage is as follows:
 
 - description of usage
-- [optional] implementation code block and/or
-- [optional] Storybook example
+- implementation code block (optional)
 
 Repeat this pattern for as many usage variations as you see fit.
 
@@ -524,24 +518,26 @@ API documentation lives in `<Type>/<Component>/<Component>.mdx`, below [usage do
 
 If you generated a new component with `yarn createComponent`, a template layout should exist for your component. If you are contributing to an existing component, follow the patterns established there. Adding API documentation should follow this pattern:
 
-```
+```mdx
 ## API
+
+### Parent Properties
+
+ComponentName has the same properties as [ParentComponentName](?path=/docs/components-parentName--docs)
+
+<ArgTypes of={ParentNameStories.parentName} exclude={['mode']} />
 
 ### Properties
 
-name|type|required|default|description
--|-|-|-
--|-|-|-
+<ArgTypes of={ComponentNameStories.Basic} exclude={['mode']} />
 
 ### Methods
 
 #### methodName(argument:type): returnValue | void
 
-description
+### Style Properties
 
-##### Arguments
-
-name|type|required|default|description
--|-|-|-|-
--|-|-|-|-
+| name | type | required | default | description |
+| ---- | ---- | -------- | ------- | ----------- |
+| -    | -    | -        | -       | -           |
 ```

--- a/packages/apps/lightning-ui-docs/src/Contributing.mdx
+++ b/packages/apps/lightning-ui-docs/src/Contributing.mdx
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 \*/}
 
-import { Meta, Markdown } from '@storybook/blocks';
+import { Meta } from '@storybook/blocks';
 
 <Meta title="Docs / Contributing" />
 

--- a/packages/apps/lightning-ui-docs/src/Contributing.mdx
+++ b/packages/apps/lightning-ui-docs/src/Contributing.mdx
@@ -176,11 +176,14 @@ yarn createComponent <packageName> <componentName>
 
 - `packageName`: name of which package the component will be published to (`@lightningjs/ui-components` or `@lightningjs/ui-components`)
 - `componentName`: name of component to be added
+- `parentName`: name of parent component the new components extends
+
+If `parentName` is left out, the component's doc will reference an `undefined` component which can either be changed to reference another component or deleted
 
 Example: add a new component, `MyComponent`, to the `@lightningjs/ui-components` package
 
 ```sh
-yarn createComponent @lightningjs/ui-components MyComponent
+yarn createComponent @lightningjs/ui-components MyComponent ParentCompent
 ```
 
 This will create the following files:


### PR DESCRIPTION
## Description

This PR updates:
- references to Storybook documentation
- updates the component template doc with props automation from ArgTypes for component and parent component

## References

LUI-1299

## Testing
- read the updated documentation for createComponent under the Development section in the Contributing.md file
- create a new component: `yarn createComponent @lightningjs/ui-components MyComponent ParentComponent`

## Automation
Updates shouldn't change anything on the automation side

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
