### PR TITLE
fix(KeyboardSearch): export from index.js

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/index.js
+++ b/packages/@lightningjs/ui-components/src/components/index.js
@@ -48,7 +48,8 @@ export {
   KeyboardFullscreen,
   KeyboardNumbers,
   KeyboardQwerty,
-  KeyboardInput
+  KeyboardInput,
+  KeyboardSearch
 } from './Keyboard';
 export { default as Knob } from './Knob/Knob.js';
 export { default as Label } from './Label/Label.js';


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
KeyboardSearch was not added to index.js as an export, only index.d.ts.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
