### PR TITLE
fix(Tile): update Logo tag for patching

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
@@ -214,7 +214,7 @@ export default class Tile extends Surface {
         this.applySmooth(this._Logo, logoObject);
       }
     } else {
-      this.patch({ Icon: undefined });
+      this.patch({ Logo: undefined });
     }
   }
 


### PR DESCRIPTION
## Description

Corrects the tag being used to remove the logo when not in focused state or when there is not persistent metadata.

## References

N/A

## Testing

Switching to unfocused or disabled mode for Tile should now hide the logo.

## Automation

N/A

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
