### PR TITLE
fix(TextBox): toggleMarquee should not short-circuit if there is no contentTag

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
@@ -321,7 +321,7 @@ export default class TextBox extends Base {
   }
 
   _toggleMarquee(contentTag) {
-    if (!contentTag) return;
+    // do not just return if there is no contentTag, we may still need to alpha the Marquee
     if (this.marquee) {
       if (contentTag) {
         contentTag.alpha = 0.001;


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
If there is no contentTag, we may still need to alpha the marquee on/off. This is possible if the Marquee was already created and the text changed over time. This was added during the performance PRs, probably before this fix #448 had gone in, so this was just an unfortunate merge of both approaches.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
