### PR TITLE
fix(Slider): adds initial content so Value shows on load

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Slider/Slider.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Slider/Slider.stories.js
@@ -104,7 +104,8 @@ export const SignalHandling = () =>
         },
         Text: {
           y: 60,
-          type: TextBox
+          type: TextBox,
+          content: 'Value: 0'
         }
       };
     }


### PR DESCRIPTION
## Description

this PR adds 'Value: 0' to `Text.content` so there is a value showing on initial load of the story

## References

LUI-1305

## Testing

cd into branch
go to signalSlider story
Value: 0 should appear under the Slider component and should update when clicking on left and right arrows

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
