### PR TITLE
fix(Tile): update conditions to show/hide gradient

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
@@ -196,6 +196,10 @@ export default class Tile extends Surface {
   /* ------------------------------ Logo ------------------------------ */
 
   _updateLogo() {
+    if (!this.logo) {
+      this.patch({ Logo: undefined });
+      return;
+    }
     const logoObject = {
       w: this.style.logoWidth,
       h: this.style.logoHeight,
@@ -204,21 +208,16 @@ export default class Tile extends Surface {
       x: this.style.paddingX,
       y: this._calculateLogoYPosition()
     };
-
-    if (this._shouldShowLogo) {
-      if (!this._Logo) {
-        this.patch({
-          Logo: {
-            type: Icon,
-            mountY: 1,
-            ...logoObject
-          }
-        });
-      } else {
-        this.applySmooth(this._Logo, logoObject);
-      }
-    } else if (!this.logo) {
-      this.patch({ Logo: undefined });
+    if (!this._Logo) {
+      this.patch({
+        Logo: {
+          type: Icon,
+          mountY: 1,
+          ...logoObject
+        }
+      });
+    } else {
+      this.applySmooth(this._Logo, logoObject);
     }
   }
 

--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
@@ -146,7 +146,11 @@ export default class Tile extends Surface {
   get _gradient() {
     if (this._isCircleLayout) return false;
     return Boolean(
-      this._isInsetMetadata && this._hasMetadata && this._shouldShowMetadata
+      (this._isInsetMetadata &&
+        this._hasMetadata &&
+        this._shouldShowMetadata) ||
+        this.progressBar?.progress > 0 ||
+        this._shouldShowLogo
     );
   }
 
@@ -196,12 +200,12 @@ export default class Tile extends Surface {
       w: this.style.logoWidth,
       h: this.style.logoHeight,
       icon: this.logo,
-      alpha: this.style.alpha,
+      alpha: this._shouldShowLogo ? this.style.alpha : 0.001,
       x: this.style.paddingX,
       y: this._calculateLogoYPosition()
     };
 
-    if (this.logo && (this.persistentMetadata || this._isFocusedMode)) {
+    if (this._shouldShowLogo) {
       if (!this._Logo) {
         this.patch({
           Logo: {
@@ -213,7 +217,7 @@ export default class Tile extends Surface {
       } else {
         this.applySmooth(this._Logo, logoObject);
       }
-    } else {
+    } else if (!this.logo) {
       this.patch({ Logo: undefined });
     }
   }
@@ -226,6 +230,11 @@ export default class Tile extends Surface {
       ? this._progressBarY - this.style.paddingYBetweenContent
       : this._h - this.style.paddingY;
   }
+
+  get _shouldShowLogo() {
+    return this.logo && (this.persistentMetadata || this._isFocusedMode);
+  }
+
   /* ------------------------------ Artwork ------------------------------ */
 
   _updateArtwork() {

--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.js
@@ -143,14 +143,14 @@ export default class Tile extends Surface {
     return this._h; // Ensure that surface respects the correct height when metadata is displayed below
   }
 
-  get _gradient() {
-    if (this._isCircleLayout) return false;
+  get _shouldShowGradient() {
     return Boolean(
-      (this._isInsetMetadata &&
+      ((this._isInsetMetadata &&
         this._hasMetadata &&
         this._shouldShowMetadata) ||
         this.progressBar?.progress > 0 ||
-        this._shouldShowLogo
+        this._shouldShowLogo) &&
+        !this._isCircleLayout
     );
   }
 
@@ -252,7 +252,7 @@ export default class Tile extends Surface {
         radius: this.style?.radius,
         ...this.artwork?.style
       },
-      gradient: this._gradient,
+      gradient: this._shouldShowGradient,
       shouldScale: this._isFocusedMode
     });
   }

--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.stories.js
@@ -78,7 +78,7 @@ Tile.argTypes = {
   },
   logo: {
     control: 'select',
-    options: [xfinityLogo, 'null'],
+    options: [xfinityLogo, null],
     description: 'Icon source',
     table: {
       defaultValue: { summary: 'undefined' }

--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.test.js
@@ -444,7 +444,7 @@ describe('Tile', () => {
         progress: 0.5
       };
       await tile.__updateSpyPromise;
-      expect(tile._gradient).toBe(false);
+      expect(tile._gradient).toBe(true);
       tile.progressBar = {
         progress: 0
       };

--- a/packages/@lightningjs/ui-components/src/components/Tile/Tile.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Tile/Tile.test.js
@@ -430,7 +430,7 @@ describe('Tile', () => {
     });
 
     it('returns the proper value for gradient when has metadata is in focus and layout is inset', async () => {
-      expect(tile._gradient).toBe(false);
+      expect(tile._shouldShowGradient).toBe(false);
       // Overwrite _hasMetadata to always be true for test
       Object.defineProperty(tile, '_hasMetadata', {
         get() {
@@ -439,12 +439,12 @@ describe('Tile', () => {
       });
       testRenderer.focus();
       await tile.__updateSpyPromise;
-      expect(tile._gradient).toBe(false);
+      expect(tile._shouldShowGradient).toBe(false);
       tile.progressBar = {
         progress: 0.5
       };
       await tile.__updateSpyPromise;
-      expect(tile._gradient).toBe(true);
+      expect(tile._shouldShowGradient).toBe(true);
       tile.progressBar = {
         progress: 0
       };
@@ -453,17 +453,17 @@ describe('Tile', () => {
       testRenderer.unfocus();
       await tile.__updateSpyPromise;
 
-      expect(tile._gradient).toBe(false);
+      expect(tile._shouldShowGradient).toBe(false);
       testRenderer.focus();
       await tile.__updateSpyPromise;
-      expect(tile._gradient).toBe(false);
+      expect(tile._shouldShowGradient).toBe(false);
       tile.metadataLocation = 'inset';
       tile.progressBar = {
         progress: 0.7
       };
       testRenderer.focus();
       await tile.__updateSpyPromise;
-      expect(tile._gradient).toBe(true);
+      expect(tile._shouldShowGradient).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Description

Updates under what conditions the gradient is shown/hidden on Tile.

## References

LUI-1276

## Testing

Ensure that the gradient shows when any of the below are visible on the Tile and hidden when none are visible:
- inset metadata
- progress bar
- logo

## Automation

This does update the visibility of the gradient, so it may require updates to the Tile tests.

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
