### PR TITLE
fix(TabBar): add missing getters/setters from LUI 4

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.js
@@ -196,6 +196,22 @@ export default class TabBar extends Base {
     return tabs;
   }
 
+  _getTabs() {
+    return this._Tabs.items;
+  }
+
+  get selected() {
+    return this._Tabs.selected;
+  }
+
+  get selectedIndex() {
+    return this._Tabs.selectedIndex;
+  }
+
+  set selectedIndex(index) {
+    this._Tabs.selectedIndex = index;
+  }
+
   get _collapsedHeight() {
     return this._Tabs.h;
   }


### PR DESCRIPTION
## Description

Adds missing getters and setters that were previously available in TabBar in LUI 4.

## References

LUI-1269

## Testing

N/A

## Automation

N/A

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
