### PR TITLE
feat(Extensions): prototype extensions refactor

### DIFF
--- a/packages/@lightningjs/ui-components/src/globals/context/applyExtension.js
+++ b/packages/@lightningjs/ui-components/src/globals/context/applyExtension.js
@@ -1,0 +1,75 @@
+const SUFFIX = '__ORIGINAL__';
+
+// If applyExtensions happens after component has been intialized, need to trigger component update cycle after theme is applied
+// This would happen with the themeUpdate event
+export function applyExtension(targetClass, extensionClass) {
+  const extensionDescriptors = Object.getOwnPropertyDescriptors(
+    extensionClass.prototype
+  );
+
+  // Important note: b/c we're rolling our own super implementaion, we need to make sure we're looking
+  // for overriding methods at all deeper levels of the class, not just highest level.
+  const originalAllDescriptors = getAllCustomDescriptors(targetClass.prototype);
+  const originalOwnDescriptors = Object.getOwnPropertyDescriptors(
+    targetClass.prototype
+  );
+
+  Object.getOwnPropertyNames(extensionDescriptors).forEach(propName => {
+    if (propName !== 'constructor') {
+      // If has value prop, It's a normal method, not accessor
+      if (extensionDescriptors[propName].value) {
+        const originalMethod = originalAllDescriptors[propName];
+        const originalOwnMethod = originalOwnDescriptors[propName];
+
+        // Preserve original method if it was an own method
+        const nameWithSuffix = propName + SUFFIX;
+        if (!targetClass[nameWithSuffix] && originalOwnMethod) {
+          targetClass.prototype[nameWithSuffix] = originalMethod;
+        }
+
+        // Wrap the mixin method to inject the `next` method in the chain.
+        targetClass.prototype[propName] = function (...args) {
+          // TODO: do we need to catch overrriding method with an accessor and vice versa?
+          // const next = originalMethod
+          //   ? originalMethod.value.bind(this)
+          //   : undefined;
+
+          const next = originalMethod ? originalMethod.value : undefined;
+
+          // Call the mixin method with arguments and `next` as the last argument.
+          return extensionClass.prototype[propName].apply(this, [
+            ...args,
+            next
+          ]);
+        };
+      } else {
+        // setup accessor
+        // I'm not sure this implementation allows for super calls in accessors
+        Object.defineProperty(
+          targetClass.prototype,
+          propName,
+          extensionDescriptors[propName]
+        );
+      }
+    }
+  });
+}
+
+// For extensions cleanup, you still need to call _cleanupExtension on each instance.
+// would need like before
+// to handle detached instances, could cleanupe extension on detach
+
+// TODO: implement, remove added methods and replace original
+export function cleanupExtensions(targetClass) {}
+
+function getAllCustomDescriptors(obj) {
+  if (!obj || obj === Object.prototype) {
+    return {};
+  } else {
+    const proto = Object.getPrototypeOf(obj);
+    return {
+      ...getAllCustomDescriptors(proto),
+      ...Object.getOwnPropertyDescriptors(obj)
+    };
+  }
+}

--- a/packages/@lightningjs/ui-components/src/globals/context/theme-manager.js
+++ b/packages/@lightningjs/ui-components/src/globals/context/theme-manager.js
@@ -27,7 +27,7 @@ import logger from './logger.js';
 import events from './events.js';
 import { fontLoader, cleanupFonts } from './fonts.js';
 import { THEME_KEY_REPLACER } from './constants.js';
-
+import { applyExtension } from './applyExtension.js';
 const merge = {
   all: objArray => {
     let result = {};
@@ -158,6 +158,8 @@ class ThemeManager {
 
   async setTheme(themeConfig) {
     let value;
+
+    const testExtensions = themeConfig.testExtensions;
     if (Array.isArray(themeConfig)) {
       value = merge.all(themeConfig);
     } else {
@@ -176,6 +178,16 @@ class ThemeManager {
     if (theme.font && theme.font.length) {
       await this._loadFonts(theme.font);
     }
+
+    // Here we would if theme.extensions check
+    if (testExtensions) {
+      testExtensions.forEach(({ components, extension }) => {
+        components.forEach(compClass => {
+          applyExtension(compClass, extension);
+        });
+      });
+    }
+
     this._refreshSubThemes();
     this._emit('themeExtensionsUpdate');
     this._emit('themeUpdate'); // Notify components that an update cycle is required


### PR DESCRIPTION
## Description

Prototype implementation of applying extensions at setTheme time to Component prototypes rather than at instance construct time.

Extensions take an array of imported component references rather than component names
```
const extensions = [
  {
    components: [Surface],
    extension: WithRedRect,
  },
]
```

Extensions are just classes, and super calls are replaces by this custom next implementation 
```
class WithRedRect {
  _update(next) {
    // super calls are replaced with next
   // this can be bound during applyExtensions instead, but think this may be technically faster. 
     if (next) {
      next.apply(this)
    }
    this.patch({
      PopupRed: {
        rect: true,
        w: 100,
        h: 100,
        x: 10,
        y: 10,
        color: 0xffff0000,
        zIndex: 100,
      },
    })
  }

  _cleanupExtension() {
    this.patch({
      PopupRed: undefined,
    })
  }
}
```


Results in roughly 15-20% faster component construct/init time. 
Perf. was measured creating a column of 4 rows of 8 tiles. 

Before: 

![image](https://github.com/rdkcentral/Lightning-UI-Components/assets/841975/8428eee4-ca5d-46ed-8708-4d85f6350572)

After: 

![image](https://github.com/rdkcentral/Lightning-UI-Components/assets/841975/a8a82f71-13c2-4520-97fd-b4fdcd5e0968)
## References
https://ccp.sys.comcast.net/projects/LUI/issues/LUI-1329
<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->


## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
