### PR TITLE
fix(Keyboard): setting selectedIndex when creating rows

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.js
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.js
@@ -130,6 +130,7 @@ export default class Keyboard extends Base {
           itemSpacing: this.style.keySpacing
         },
         items: this._createKeys(keys, keyboard),
+        selectedIndex: this._currentKeyboard?.selected?.selectedIndex || 0,
         waitForDimensions: true
       };
     });


### PR DESCRIPTION
## Description

setting the selectedIndex for the Row when creating a new keyboard on toggle

## References

LUI-1320

## Testing

- migrate to a keyboard that has multiple formats (example: keyboard-qwerty)
- click one of the keys that toggle a keyboard change (such as symbols, shift etc)
- notice how the focus stays on that key

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
