### PR TITLE
fix(UpdateManager): sync updates to render loop

### DIFF
--- a/packages/@lightningjs/ui-components-test-utils/src/lightning-test-renderer.js
+++ b/packages/@lightningjs/ui-components-test-utils/src/lightning-test-renderer.js
@@ -111,6 +111,7 @@ function create(Component, options = {}) {
   app.stage.transitions.defaultTransitionSettings.duration = 0;
   app.children = Component;
   app.updateFocusPath();
+  updateManager.init(app.stage);
   return {
     toJSON: (children = 1) => toJSON(app.childList.first, { children }),
     update: () => {

--- a/packages/@lightningjs/ui-components/src/components/Button/Button.js
+++ b/packages/@lightningjs/ui-components/src/components/Button/Button.js
@@ -272,7 +272,8 @@ export default class Button extends Surface {
     // Using the "get h" return statement does not force an update to the inspector,
     // whereas this will ensure the "height" attribute is updated
     if (!this._hSetByUser && !this.style.h) {
-      this._h = this.style.textStyle.lineHeight + this.style.paddingY * 2;
+      // TODO: name this prop... We still want updated tiggered on height change
+      this.hNoUser = this.style.textStyle.lineHeight + this.style.paddingY * 2;
     }
 
     // TODO breaks row resizing if this is wrapped in the width conditional above

--- a/packages/@lightningjs/ui-components/src/components/Button/Button.js
+++ b/packages/@lightningjs/ui-components/src/components/Button/Button.js
@@ -256,6 +256,9 @@ export default class Button extends Surface {
   }
 
   _updateSurfaceDimensions() {
+    const startW = this.w;
+    const startH = this.h;
+
     let newWidth = this.w;
     if (this.fixed) {
       newWidth = this._w;
@@ -276,8 +279,10 @@ export default class Button extends Surface {
       this.hNoUser = this.style.textStyle.lineHeight + this.style.paddingY * 2;
     }
 
-    // TODO breaks row resizing if this is wrapped in the width conditional above
-    this.fireAncestors('$itemChanged');
+    // Only fire if changed
+    if (this.w !== startW || this.h !== startH) {
+      this.fireAncestors('$itemChanged');
+    }
   }
 
   _calcDynamicWidth() {

--- a/packages/@lightningjs/ui-components/src/components/Column/Column.js
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.js
@@ -104,10 +104,6 @@ export default class Column extends NavigationManager {
     this.onScreenEffect(this.onScreenItems);
   }
 
-  _performRender() {
-    this._render(this.selected, this.prevSelected);
-  }
-
   checkSkipPlinko(prev, next) {
     // If previous doesn't have skip plinko or previous is the first or last item
     if (

--- a/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.d.ts
@@ -176,8 +176,9 @@ declare class FocusManager<
   /**
    * Selects next item. If this.wrapSelected=true, will select the first element in the list if focus is currently on the last item.
    * emits the `selectedChange` signal
+   * @param forceSmoothValue allows setting the shouldSmooth value before the select update
    */
-  selectNext(): void;
+  selectNext(forceSmoothValue?: boolean): void;
 
   /**
    * Selects previous item. If this.wrapSelected=true, will select the last element in the list if focus is currently on the first item.

--- a/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.js
+++ b/packages/@lightningjs/ui-components/src/components/FocusManager/FocusManager.js
@@ -171,7 +171,7 @@ export default class FocusManager extends Base {
     // If the first item has skip focus when appended get the next focusable item
     const initialSelection = this.Items.children[this.selectedIndex];
     if (initialSelection && initialSelection.skipFocus) {
-      this.selectNext();
+      this.selectNext(false);
     }
   }
 
@@ -259,8 +259,8 @@ export default class FocusManager extends Base {
     return false;
   }
 
-  selectNext() {
-    this.shouldSmooth = true;
+  selectNext(forceSmoothValue) {
+    this.shouldSmooth = forceSmoothValue ?? true;
     if (this._lazyItems && this._lazyItems.length) {
       delayForAnimation(() => {
         this._appendLazyItem(this._lazyItems.splice(0, 1)[0]);

--- a/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.js
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.js
@@ -123,7 +123,7 @@ export default class Keyboard extends Base {
         type: Row,
         autoResizeHeight: true,
         autoResizeWidth: true,
-        centerInParent: this.centerKeyboard,
+        centerInParent: this.centerKeys,
         neverScroll: true,
         wrapSelected: this.rowWrap !== undefined ? this.rowWrap : true,
         style: {

--- a/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.js
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.js
@@ -110,8 +110,7 @@ export default class Keyboard extends Base {
           },
           autoResizeWidth: true,
           autoResizeHeight: true,
-          neverScroll: true,
-          waitForDimensions: true
+          neverScroll: true
         }
       });
     }
@@ -130,8 +129,7 @@ export default class Keyboard extends Base {
           itemSpacing: this.style.keySpacing
         },
         items: this._createKeys(keys, keyboard),
-        selectedIndex: this._currentKeyboard?.selected?.selectedIndex || 0,
-        waitForDimensions: true
+        selectedIndex: this._currentKeyboard?.selected?.selectedIndex || 0
       };
     });
   }

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -302,8 +302,8 @@ export default class NavigationManager extends FocusManager {
     this._render(this.selected, this.prevSelected);
   }
 
-  _appendItem(item) {
-    this.shouldSmooth = false;
+  _appendItem(item, shouldStopSmooth = true) {
+    this.shouldSmooth = !shouldStopSmooth;
     item.parentFocus = this.hasFocus();
     item = this.Items.childList.a(item);
 
@@ -324,11 +324,14 @@ export default class NavigationManager extends FocusManager {
     const lastChild = this._Items.children[this.items.length - 1];
     const nextPosition =
       lastChild[lengthDimension] +
+      lastChild[axis] +
       (lastChild.extraItemSpacing || 0) +
       this.style.itemSpacing;
-    item[axis] = nextPosition;
-    this._appendItem(item);
-    this.requestUpdate();
+
+    const appended = this._appendItem(item, false);
+
+    appended[axis] = nextPosition;
+    this._Items[lengthDimension] += nextPosition + item[lengthDimension];
   }
 
   $itemChanged() {

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -298,8 +298,9 @@ export default class NavigationManager extends FocusManager {
     });
   }
 
-  // can be overwritten
-  _performRender() {}
+  _performRender() {
+    this._render(this.selected, this.prevSelected);
+  }
 
   _appendItem(item) {
     this.shouldSmooth = false;

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -315,12 +315,19 @@ export default class NavigationManager extends FocusManager {
     }
 
     item = this._withAfterUpdate(item);
+    return item;
   }
 
   _appendLazyItem(item) {
+    const { lengthDimension, axis } = this._directionPropNames;
+    const lastChild = this._Items.children[this.items.length - 1];
+    const nextPosition =
+      lastChild[lengthDimension] +
+      (lastChild.extraItemSpacing || 0) +
+      this.style.itemSpacing;
+    item[axis] = nextPosition;
     this._appendItem(item);
-    this.queueRequestUpdate();
-    this._refocus();
+    this.requestUpdate();
   }
 
   $itemChanged() {

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -118,6 +118,10 @@ export default class NavigationManager extends FocusManager {
 
     for (let i = 0; i < this.Items.children.length; i++) {
       const child = this.Items.children[i];
+      // If child has a queued update, run it first so it is sized before layout happens.
+      if (child.requestEarlyUpdate) {
+        child.requestEarlyUpdate();
+      }
       const childCrossDimensionSize = this._calcCrossDimensionSize(child);
 
       if (

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.js
@@ -208,10 +208,6 @@ export default class Row extends NavigationManager {
     this.onScreenEffect(this.onScreenItems);
   }
 
-  _performRender() {
-    this._render(this.selected, this.prevSelected);
-  }
-
   _isOnScreen(child) {
     if (!child) return false;
 

--- a/packages/@lightningjs/ui-components/src/components/TabBar/Tab.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/Tab.js
@@ -68,18 +68,50 @@ export default class Tab extends Surface {
   }
 
   _onTextBoxChanged() {
-    this._updateContent();
-    this._updateTabSize();
+    this._updateSizing();
   }
 
   _update() {
-    super._update();
     this._updateIcon();
     this._updateText();
-    this._updateContent();
-    this._updateTabSize();
+    this._updateSizing();
   }
 
+  _updateSizing() {
+    this._updateContent();
+    this._updateTabSize();
+    this._updatePositions();
+    super._update();
+  }
+
+  _updatePositions() {
+    if (this._Icon) {
+      const iconPatch = {
+        y: this._Content.h / 2
+      };
+      if (this.title) {
+        iconPatch.x = 0;
+        iconPatch.mountX = 0;
+      } else {
+        iconPatch.x = this._Content.w / 2;
+        iconPatch.mountX = 0.5;
+      }
+      this._Icon.patch(iconPatch);
+    }
+    if (this._Text) {
+      const textPatch = {
+        y: this._Content.h / 2
+      };
+      if (this.icon) {
+        textPatch.x = this._iconW + this.style.iconMarginRight;
+        textPatch.mountX = 0;
+      } else {
+        textPatch.x = this._Content.w / 2;
+        textPatch.mountX = 0.5;
+      }
+      this._Text.patch(textPatch);
+    }
+  }
   _updateIcon() {
     if (!this.icon) {
       this._Content.patch({ Icon: undefined });
@@ -89,19 +121,11 @@ export default class Tab extends Surface {
       icon: this.icon,
       w: this.style.iconSize,
       h: this.style.iconSize,
-      y: this._Content.h / 2,
+
       style: {
         color: this.style.contentColor
       }
     };
-
-    if (this.title) {
-      iconPatch.x = 0;
-      iconPatch.mountX = 0;
-    } else {
-      iconPatch.x = this._Content.w / 2;
-      iconPatch.mountX = 0.5;
-    }
 
     if (this._Icon) {
       this._Icon.patch(iconPatch);
@@ -119,16 +143,8 @@ export default class Tab extends Surface {
   _updateText() {
     const textPatch = {
       content: this.title,
-      style: { textStyle: this.style.textStyle },
-      y: this._Content.h / 2
+      style: { textStyle: this.style.textStyle }
     };
-    if (this.icon) {
-      textPatch.x = this._iconW + this.style.iconMarginRight;
-      textPatch.mountX = 0;
-    } else {
-      textPatch.x = this._Content.w / 2;
-      textPatch.mountX = 0.5;
-    }
 
     this._Text.patch(textPatch);
   }

--- a/packages/@lightningjs/ui-components/src/globals/global-update-manager/GlobalUpdateManager.js
+++ b/packages/@lightningjs/ui-components/src/globals/global-update-manager/GlobalUpdateManager.js
@@ -82,6 +82,10 @@ class GlobalUpdateManager {
     // See note in deleteRequestUpdate()
     this._requestUpdateSet.delete(component);
   }
+
+  hasQueuedRequestFor(component) {
+    return this._requestUpdateSet.has(component);
+  }
 }
 
 export const updateManager = new GlobalUpdateManager();

--- a/packages/@lightningjs/ui-components/src/globals/global-update-manager/GlobalUpdateManager.js
+++ b/packages/@lightningjs/ui-components/src/globals/global-update-manager/GlobalUpdateManager.js
@@ -23,7 +23,18 @@ class GlobalUpdateManager {
     this._updateThemeSet = new Set();
     this._requestUpdateSet = new Set();
     this._timeout = null;
+    this.isInitialized = false;
     this._runUpdatesTimeoutHandler = this._runUpdatesTimeoutHandler.bind(this);
+  }
+
+  init(stage) {
+    if (!this._initialized) {
+      this.isInitialized = true;
+      this.stage = stage;
+      this.stage.on('frameStart', () => {
+        this._runUpdatesTimeoutHandler();
+      });
+    }
   }
 
   _runUpdatesTimeoutHandler() {
@@ -36,7 +47,6 @@ class GlobalUpdateManager {
       }
     });
     this._updateThemeSet.clear();
-
     this._requestUpdateSet.forEach(component => {
       try {
         component.requestUpdate();
@@ -61,9 +71,6 @@ class GlobalUpdateManager {
 
   addUpdateTheme(component) {
     this._updateThemeSet.add(component);
-    if (!this._timeout) {
-      this._timeout = setTimeout(this._runUpdatesTimeoutHandler, 0);
-    }
   }
 
   deleteUpdateTheme(component) {
@@ -74,9 +81,6 @@ class GlobalUpdateManager {
 
   addRequestUpdate(component) {
     this._requestUpdateSet.add(component);
-    if (!this._timeout) {
-      this._timeout = setTimeout(this._runUpdatesTimeoutHandler, 0);
-    }
   }
 
   deleteRequestUpdate(component) {

--- a/packages/@lightningjs/ui-components/src/globals/global-update-manager/GlobalUpdateManager.js
+++ b/packages/@lightningjs/ui-components/src/globals/global-update-manager/GlobalUpdateManager.js
@@ -22,7 +22,6 @@ class GlobalUpdateManager {
   constructor() {
     this._updateThemeSet = new Set();
     this._requestUpdateSet = new Set();
-    this._timeout = null;
     this.isInitialized = false;
     this._runUpdatesTimeoutHandler = this._runUpdatesTimeoutHandler.bind(this);
   }
@@ -38,7 +37,6 @@ class GlobalUpdateManager {
   }
 
   _runUpdatesTimeoutHandler() {
-    this._timeout = null;
     this._updateThemeSet.forEach(component => {
       try {
         component._updateThemeComponent();
@@ -63,9 +61,6 @@ class GlobalUpdateManager {
    * @returns
    */
   flush() {
-    // If there is no timeout then there is definately nothing to update
-    if (!this._timeout) return;
-    clearTimeout(this._timeout);
     this._runUpdatesTimeoutHandler();
   }
 

--- a/packages/@lightningjs/ui-components/src/globals/global-update-manager/GlobalUpdateManager.test.js
+++ b/packages/@lightningjs/ui-components/src/globals/global-update-manager/GlobalUpdateManager.test.js
@@ -18,8 +18,11 @@
 
 import context from '../context';
 import { updateManager } from './GlobalUpdateManager.js';
-import { nextTick } from '@lightningjs/ui-components-test-utils';
 import { jest } from '@jest/globals';
+import lng from '@lightningjs/core';
+
+const stageEmitterInstance = new lng.EventEmitter();
+updateManager.init(stageEmitterInstance);
 
 describe('GlobalUpdateManager', () => {
   describe('addUpdateTheme', () => {
@@ -29,10 +32,10 @@ describe('GlobalUpdateManager', () => {
       };
       updateManager.addUpdateTheme(fakeComponent);
       expect(fakeComponent._updateThemeComponent).not.toHaveBeenCalled();
-      await nextTick();
+      stageEmitterInstance.emit('frameStart');
       expect(fakeComponent._updateThemeComponent).toHaveBeenCalledTimes(1);
-      await nextTick();
-      await nextTick();
+      stageEmitterInstance.emit('frameStart');
+      stageEmitterInstance.emit('frameStart');
       expect(fakeComponent._updateThemeComponent).toHaveBeenCalledTimes(1);
     });
 
@@ -44,9 +47,10 @@ describe('GlobalUpdateManager', () => {
       updateManager.addUpdateTheme(fakeComponent);
       updateManager.addUpdateTheme(fakeComponent);
       updateManager.addUpdateTheme(fakeComponent);
-      await nextTick();
-      await nextTick();
-      await nextTick();
+      stageEmitterInstance.emit('frameStart');
+      stageEmitterInstance.emit('frameStart');
+      stageEmitterInstance.emit('frameStart');
+      stageEmitterInstance.emit('frameStart');
       expect(fakeComponent._updateThemeComponent).toHaveBeenCalledTimes(1);
     });
   });
@@ -61,10 +65,10 @@ describe('GlobalUpdateManager', () => {
       updateManager.addUpdateTheme(fakeComponent);
       updateManager.deleteUpdateTheme(fakeComponent);
       expect(fakeComponent._updateThemeComponent).not.toHaveBeenCalled();
-      await nextTick();
+      stageEmitterInstance.emit('frameStart');
       expect(fakeComponent._updateThemeComponent).not.toHaveBeenCalled();
-      await nextTick();
-      await nextTick();
+      stageEmitterInstance.emit('frameStart');
+      stageEmitterInstance.emit('frameStart');
       expect(fakeComponent._updateThemeComponent).not.toHaveBeenCalled();
     });
 
@@ -83,9 +87,9 @@ describe('GlobalUpdateManager', () => {
         requestUpdate: jest.fn()
       };
       updateManager.addRequestUpdate(fakeComponent);
-      await nextTick();
-      await nextTick();
-      await nextTick();
+      stageEmitterInstance.emit('frameStart');
+      stageEmitterInstance.emit('frameStart');
+      stageEmitterInstance.emit('frameStart');
       expect(fakeComponent.requestUpdate).toHaveBeenCalledTimes(1);
     });
 
@@ -98,10 +102,11 @@ describe('GlobalUpdateManager', () => {
       updateManager.addRequestUpdate(fakeComponent);
       updateManager.addRequestUpdate(fakeComponent);
       expect(fakeComponent.requestUpdate).not.toHaveBeenCalled();
-      await nextTick();
+
+      stageEmitterInstance.emit('frameStart');
       expect(fakeComponent.requestUpdate).toHaveBeenCalledTimes(1);
-      await nextTick();
-      await nextTick();
+      stageEmitterInstance.emit('frameStart');
+      stageEmitterInstance.emit('frameStart');
       expect(fakeComponent.requestUpdate).toHaveBeenCalledTimes(1);
     });
   });
@@ -116,10 +121,10 @@ describe('GlobalUpdateManager', () => {
       updateManager.addRequestUpdate(fakeComponent);
       updateManager.deleteRequestUpdate(fakeComponent);
       expect(fakeComponent.requestUpdate).not.toHaveBeenCalled();
-      await nextTick();
+      stageEmitterInstance.emit('frameStart');
       expect(fakeComponent.requestUpdate).not.toHaveBeenCalled();
-      await nextTick();
-      await nextTick();
+      stageEmitterInstance.emit('frameStart');
+      stageEmitterInstance.emit('frameStart');
       expect(fakeComponent.requestUpdate).not.toHaveBeenCalled();
     });
 
@@ -177,7 +182,7 @@ describe('GlobalUpdateManager', () => {
     updateManager.addUpdateTheme(fakeComponent);
     updateManager.addUpdateTheme(fakeComponent2);
     expect(callLog).toEqual([]);
-    await nextTick();
+    stageEmitterInstance.emit('frameStart');
     expect(callLog).toEqual([
       '_updateThemeComponent',
       '_updateThemeComponent',
@@ -197,7 +202,7 @@ describe('GlobalUpdateManager', () => {
     };
     updateManager.addRequestUpdate(fakeComponent);
     updateManager.addUpdateTheme(fakeComponent);
-    await nextTick();
+    stageEmitterInstance.emit('frameStart');
     expect(context.error).toHaveBeenNthCalledWith(
       1,
       'Error updating component themes',

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
@@ -415,5 +415,11 @@ export default function withThemeStyles(Base, mixinStyle = {}) {
       this._hSetByUser = true;
       this._updateThemeComponent();
     }
+
+    set hNoUser(v) {
+      if (this._h === v) return;
+      super.h = v;
+      this._updateThemeComponent();
+    }
   };
 }

--- a/packages/@lightningjs/ui-components/src/mixins/withUpdates/index.d.ts
+++ b/packages/@lightningjs/ui-components/src/mixins/withUpdates/index.d.ts
@@ -20,6 +20,7 @@ import lng from '@lightningjs/core';
 
 export interface WithUpdates {
   queueRequestUpdate();
+  requestEarlyUpdate();
   requestUpdate(force: boolean);
   logPropTable();
 }

--- a/packages/@lightningjs/ui-components/src/mixins/withUpdates/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withUpdates/index.js
@@ -101,6 +101,9 @@ export default function withUpdates(Base) {
     _construct() {
       const prototype = Object.getPrototypeOf(this);
       if (!prototype._withUpdatesInitialized) {
+        if (!updateManager.isInitialized) {
+          updateManager.init(this.stage);
+        }
         // create custom accessors and mutators for the props in the properties array
         const props = this.constructor.properties || [];
         props.forEach(name => {

--- a/packages/@lightningjs/ui-components/src/mixins/withUpdates/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withUpdates/index.js
@@ -156,6 +156,16 @@ export default function withUpdates(Base) {
       super._firstEnable && super._firstEnable();
     }
 
+    requestEarlyUpdate() {
+      this._readyForUpdates = true;
+      if (updateManager.hasQueuedRequestFor(this)) {
+        updateManager.deleteRequestUpdate(this);
+        // run this update no matter what
+        this._readyForUpdates = true;
+        this.requestUpdate();
+      }
+    }
+
     _detach() {
       super._detach();
       updateManager.deleteRequestUpdate(this);

--- a/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
+++ b/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
@@ -130,6 +130,24 @@ export const withLightning = (
             this._refocus(); // Force Lightning to reset focus
           }
           _setup() {
+            // This ensures the component has its args before the first update cycle.
+            if (Object.keys(args).length) {
+              const argsToPatch = {};
+              for (const prop in args) {
+                // Apply arguments from controls
+                const propValue =
+                  'undefined' !== typeof args[prop]
+                    ? args[prop]
+                    : parameters.argTypes[prop].defaultValue;
+                if (!parameters.argActions || !parameters.argActions[prop]) {
+                  argsToPatch[prop] = propValue;
+                }
+              }
+              this.componentTarget.patch({
+                ...argsToPatch
+              });
+            }
+
             setTimeout(() => {
               this.fireAncestors('$storyChanged');
             });

--- a/packages/apps/lightning-ui-docs/.storybook/preview.js
+++ b/packages/apps/lightning-ui-docs/.storybook/preview.js
@@ -19,7 +19,7 @@
 // these two lines need to be in this order
 // to wait until the inspector is enabled before attaching it
 import { withLightning } from './addons/decorators/withLightning';
-import { registerEventListeners } from './utils/registerEvents';
+import { registerEventListeners, themeSelect } from './utils/registerEvents';
 import { themes } from '@storybook/theming';
 
 // loads window event listeners
@@ -121,6 +121,12 @@ const preview = {
       defaultValue: false
     }
   },
-  decorators: [withLightning]
+  decorators: [withLightning],
+  loaders: [
+    async ({ globals }) => {
+      await themeSelect(globals.LUITheme);
+      return;
+    }
+  ]
 };
 export default preview;

--- a/packages/apps/lightning-ui-docs/.storybook/utils/registerEvents.js
+++ b/packages/apps/lightning-ui-docs/.storybook/utils/registerEvents.js
@@ -36,7 +36,10 @@ export const themeSelect = theme => {
       targetTheme = {};
       break;
   }
-  return context.setTheme(targetTheme);
+
+  return targetTheme.name && context.theme.name !== targetTheme.name
+    ? context.setTheme(targetTheme)
+    : Promise.resolve();
 };
 
 // registers all window events needed on load

--- a/packages/apps/lightning-ui-docs/index.js
+++ b/packages/apps/lightning-ui-docs/index.js
@@ -24,10 +24,7 @@ import {
   pool,
   context
 } from '@lightningjs/ui-components/src';
-import {
-  themeSelect,
-  themeSelectFromMessageEvent
-} from './.storybook/utils/registerEvents';
+import { themeSelectFromMessageEvent } from './.storybook/utils/registerEvents';
 
 /**
  * creates the Lightning App and attaches it to the DOM for use in Storybook
@@ -75,23 +72,7 @@ export const createApp = parameters => {
     }
 
     _attach() {
-      setTimeout(() => {
-        if (parameters.theme) {
-          themeSelect(parameters.theme).then(() => {
-            window.addEventListener(
-              'message',
-              themeSelectFromMessageEvent,
-              false
-            );
-          });
-        } else {
-          window.addEventListener(
-            'message',
-            themeSelectFromMessageEvent,
-            false
-          );
-        }
-      });
+      window.addEventListener('message', themeSelectFromMessageEvent, false);
     }
 
     $storyChanged() {


### PR DESCRIPTION
## Description

An alternative solution to the column stacking issue. This syncs the GlobalUpdateManager update to stage.frameStart rather than setTimeout 0. This seems to be a good general fix because components could render before their update cycle actually runs, causing stacked layouts/other issues. 

## Todo's/Questions: 

- [ ] Since update manager needs a reference to the stage, where does it make sense to initialize with the stage reference?
- [ ] Probably need to teardown/cleanup something to actually handle a user that destroys the app/stage. 

## References

Related to: [LUI-1328](https://ccp.sys.comcast.net/browse/LUI-1328)

## Testing

This is a global change, so we should do some thorough testing.

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
