### PR TITLE
fix(Storybook): set theme and props before render

### DIFF
--- a/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
+++ b/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
@@ -130,11 +130,24 @@ export const withLightning = (
             this._refocus(); // Force Lightning to reset focus
           }
           _setup() {
-            // This ensures the component as it's args before the first update cycle. Fixes some flashing in storybook.
-            // TODO: confirm if this can be the whole args object or if we have to process it somehow
-            this.componentTarget.patch({
-              ...args
-            });
+            // This ensures the component has its args before the first update cycle.
+            if (Object.keys(args).length) {
+              const argsToPatch = {};
+              for (const prop in args) {
+                // Apply arguments from controls
+                const propValue =
+                  'undefined' !== typeof args[prop]
+                    ? args[prop]
+                    : parameters.argTypes[prop].defaultValue;
+                if (!parameters.argActions || !parameters.argActions[prop]) {
+                  argsToPatch[prop] = propValue;
+                }
+              }
+              this.componentTarget.patch({
+                ...argsToPatch
+              });
+            }
+
             setTimeout(() => {
               this.fireAncestors('$storyChanged');
             });

--- a/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
+++ b/packages/apps/lightning-ui-docs/.storybook/addons/decorators/withLightning.js
@@ -130,6 +130,11 @@ export const withLightning = (
             this._refocus(); // Force Lightning to reset focus
           }
           _setup() {
+            // This ensures the component as it's args before the first update cycle. Fixes some flashing in storybook.
+            // TODO: confirm if this can be the whole args object or if we have to process it somehow
+            this.componentTarget.patch({
+              ...args
+            });
             setTimeout(() => {
               this.fireAncestors('$storyChanged');
             });

--- a/packages/apps/lightning-ui-docs/.storybook/preview.js
+++ b/packages/apps/lightning-ui-docs/.storybook/preview.js
@@ -19,7 +19,7 @@
 // these two lines need to be in this order
 // to wait until the inspector is enabled before attaching it
 import { withLightning } from './addons/decorators/withLightning';
-import { registerEventListeners } from './utils/registerEvents';
+import { registerEventListeners, themeSelect } from './utils/registerEvents';
 import { themes } from '@storybook/theming';
 
 // loads window event listeners
@@ -121,6 +121,12 @@ const preview = {
       defaultValue: false
     }
   },
-  decorators: [withLightning]
+  decorators: [withLightning],
+  loaders: [
+    async ({ globals }) => {
+      await themeSelect(globals.LUITheme);
+      return;
+    }
+  ]
 };
 export default preview;

--- a/packages/apps/lightning-ui-docs/.storybook/utils/registerEvents.js
+++ b/packages/apps/lightning-ui-docs/.storybook/utils/registerEvents.js
@@ -36,7 +36,9 @@ export const themeSelect = theme => {
       targetTheme = {};
       break;
   }
-  return context.setTheme(targetTheme);
+  return targetTheme.name && context.theme.name !== targetTheme.name
+    ? context.setTheme(targetTheme)
+    : Promise.resolve();
 };
 
 // registers all window events needed on load

--- a/packages/apps/lightning-ui-docs/index.js
+++ b/packages/apps/lightning-ui-docs/index.js
@@ -24,10 +24,7 @@ import {
   pool,
   context
 } from '@lightningjs/ui-components/src';
-import {
-  themeSelect,
-  themeSelectFromMessageEvent
-} from './.storybook/utils/registerEvents';
+import { themeSelectFromMessageEvent } from './.storybook/utils/registerEvents';
 
 /**
  * creates the Lightning App and attaches it to the DOM for use in Storybook
@@ -75,23 +72,7 @@ export const createApp = parameters => {
     }
 
     _attach() {
-      setTimeout(() => {
-        if (parameters.theme) {
-          themeSelect(parameters.theme).then(() => {
-            window.addEventListener(
-              'message',
-              themeSelectFromMessageEvent,
-              false
-            );
-          });
-        } else {
-          window.addEventListener(
-            'message',
-            themeSelectFromMessageEvent,
-            false
-          );
-        }
-      });
+      window.addEventListener('message', themeSelectFromMessageEvent, false);
     }
 
     $storyChanged() {


### PR DESCRIPTION
## Description

During some keyboard layout debugging, I encountered a couple glitches that could be attributed to storybook rather than the component.

**With the following logs set in Keyboard**: 

![storybook-log](https://github.com/rdkcentral/Lightning-UI-Components/assets/841975/7936bc86-af5e-4bb8-918a-8cc12a109d00)

**It was observed that:**

1. An initial render was happening without the desired props
2. a setTheme event was triggering after the component's first update. 



![storybook-before](https://github.com/rdkcentral/Lightning-UI-Components/assets/841975/f67d0d60-42e4-4ddc-851d-7dc7d8b0469b)

After these changes, no setTheme event fires after the component mounts, and the props are set as expected on initial render. 


![storybook-after](https://github.com/rdkcentral/Lightning-UI-Components/assets/841975/b3b660a8-3eaf-42fc-b6f9-940683f11168)


## Testing

This is not a Component change, should just confirm storybook is working as expected. 


## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
