### PR TITLE
fix(Keyboard): centerKeys prop used properly on createKeyboard

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.js
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.js
@@ -123,7 +123,7 @@ export default class Keyboard extends Base {
         type: Row,
         autoResizeHeight: true,
         autoResizeWidth: true,
-        centerInParent: this.centerKeyboard,
+        centerInParent: this.centerKeys,
         neverScroll: true,
         wrapSelected: this.rowWrap !== undefined ? this.rowWrap : true,
         style: {


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

In createRows, the centering of rows was looking at the `centerKeyboard` property instead of `centerKeys`, causing an initially left-aligned render then shifting to the correct position. 

I believe this fix is not visually apparent until the storybook changes are merged, since it is rendering as undefined first anyway. 

`_formatKeys` was using the correct property, but can happen after createKeyboard. 


## Testing

<!-- step by step instructions to review this PR's changes -->

- Keyboard should function properly

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
