### PR TITLE
fix: Add marquee property to CardContentVerticalSmall

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVerticalSmall.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVerticalSmall.js
@@ -31,6 +31,7 @@ export default class CardContentVerticalSmall extends CardContentVertical {
   _setMetadata(metadata) {
     return {
       ...metadata,
+      marquee: this._isFocusedMode,
       details: undefined,
       provider: undefined
     };


### PR DESCRIPTION
## Description

[OTTX-30843 ](https://ccp.sys.comcast.net/browse/OTTX-30843)

This change is necessary for the flex cards, particularly in the context of CardContentVerticalSmall. To address this requirement, I have specifically added the marquee property to CardContentVerticalSmall instead of MetadataCardContent.
I have tried overriding in flex directly as well it didn't work for me