### PR TITLE
fix(MetadataBase): fix layout order

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.js
@@ -133,13 +133,13 @@ class MetadataBase extends Base {
   }
 
   _updateLayout() {
-    this._updatePositions();
+    this._Text.h = this._textH();
     this._updateMetadataHeight();
+    this._updatePositions();
     this._updateLogo();
   }
 
   _updatePositions() {
-    this._Text.h = this._textH();
     this._Text.x =
       this.logo && this.logoPosition === 'left'
         ? this.logoWidth + this.style.logoPadding


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

Slight adjustment to the Metadata layout update order to allow metadata to be properly positioned in a Tile on the first render. 

**Before (Note vertical shift downward of metadata):** 

https://github.com/rdkcentral/Lightning-UI-Components/assets/841975/f91b497b-5715-4950-b339-e92aa5982e7f


**After:** 

https://github.com/rdkcentral/Lightning-UI-Components/assets/841975/6b3d5550-6a83-476a-adeb-fc06ec9059df


## Testing

<!-- step by step instructions to review this PR's changes -->

- Tile should render metadata properly on the first frame
- Ensure Metadata layout is unaffected. 

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
