### PR TITLE
fix(Keyboard): currentKeyboard not undefined check before calling functions on it

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.js
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.js
@@ -276,7 +276,9 @@ export default class Keyboard extends Base {
   }
 
   get _currentKeyboard() {
-    return this.tag(capitalize(this._currentFormat));
+    return this._currentFormat
+      ? this.tag(capitalize(this._currentFormat))
+      : null;
   }
 
   set columnCount(columnCount) {


### PR DESCRIPTION
## Description

The getFocused method called a capitalization function on the currentKeyboard which in some cases hadn't been set yet. This fix checks to see if there is a currentKeyboard before calling the capitalize function.

## References

LUI-1340

## Testing
Have been unable to reproduce in storybook or playground.
I tested this by...
- copying the Keyboard file over to the flex-app
- made the necessary import changes to import component types from '@lightning/ui'
- changed HoriziontalKeyboard in the flex-app to use this keyboard file rather than the one from '@lightning/ui'
- run the flex-app with yarn start (you might need a new .env file so let me know if you need this)
- on the top of the browser when running you will see a search icon. Click this
- you will see nothing loads and the console shows a charAt error the line change in this pr in the Keyboard (the get _currentKeyboard method) is changed to this new line

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
