### PR TITLE
fix(NavigationManager): if an itemPosX or itemPosY are set, apply offset to scrolling

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Column/Column.js
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.js
@@ -82,20 +82,14 @@ export default class Column extends NavigationManager {
         .y;
       const smoothObj = [
         -(scrollItem || this.Items.childList.first).transition('y')
-          .targetValue + (scrollItem === this.selected ? scrollOffset : 0),
+          .targetValue +
+          (scrollItem === this.selected ? scrollOffset : 0) +
+          this.itemPosY,
         this.style.itemTransition
       ];
       const scrollTarget =
         -scrollItem.y + (scrollItem === this.selected ? scrollOffset : 0);
-      this.applySmooth(
-        this.Items,
-        {
-          y: scrollTarget
-        },
-        {
-          y: smoothObj
-        }
-      );
+      this.applySmooth(this.Items, { y: scrollTarget }, { y: smoothObj });
       if (!this.shouldSmooth) {
         this._updateTransitionTarget(this.Items, 'y', scrollTarget);
       }

--- a/packages/@lightningjs/ui-components/src/components/Column/Column.js
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.js
@@ -58,8 +58,11 @@ export default class Column extends NavigationManager {
   }
 
   _shouldScroll() {
-    let shouldScroll = this.alwaysScroll;
-    if (!shouldScroll && !this.neverScroll) {
+    if (this.alwaysScroll) {
+      return true;
+    }
+    let shouldScroll = false;
+    if (!this.neverScroll) {
       const isCompletelyOnScreen = this._isOnScreenForScrolling(this.selected);
       const lastChild = this.Items.childList.last;
       shouldScroll =

--- a/packages/@lightningjs/ui-components/src/components/Column/Column.js
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.js
@@ -78,17 +78,16 @@ export default class Column extends NavigationManager {
       if (this.Items.children[this._firstFocusableIndex()] === scrollItem) {
         scrollItem = this.Items.children[0];
       }
-      const scrollOffset = (this.Items.children[this.scrollIndex] || { y: 0 })
-        .y;
-      const smoothObj = [
+      const scrollOffset =
+        (this.Items.children[this.scrollIndex] || { y: 0 }).y + this.itemPosY;
+
+      const newY =
         -(scrollItem || this.Items.childList.first).transition('y')
-          .targetValue +
-          (scrollItem === this.selected ? scrollOffset : 0) +
-          this.itemPosY,
-        this.style.itemTransition
-      ];
-      const scrollTarget =
-        -scrollItem.y + (scrollItem === this.selected ? scrollOffset : 0);
+          .targetValue + (scrollItem === this.selected ? scrollOffset : 0);
+      const smoothObj = [newY, this.style.itemTransition];
+      const scrollTarget = newY;
+      // -scrollItem.y + (scrollItem === this.selected ? scrollOffset : 0);
+
       this.applySmooth(this.Items, { y: scrollTarget }, { y: smoothObj });
       if (!this.shouldSmooth) {
         this._updateTransitionTarget(this.Items, 'y', scrollTarget);

--- a/packages/@lightningjs/ui-components/src/components/Column/Column.js
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.js
@@ -86,7 +86,6 @@ export default class Column extends NavigationManager {
           .targetValue + (scrollItem === this.selected ? scrollOffset : 0);
       const smoothObj = [newY, this.style.itemTransition];
       const scrollTarget = newY;
-      // -scrollItem.y + (scrollItem === this.selected ? scrollOffset : 0);
 
       this.applySmooth(this.Items, { y: scrollTarget }, { y: smoothObj });
       if (!this.shouldSmooth) {

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -239,8 +239,10 @@ export default class NavigationManager extends FocusManager {
       let lastScrollIndex;
       for (let i = this.Items.children.length - 1; i >= 0; i--) {
         const childPosition = this._calcAxisPosition(this.Items.children[i]);
+        const itemPos = this._isRow ? this.itemPosX : this.itemPosY;
         const canScrollToChild =
-          childPosition + this[lengthDimension] - scrollOffset > endOfLastChild;
+          childPosition + this[lengthDimension] - scrollOffset - itemPos >
+          endOfLastChild;
         if (canScrollToChild) {
           lastScrollIndex = i;
         } else {

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -228,21 +228,21 @@ export default class NavigationManager extends FocusManager {
       return;
     }
 
-    const scrollOffset = (this.Items.children[this.scrollIndex] || {
-      [axis]: 0
-    })[axis];
+    const itemPos = this._isRow ? this.itemPosX : this.itemPosY;
+    const scrollOffset =
+      (this.Items.children[this.scrollIndex] || {
+        [axis]: 0
+      })[axis] + itemPos;
     const lastChild = this.Items.childList.last;
     const endOfLastChild = lastChild
-      ? this._calcAxisPosition(lastChild) + lastChild[lengthDimension]
+      ? this._calcAxisPosition(lastChild) + lastChild[lengthDimension] + itemPos
       : 0;
     if (endOfLastChild > this[lengthDimension]) {
       let lastScrollIndex;
       for (let i = this.Items.children.length - 1; i >= 0; i--) {
         const childPosition = this._calcAxisPosition(this.Items.children[i]);
-        const itemPos = this._isRow ? this.itemPosX : this.itemPosY;
         const canScrollToChild =
-          childPosition + this[lengthDimension] - scrollOffset - itemPos >
-          endOfLastChild;
+          childPosition + this[lengthDimension] - scrollOffset > endOfLastChild;
         if (canScrollToChild) {
           lastScrollIndex = i;
         } else {

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -235,7 +235,7 @@ export default class NavigationManager extends FocusManager {
       })[axis] + itemPos;
     const lastChild = this.Items.childList.last;
     const endOfLastChild = lastChild
-      ? this._calcAxisPosition(lastChild) + lastChild[lengthDimension] + itemPos
+      ? this._calcAxisPosition(lastChild) + lastChild[lengthDimension] - itemPos
       : 0;
     if (endOfLastChild > this[lengthDimension]) {
       let lastScrollIndex;
@@ -472,7 +472,7 @@ export default class NavigationManager extends FocusManager {
       endOfItemsPosition = Math.abs(this._itemsX - this.w);
     }
     if (this._isColumn) {
-      endOfItemsPosition = Math.abs(this.itemPosY - this.h);
+      endOfItemsPosition = Math.abs(this._itemsY - this.h);
     }
 
     return (
@@ -492,6 +492,10 @@ export default class NavigationManager extends FocusManager {
 
   get _itemsX() {
     return getX(this.Items);
+  }
+
+  get _itemsY() {
+    return getY(this.Items);
   }
 
   _getAlwaysScroll() {

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -235,7 +235,7 @@ export default class NavigationManager extends FocusManager {
       })[axis] + itemPos;
     const lastChild = this.Items.childList.last;
     const endOfLastChild = lastChild
-      ? this._calcAxisPosition(lastChild) + lastChild[lengthDimension] - itemPos
+      ? this._calcAxisPosition(lastChild) + lastChild[lengthDimension]
       : 0;
     if (endOfLastChild > this[lengthDimension]) {
       let lastScrollIndex;

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -455,7 +455,10 @@ export default class NavigationManager extends FocusManager {
     }
 
     const itemsStartCoord = this._isRow ? this._itemsX : this._itemsY;
-    return itemsStartCoord < 0 && shouldScroll;
+    return (
+      itemsStartCoord < (this._isRow ? this.itemPosX : this.itemPosY) &&
+      shouldScroll
+    );
   }
 
   get _canScrollNext() {

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.js
@@ -139,7 +139,8 @@ export default class Row extends NavigationManager {
         -prevX +
         this.prevSelected.w +
         this.style.itemSpacing +
-        (this.selected.extraItemSpacing || 0)
+        (this.selected.extraItemSpacing || 0) +
+        this.itemPosX
       );
     } else if (prev) {
       // otherwise, no start/stop indexes, perform normal lazy scroll
@@ -153,7 +154,7 @@ export default class Row extends NavigationManager {
         return;
       }
       if (prevIndex > this.selectedIndex) {
-        itemsContainerX = -selectedX;
+        itemsContainerX = -selectedX + this.itemPosX;
       } else if (prevIndex < this.selectedIndex) {
         itemsContainerX = this.w - selectedX - this.selected.w;
       }
@@ -177,8 +178,9 @@ export default class Row extends NavigationManager {
 
     if (this.Items.children[itemIndex]) {
       itemsContainerX = this.Items.children[itemIndex].transition('x')
-        ? -this.Items.children[itemIndex].transition('x').targetValue
-        : -this.Items.children[itemIndex].x;
+        ? -this.Items.children[itemIndex].transition('x').targetValue +
+          this.itemPosX
+        : -this.Items.children[itemIndex].x + this.itemPosX;
     }
 
     return itemsContainerX;

--- a/packages/@lightningjs/ui-components/src/components/Row/Row.js
+++ b/packages/@lightningjs/ui-components/src/components/Row/Row.js
@@ -75,18 +75,19 @@ export default class Row extends NavigationManager {
   _shouldScroll() {
     const prevIndex = this.Items.childList.getIndex(this.prevSelected);
     if (
-      this.lazyScroll &&
-      (this.selectedIndex < this.startLazyScrollIndex ||
-        this.selectedIndex > this.stopLazyScrollIndex ||
-        (prevIndex < this.startLazyScrollIndex &&
-          this.selectedIndex === this.startLazyScrollIndex) ||
-        (prevIndex > this.stopLazyScrollIndex &&
-          this.selectedIndex === this.stopLazyScrollIndex))
+      this.alwaysScroll ||
+      (this.lazyScroll &&
+        (this.selectedIndex < this.startLazyScrollIndex ||
+          this.selectedIndex > this.stopLazyScrollIndex ||
+          (prevIndex < this.startLazyScrollIndex &&
+            this.selectedIndex === this.startLazyScrollIndex) ||
+          (prevIndex > this.stopLazyScrollIndex &&
+            this.selectedIndex === this.stopLazyScrollIndex)))
     ) {
       return true;
     }
 
-    let shouldScroll = this.alwaysScroll || this._selectedPastAdded;
+    let shouldScroll = this._selectedPastAdded;
     if (!shouldScroll && !this.neverScroll) {
       const isCompletelyOnScreen = this._isOnScreenForScrolling(this.selected);
 


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
The `itemPosX` and `itemPosY` properties allow the user to offset the `Items` container inside of NavigationManagers. However, these values were never applied to the scrolling logic, so even if the container had been offset, once the user started scrolling, this information would be wiped out entirely.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->

Columns:
- Add `itemPosY: 300` (or any value) to the Column stories
- Observe that the Column has shifted down as expected, and when scrolling, the shift is still in effect
- Confirm the above with
  - regular scrolling (no flags set)
  - alwaysScroll set to true

Rows:
- Add `itemPosX: 300` (or any value) to the Row stories
- Observe that the Row has shifted right as expected, and when scrolling, the shift is still in effect
- Confirm the above with
  - regular scrolling (no flags set)
  - alwaysScroll set to true
  - lazyScroll set to true

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
