### PR TITLE
fix(TitleRow): move title props to separate getter for easier extension

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.js
+++ b/packages/@lightningjs/ui-components/src/components/TitleRow/TitleRow.js
@@ -77,14 +77,20 @@ export default class TitleRow extends Row {
     };
     if (!this._Title) {
       titlePatch = {
-        type: TextBox,
-        signals: {
-          textBoxChanged: '_titleLoaded'
-        },
+        ...this._titleFirstLoadProps,
         ...titlePatch
       };
     }
     this.patch({ Title: titlePatch });
+  }
+
+  get _titleFirstLoadProps() {
+    return {
+      type: TextBox,
+      signals: {
+        textBoxChanged: '_titleLoaded'
+      }
+    };
   }
 
   _updateRow() {


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Moving the properties first used by the TitleRow's title element into a separate getter so that it is easier for components that extend TitleRow to make updates now that the title isn't part of the static template. This is important for rows where the title is not supposed to be fully alpha-ed in on first load.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
Confirm that the TitleRow is working the same as on develop, there should not be any visual impacts here.

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
