### PR TITLE
fix(NavigationManager): check an items render size before its set w or h

### DIFF
--- a/packages/@lightningjs/ui-components/src/utils/index.js
+++ b/packages/@lightningjs/ui-components/src/utils/index.js
@@ -609,17 +609,23 @@ export function getFirstNumber(...numbers) {
  */
 export function getDimension(prop, component) {
   if (!component) return 0;
+
   const transition = component.transition(prop);
   if (transition.isRunning()) return transition.targetValue;
-  return component[prop];
+
+  let renderProp = prop;
+  if (prop === 'w') {
+    renderProp = 'renderWidth';
+  } else if (prop === 'h') {
+    renderProp = 'renderHeight';
+  }
+  return component[renderProp] || component[prop];
 }
 
-export const getX = getDimension.bind(null, 'x');
-export const getY = getDimension.bind(null, 'y');
-export const getW = component =>
-  getDimension('w', component) || component.renderWidth;
-export const getH = component =>
-  getDimension('h', component) || component.renderHeight;
+export const getX = component => getDimension('x', component);
+export const getY = component => getDimension('y', component);
+export const getW = component => getDimension('w', component);
+export const getH = component => getDimension('h', component);
 
 /**
  * Array.prototype.flat() is not supported in WPE Browser


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
Some components set width or height might be a little different than their actual computed size. A good example of this is a Tile component with metadata underneath it. The Tile's set dimensions reflect the size of the artwork, not the padding and height of the metadata underneath. The Tile's `renderHeight` has the correct _total_ size. So, in the NavigationManager, when laying out the items, the rendered size of the item should be used if it is available before defaulting to the set w or h props.

LUI-1376

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
Confirm that all Row and Column stories work as expected, and observe there is no longer any overlapping of metadata in the Column's Skip Plinko story.

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
