### PR TITLE
fix(ControlRow): fix right controls to use lazyScrolling too

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.js
+++ b/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.js
@@ -71,8 +71,7 @@ export default class ControlRow extends TitleRow {
         items: itemsToAppend,
         selectedIndex: this.leftControls.length,
         startLazyScrollIndex: this.leftControls.length,
-        stopLazyScrollIndex:
-          this.leftControls.length + this.contentItems.length - 1
+        stopLazyScrollIndex: this.leftControls.length + this.items.length - 1
       });
     }
   }
@@ -144,8 +143,7 @@ export default class ControlRow extends TitleRow {
     }
 
     this.patch({
-      stopLazyScrollIndex:
-        this.leftControls.length + this.contentItems.length - 1
+      stopLazyScrollIndex: this.leftControls.length + this.items.length - 1
     });
   }
 
@@ -163,8 +161,7 @@ export default class ControlRow extends TitleRow {
       }
 
       this.patch({
-        stopLazyScrollIndex:
-          this.leftControls.length + this.contentItems.length - 1
+        stopLazyScrollIndex: this.leftControls.length + this.items.length - 1
       });
     }
   }
@@ -180,8 +177,7 @@ export default class ControlRow extends TitleRow {
 
     this.patch({
       startLazyScrollIndex: this.leftControls.length,
-      stopLazyScrollIndex:
-        this.leftControls.length + this.contentItems.length - 1
+      stopLazyScrollIndex: this.leftControls.length + this.items.length - 1
     });
   }
 
@@ -198,8 +194,7 @@ export default class ControlRow extends TitleRow {
 
     this.patch({
       startLazyScrollIndex: this.leftControls.length,
-      stopLazyScrollIndex:
-        this.leftControls.length + this.contentItems.length - 1
+      stopLazyScrollIndex: this.leftControls.length + this.items.length - 1
     });
   }
 
@@ -217,8 +212,7 @@ export default class ControlRow extends TitleRow {
 
       this.patch({
         startLazyScrollIndex: this.leftControls.length,
-        stopLazyScrollIndex:
-          this.leftControls.length + this.contentItems.length - 1
+        stopLazyScrollIndex: this.leftControls.length + this.items.length - 1
       });
     }
   }
@@ -234,8 +228,7 @@ export default class ControlRow extends TitleRow {
 
     this.patch({
       startLazyScrollIndex: this.leftControls.length,
-      stopLazyScrollIndex:
-        this.leftControls.length + this.contentItems.length - 1
+      stopLazyScrollIndex: this.leftControls.length + this.items.length - 1
     });
   }
 


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
The ControlRow currently has some odd scrolling behavior where we attempt to "alwaysScroll" on the right controls (like the left), but this creates some odd behaviors. It makes more sense to always lazyScroll on those pieces as well and only do the alwaysScroll for the leftmost controls. We can always tweak this further in the future (like if we want to "alwaysScroll" _back_ from the right controls to the main content), but this makes it look less broken for the moment.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
Confirm scrolling in the ControlRow stories look more intentional.

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
