### PR TITLE
fix: small optimization to add extra gaurd to updatePropDefaults

### DIFF
--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
@@ -134,12 +134,15 @@ export default function withThemeStyles(Base, mixinStyle = {}) {
      */
     _updatePropDefaults() {
       // If the current properties are the same as the previous configuration, no update is needed
+      
       if (
+        !Object.keys(this._styleManager.props).length ||
         JSON.stringify(this._styleManager.props) ===
         JSON.stringify(this._prevComponentConfigProps)
       ) {
         return;
       }
+     
       // Compare current properties with previous configuration and get the payload
       const payload = this._prevComponentConfigProps
         ? mergeObjectsWithSecondDominant(

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/index.js
@@ -134,15 +134,15 @@ export default function withThemeStyles(Base, mixinStyle = {}) {
      */
     _updatePropDefaults() {
       // If the current properties are the same as the previous configuration, no update is needed
-      
+
       if (
         !Object.keys(this._styleManager.props).length ||
         JSON.stringify(this._styleManager.props) ===
-        JSON.stringify(this._prevComponentConfigProps)
+          JSON.stringify(this._prevComponentConfigProps)
       ) {
         return;
       }
-     
+
       // Compare current properties with previous configuration and get the payload
       const payload = this._prevComponentConfigProps
         ? mergeObjectsWithSecondDominant(


### PR DESCRIPTION
## Description

Small optimization to withThemeStyles to make sure updatePropDefaults does not run if the styleManager does not have any props

## Testing

Everything should work ask previously expected. The entire _updatePropDefaults method in withThemeStyles should not run each time a component is created unless props are defined in the theme.

## Automation

NA

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
