### PR TITLE
fix: allow CardContentVerticalSmall to control marquee onFocus

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.js
@@ -107,6 +107,11 @@ export default class CardContent extends Card {
       alpha: this._shouldShowMetadata ? 1 : 0,
       style: this.style.metadata
     };
+
+    if (this.style.marqueeOnFocus) {
+      metadataPatch.marquee = this._isFocusedMode;
+    }
+    
     if (!this._Metadata) {
       metadataPatch.type = MetadataCardContent;
     }

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.js
@@ -111,7 +111,7 @@ export default class CardContent extends Card {
     if (this.style.marqueeOnFocus) {
       metadataPatch.marquee = this._isFocusedMode;
     }
-    
+
     if (!this._Metadata) {
       metadataPatch.type = MetadataCardContent;
     }

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVertical.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVertical.styles.js
@@ -25,5 +25,6 @@ export const base = theme => ({
     theme.spacer.xxxl * 7 +
     theme.spacer.lg +
     theme.spacer.xxs,
-  metadata: { descriptionTextStyle: { maxLines: 3 } }
+  metadata: { descriptionTextStyle: { maxLines: 3 } },
+  marqueeOnFocus: true
 });

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVerticalSmall.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContentVerticalSmall.js
@@ -31,7 +31,6 @@ export default class CardContentVerticalSmall extends CardContentVertical {
   _setMetadata(metadata) {
     return {
       ...metadata,
-      marquee: this._isFocusedMode,
       details: undefined,
       provider: undefined
     };


### PR DESCRIPTION
## Description

Allow Marquee scroll behavior to be controlled with the theme

## References

[Ticket](https://ccp.sys.comcast.net/browse/LUI-1405)

## Testing

- CardContentVerticalSmall  should marquee the title on focus.
- You should be able to update the theme for CardContentVerticalSmall with componentConfig. Setting the marqueeOnFocus to false should disable marquee for the title on scroll

## Automation

Title should marquee title on focus

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
