### PR TITLE
fix: allow CardContent to pass through style to Tile component

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.js
@@ -64,7 +64,6 @@ export default class CardContent extends Card {
   _update() {
     this._updateSize();
     this._updateTile();
-    this._updateRadius();
     this._updateMetadata();
     super._update();
   }
@@ -76,6 +75,20 @@ export default class CardContent extends Card {
   _updateTile() {
     let w = this.style.imageSize.w;
     let h = this.style.expandedHeight;
+    const radius =
+      Array.isArray(this.style.radius) && this.style.radius.length === 4
+        ? this.style.radius
+        : Array(4).fill(this.style.radius);
+
+    let tileRadius = radius;
+
+    if (!this._collapse) {
+      tileRadius =
+        this._orientation === 'horizontal'
+          ? [radius[0], 0, 0, radius[3]]
+          : [radius[0], radius[1], 0, 0];
+    }
+
     if (this._orientation !== 'horizontal') {
       w = this.style.expandedWidth;
       h = this.style.imageSize.h;
@@ -93,6 +106,10 @@ export default class CardContent extends Card {
       w,
       h,
       ...tile,
+      style: {
+        ...(tile.style || {}),
+        radius: tileRadius
+      },
       persistentMetadata: true,
       alpha: this._shouldShowTile ? 1 : 0
     });
@@ -131,23 +148,6 @@ export default class CardContent extends Card {
     }
     this.w = w;
     this.h = h;
-  }
-
-  _updateRadius() {
-    const radius =
-      Array.isArray(this.style.radius) && this.style.radius.length === 4
-        ? this.style.radius
-        : Array(4).fill(this.style.radius);
-    let tileRadius = radius;
-
-    if (!this._collapse) {
-      tileRadius =
-        this._orientation === 'horizontal'
-          ? [radius[0], 0, 0, radius[3]]
-          : [radius[0], radius[1], 0, 0];
-    }
-
-    this._Tile.patch({ style: { radius: tileRadius } });
   }
 
   _getSrc() {

--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.js
@@ -107,7 +107,7 @@ export default class CardContent extends Card {
       h,
       ...tile,
       style: {
-        ...(tile.style || {}),
+        ...(tile?.style || {}),
         radius: tileRadius
       },
       persistentMetadata: true,


### PR DESCRIPTION
## Description

In some instances it may be necessary to pass a style down from CardContentHorizantal through the tile prop into the Tile component. This 

## References

No Jira

## Testing

Open CardContentHorizantal story
remove all controls to ensure you can add the required props directly to the component. Then add something like the following.
```
        tile: {
            style: {
              paddingX: 40
            },
            progressBar: {
              progress: .5
            },
            metadata: {
              title: 'foo'
            }
          }
```

All tile styles should now be allowed to be modified at the instance level.

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
