### PR TITLE
feat: adding ‘retainSelection’ to TabBar

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.js
@@ -49,7 +49,14 @@ export default class TabBar extends Base {
   }
 
   static get properties() {
-    return ['alphaSelectedTab', 'collapse', 'reset', 'tabs', ...Row.properties];
+    return [
+      'alphaSelectedTab',
+      'collapse',
+      'reset',
+      'tabs',
+      'retainSelection',
+      ...Row.properties
+    ];
   }
 
   static get tags() {
@@ -101,7 +108,8 @@ export default class TabBar extends Base {
     this._Tabs.items.forEach(tab => {
       const isSelectedTab = tab === this._Tabs.selected;
       if (this._isUnfocusedMode) {
-        tab.mode = 'unfocused';
+        tab.mode =
+          isSelectedTab && this.retainSelection ? 'selected' : 'unfocused';
       } else if (this._isFocusedMode) {
         if (this._isTabsFocused) {
           tab.mode = isSelectedTab ? 'focused' : 'unfocused';

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
@@ -354,4 +354,16 @@ describe('TabBar', () => {
       expect(tabBar._Tabs.selectedIndex).toBe(1);
     });
   });
+
+  it('should optionally allow the selected tab to remain selected when tab bar loses focus', () => {
+    expect(tabBar._Tabs.items[0].mode).toBe('focused');
+    expect(tabBar._Tabs.items[1].mode).toBe('unfocused');
+
+    tabBar.retainSelection = true;
+    tabBar.mode = 'unfocused';
+    tabBar._updateTabs();
+
+    expect(tabBar._Tabs.items[0].mode).toBe('selected');
+    expect(tabBar._Tabs.items[1].mode).toBe('unfocused');
+  });
 });

--- a/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/TabBar.test.js
@@ -361,7 +361,8 @@ describe('TabBar', () => {
 
     tabBar.retainSelection = true;
     tabBar.mode = 'unfocused';
-    tabBar._updateTabs();
+
+    testRenderer.forceAllUpdates();
 
     expect(tabBar._Tabs.items[0].mode).toBe('selected');
     expect(tabBar._Tabs.items[1].mode).toBe('unfocused');


### PR DESCRIPTION
## Description

New 'retainSelection' property allows selected tab to remain ‘selected’ in mode even when the TabBar loses focus. That way, if the content is not using the 'TabContent' area in TabBar, we can maintain the same sort of relationship between 'selected' content and retain the visual identity of the selected tab.

## References

## Testing

I added a test to verify this change.

## Automation

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
