### PR TITLE
fix(Announcer): add super call to withAnnouncer _construct

### DIFF
--- a/packages/@lightningjs/ui-components/src/mixins/withAnnouncer/index.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withAnnouncer/index.js
@@ -40,6 +40,7 @@ export default function withAnnouncer(Base, speak = Speech, options = {}) {
     _construct() {
       this._announceEndedTimeout;
       this._currentlySpeaking = '';
+      super._construct && super._construct();
     }
 
     _voiceOut(toAnnounce) {


### PR DESCRIPTION
## Description

In some cases it may be desirable to use withAnnouncer along with other mixins. In this case super._construct will need to be called.

## References
[TICKET](https://ccp.sys.comcast.net/browse/LUI-1423)