### PR TITLE
fix: if the color parser fails to generate a color, return the original value

### DIFF
--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
@@ -562,7 +562,7 @@ export const colorParser = (targetObject, styleObj) => {
       return getValFromObjPath(targetObject, value); // If no theme value exists, the property will be removed from the object
     } else if (Array.isArray(value) && value.length === 2) {
       // Process value as a color ['#663399', 1]
-      return getHexColor(value[0], value[1]);
+      return getHexColor(value[0], value[1]) || value;
     }
     return value;
   });


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
For the new RailLozenge, we need to pass through an array of start and end color values for gradients, like this:
```js
      gradient: [
        [#ffffff, #000000],
        [#ffffff, #000000],
        [#ffffff, #000000],
        [#ffffff, #000000],
        [#ffffff, #000000]
      ]
```
 Unfortunately, this style was being interpreted as a single array of colors. Since the second value wasn't actually an alpha value, the `getHexColor` function was returning null. This will at least return the original value if the process fails.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
