### PR TITLE
fix: update color parsing to only apply if the second array value is a number

### DIFF
--- a/packages/@lightningjs/ui-components/src/globals/context/theme-manager.js
+++ b/packages/@lightningjs/ui-components/src/globals/context/theme-manager.js
@@ -389,7 +389,9 @@ class ThemeManager {
         2 === value.length &&
         !value[0].targetComponent &&
         value[0].length &&
-        value[0].substr(0, 1) === '#'
+        typeof value[0] === 'string' &&
+        value[0].substr(0, 1) === '#' &&
+        typeof value[1] === 'number'
       ) {
         // Better check to filter out extensions?
         return getHexColor(value[0], value[1]);

--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
@@ -560,7 +560,13 @@ export const colorParser = (targetObject, styleObj) => {
     if ('string' === typeof value && value.startsWith('theme.')) {
       // Support theme strings example: theme.radius.md
       return getValFromObjPath(targetObject, value); // If no theme value exists, the property will be removed from the object
-    } else if (Array.isArray(value) && value.length === 2) {
+    } else if (
+      Array.isArray(value) &&
+      value.length === 2 &&
+      typeof value[0] === 'string' &&
+      value[0].substr(0, 1) === '#' &&
+      typeof value[1] === 'number'
+    ) {
       // Process value as a color ['#663399', 1]
       return getHexColor(value[0], value[1]) || value;
     }

--- a/packages/@lightningjs/ui-components/src/utils/index.js
+++ b/packages/@lightningjs/ui-components/src/utils/index.js
@@ -386,24 +386,26 @@ export function getHexColor(hex, alpha = 1) {
  * @param {boolean} fill
  */
 export function getValidColor(color) {
-  if (/^0x[0-9a-fA-F]{8}/g.test(color)) {
-    // User enters a valid 0x00000000 hex code
-    return Number(color);
-  } else if (/^#[0-9a-fA-F]{6}/g.test(color)) {
-    // User enters valid #000000 hex code
-    return getHexColor(color.substr(1, 6));
-  } else if (typeof color === 'string' && /^[0-9]{8,10}/g.test(color)) {
-    return parseInt(color);
-  } else if (
-    typeof color === 'number' &&
-    /^[0-9]{8,10}/g.test(color.toString())
-  ) {
-    return color;
-  } else if (typeof color === 'string' && color.indexOf('rgba') > -1) {
-    return rgba2argb(color);
-  } else if (typeof color === 'string' && color.indexOf('rgb') > -1) {
-    const rgba = [...color.replace(/rgb\(|\)/g, '').split(','), '255'];
-    return lng.StageUtils.getArgbNumber(rgba);
+  if (typeof color === 'string' || typeof color === 'number') {
+    if (/^0x[0-9a-fA-F]{8}/g.test(color)) {
+      // User enters a valid 0x00000000 hex code
+      return Number(color);
+    } else if (/^#[0-9a-fA-F]{6}/g.test(color)) {
+      // User enters valid #000000 hex code
+      return getHexColor(color.substr(1, 6));
+    } else if (typeof color === 'string' && /^[0-9]{8,10}/g.test(color)) {
+      return parseInt(color);
+    } else if (
+      typeof color === 'number' &&
+      /^[0-9]{8,10}/g.test(color.toString())
+    ) {
+      return color;
+    } else if (typeof color === 'string' && color.indexOf('rgba') > -1) {
+      return rgba2argb(color);
+    } else if (typeof color === 'string' && color.indexOf('rgb') > -1) {
+      const rgba = [...color.replace(/rgb\(|\)/g, '').split(','), '255'];
+      return lng.StageUtils.getArgbNumber(rgba);
+    }
   }
   return null;
 }


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->
The theme color parser was still trying to parse nested gradients and set them as formatted colors.

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

<!-- step by step instructions to review this PR's changes -->
- Trying adding this to the base theme
```js
  componentConfig: {
    RailLozenge: {
      style: {
        gradient: [
          ['#CEF6F3', '#6EDBD2'],
          ['#6BDAD1', '#1ABBAF'],
          ['#1AB8AD', '#1A827E'],
          ['#1A817D', '#1A4C4F'],
          ['#194C4E', '#0E3638']
        ]
      }
    },
```
- Then in Storybook, open a story like Button, right click on the canvas, hit inspect, and add this to the console:
`window.CONTEXT.theme.componentConfig.RailLozenge.style.gradient`.
- Confirm that the gradient is an array where each element is an array of 2 colors. Previously, this was all wiped out to be "null"

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
