### PR TITLE
fix: Round radius token inverting

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.js
+++ b/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.js
@@ -17,7 +17,7 @@
  */
 
 import lng from '@lightningjs/core';
-import { getValidColor, reduceFraction } from '../../utils';
+import { getMaxRoundRadius, getValidColor, reduceFraction } from '../../utils';
 import Base from '../Base';
 import Gradient from '../Gradient';
 import * as styles from './Artwork.styles';
@@ -629,10 +629,13 @@ export default class Artwork extends Base {
         ? {
             shader: {
               type: lng.shaders.RoundedRectangle,
-              radius: this.style.radius
+              radius: getMaxRoundRadius(this.style.radius, this.w, this.h, 0)
             }
           }
         : { shader: undefined }
     );
   }
+
+  
+  
 }

--- a/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.js
+++ b/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.js
@@ -635,7 +635,4 @@ export default class Artwork extends Base {
         : { shader: undefined }
     );
   }
-
-  
-  
 }

--- a/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.js
+++ b/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.js
@@ -629,7 +629,7 @@ export default class Artwork extends Base {
         ? {
             shader: {
               type: lng.shaders.RoundedRectangle,
-              radius: getMaxRoundRadius(this.style.radius, this.w, this.h, 0)
+              radius: getMaxRoundRadius(this.style.radius, this.w, this.h)
             }
           }
         : { shader: undefined }

--- a/packages/@lightningjs/ui-components/src/components/Badge/Badge.js
+++ b/packages/@lightningjs/ui-components/src/components/Badge/Badge.js
@@ -18,7 +18,7 @@
 
 import Base from '../Base';
 import Icon from '../Icon';
-import { getHexColor } from '../../utils';
+import { getHexColor, getMaxRoundRadius } from '../../utils';
 import * as styles from './Badge.styles';
 import lng from '@lightningjs/core';
 
@@ -86,7 +86,7 @@ export default class Badge extends Base {
       texture: lng.Tools.getRoundRect(
         this.w,
         height,
-        this.style.radius,
+        getMaxRoundRadius(this.style.radius, this.w, height, 0),
         this.style.strokeWidth,
         this.style.strokeColor,
         true,

--- a/packages/@lightningjs/ui-components/src/components/Badge/Badge.js
+++ b/packages/@lightningjs/ui-components/src/components/Badge/Badge.js
@@ -86,7 +86,7 @@ export default class Badge extends Base {
       texture: lng.Tools.getRoundRect(
         this.w,
         height,
-        getMaxRoundRadius(this.style.radius, this.w, height, 0),
+        getMaxRoundRadius(this.style.radius, this.w, height),
         this.style.strokeWidth,
         this.style.strokeColor,
         true,

--- a/packages/@lightningjs/ui-components/src/components/Checkbox/Checkbox.js
+++ b/packages/@lightningjs/ui-components/src/components/Checkbox/Checkbox.js
@@ -124,7 +124,7 @@ export default class Checkbox extends Base {
         // Compensating for the extra 2 pixels getRoundRect adds
         this.w - 2,
         this.h - 2,
-        getMaxRoundRadius(this.style.radius, this.w, this.h, 0),
+        getMaxRoundRadius(this.style.radius, this.w - 2, this.h - 2),
         this.style.strokeWidth,
         this.style.strokeColor,
         false

--- a/packages/@lightningjs/ui-components/src/components/Checkbox/Checkbox.js
+++ b/packages/@lightningjs/ui-components/src/components/Checkbox/Checkbox.js
@@ -96,16 +96,19 @@ export default class Checkbox extends Base {
       ? this.style.backgroundColorChecked
       : this.style.backgroundColor;
 
+    const width = this.w - this.style.strokeWidth * 2 - 2;
+    const height = this.h - this.style.strokeWidth * 2 - 2;
+  
     this._Body.patch({
       texture: lng.Tools.getRoundRect(
         // Compensating for the extra 2 pixels getRoundRect adds
-        this.w - this.style.strokeWidth * 2 - 2,
-        this.h - this.style.strokeWidth * 2 - 2,
+        width,
+        height,
         getMaxRoundRadius(
           this.style.radius,
-          this.w,
-          this.h,
-          this.style.strokeWidth - 2
+          width,
+          height,
+          this.style.strokeWidth * 2 - 2
         ),
         0,
         null,

--- a/packages/@lightningjs/ui-components/src/components/Checkbox/Checkbox.js
+++ b/packages/@lightningjs/ui-components/src/components/Checkbox/Checkbox.js
@@ -20,6 +20,7 @@ import lng from '@lightningjs/core';
 import Icon from '../Icon';
 import Base from '../Base';
 import * as styles from './Checkbox.styles';
+import { getMaxRoundRadius } from '../../utils';
 
 export default class Checkbox extends Base {
   static get __componentName() {
@@ -106,7 +107,7 @@ export default class Checkbox extends Base {
         // Compensating for the extra 2 pixels getRoundRect adds
         this.w - this.style.strokeWidth * 2 - 2,
         this.h - this.style.strokeWidth * 2 - 2,
-        radius,
+        getMaxRoundRadius(this.style.radius, this.w, this.h, this.style.strokeWidth - 2),
         0,
         null,
         true,
@@ -121,7 +122,7 @@ export default class Checkbox extends Base {
         // Compensating for the extra 2 pixels getRoundRect adds
         this.w - 2,
         this.h - 2,
-        this.style.radius,
+        getMaxRoundRadius(this.style.radius, this.w, this.h, 0),
         this.style.strokeWidth,
         this.style.strokeColor,
         false

--- a/packages/@lightningjs/ui-components/src/components/Checkbox/Checkbox.js
+++ b/packages/@lightningjs/ui-components/src/components/Checkbox/Checkbox.js
@@ -96,18 +96,17 @@ export default class Checkbox extends Base {
       ? this.style.backgroundColorChecked
       : this.style.backgroundColor;
 
-    // if the inner checkbox should be square, a rounded corner radius can still be applied to the stroke
-    const radius =
-      this.style.radius >= this.w / 2
-        ? (this.w - this.style.strokeWidth - 2) / 2
-        : 0;
-
     this._Body.patch({
       texture: lng.Tools.getRoundRect(
         // Compensating for the extra 2 pixels getRoundRect adds
         this.w - this.style.strokeWidth * 2 - 2,
         this.h - this.style.strokeWidth * 2 - 2,
-        getMaxRoundRadius(this.style.radius, this.w, this.h, this.style.strokeWidth - 2),
+        getMaxRoundRadius(
+          this.style.radius,
+          this.w,
+          this.h,
+          this.style.strokeWidth - 2
+        ),
         0,
         null,
         true,

--- a/packages/@lightningjs/ui-components/src/components/Checkbox/Checkbox.js
+++ b/packages/@lightningjs/ui-components/src/components/Checkbox/Checkbox.js
@@ -98,7 +98,7 @@ export default class Checkbox extends Base {
 
     const width = this.w - this.style.strokeWidth * 2 - 2;
     const height = this.h - this.style.strokeWidth * 2 - 2;
-  
+
     this._Body.patch({
       texture: lng.Tools.getRoundRect(
         // Compensating for the extra 2 pixels getRoundRect adds

--- a/packages/@lightningjs/ui-components/src/components/Gradient/Gradient.js
+++ b/packages/@lightningjs/ui-components/src/components/Gradient/Gradient.js
@@ -19,6 +19,7 @@
 import lng from '@lightningjs/core';
 import Base from '../Base';
 import * as styles from './Gradient.styles';
+import { getMaxRoundRadius } from '../../utils';
 
 export default class Gradient extends Base {
   static get __componentName() {
@@ -35,7 +36,7 @@ export default class Gradient extends Base {
       rtt: true,
       colorTop: this.style.gradientTop,
       colorBottom: this.style.gradientColor,
-      texture: lng.Tools.getRoundRect(this.w, this.h, this.style.radius)
+      texture: lng.Tools.getRoundRect(this.w, this.h, getMaxRoundRadius(this.style.radius, this.w, this.h, 0))
     });
   }
 }

--- a/packages/@lightningjs/ui-components/src/components/Gradient/Gradient.js
+++ b/packages/@lightningjs/ui-components/src/components/Gradient/Gradient.js
@@ -36,7 +36,11 @@ export default class Gradient extends Base {
       rtt: true,
       colorTop: this.style.gradientTop,
       colorBottom: this.style.gradientColor,
-      texture: lng.Tools.getRoundRect(this.w, this.h, getMaxRoundRadius(this.style.radius, this.w, this.h, 0))
+      texture: lng.Tools.getRoundRect(
+        this.w,
+        this.h,
+        getMaxRoundRadius(this.style.radius, this.w, this.h, 0)
+      )
     });
   }
 }

--- a/packages/@lightningjs/ui-components/src/components/Gradient/Gradient.js
+++ b/packages/@lightningjs/ui-components/src/components/Gradient/Gradient.js
@@ -39,7 +39,7 @@ export default class Gradient extends Base {
       texture: lng.Tools.getRoundRect(
         this.w,
         this.h,
-        getMaxRoundRadius(this.style.radius, this.w, this.h, 0)
+        getMaxRoundRadius(this.style.radius, this.w, this.h)
       )
     });
   }

--- a/packages/@lightningjs/ui-components/src/components/Knob/Knob.js
+++ b/packages/@lightningjs/ui-components/src/components/Knob/Knob.js
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { getMaxRoundRadius } from '../../utils';
 import Base from '../Base';
 import * as styles from './Knob.styles';
 import lng from '@lightningjs/core';
@@ -44,7 +45,7 @@ export default class Knob extends Base {
       texture: lng.Tools.getRoundRect(
         this.w,
         this.h,
-        this.style.radius,
+        getMaxRoundRadius(this.style.radius, this.w, this.h, 0),
         null,
         null,
         true,

--- a/packages/@lightningjs/ui-components/src/components/Knob/Knob.js
+++ b/packages/@lightningjs/ui-components/src/components/Knob/Knob.js
@@ -45,7 +45,7 @@ export default class Knob extends Base {
       texture: lng.Tools.getRoundRect(
         this.w,
         this.h,
-        getMaxRoundRadius(this.style.radius, this.w, this.h, 0),
+        getMaxRoundRadius(this.style.radius, this.w, this.h),
         null,
         null,
         true,

--- a/packages/@lightningjs/ui-components/src/components/ProgressBar/ProgressBar.js
+++ b/packages/@lightningjs/ui-components/src/components/ProgressBar/ProgressBar.js
@@ -62,7 +62,7 @@ export default class ProgressBar extends Base {
   _updateTextures() {
     const w = this._getProgressWidth();
 
-    const radius = getMaxRoundRadius(this.style.radius, this.w, this.h, 0)
+    const radius = getMaxRoundRadius(this.style.radius, this.w, this.h, 0);
 
     this._Bar.texture = lng.Tools.getRoundRect(
       // getRoundRect adds 2 to the width

--- a/packages/@lightningjs/ui-components/src/components/ProgressBar/ProgressBar.js
+++ b/packages/@lightningjs/ui-components/src/components/ProgressBar/ProgressBar.js
@@ -62,7 +62,7 @@ export default class ProgressBar extends Base {
   _updateTextures() {
     const w = this._getProgressWidth();
 
-    const radius = getMaxRoundRadius(this.style.radius, this.w, this.h, 0);
+    const radius = getMaxRoundRadius(this.style.radius, this.w - 2, this.h);
 
     this._Bar.texture = lng.Tools.getRoundRect(
       // getRoundRect adds 2 to the width

--- a/packages/@lightningjs/ui-components/src/components/ProgressBar/ProgressBar.js
+++ b/packages/@lightningjs/ui-components/src/components/ProgressBar/ProgressBar.js
@@ -19,6 +19,7 @@
 import lng from '@lightningjs/core';
 import Base from '../Base';
 import * as styles from './ProgressBar.styles';
+import { getMaxRoundRadius } from '../../utils';
 
 export default class ProgressBar extends Base {
   static _template() {
@@ -61,11 +62,13 @@ export default class ProgressBar extends Base {
   _updateTextures() {
     const w = this._getProgressWidth();
 
+    const radius = getMaxRoundRadius(this.style.radius, this.w, this.h, 0)
+
     this._Bar.texture = lng.Tools.getRoundRect(
       // getRoundRect adds 2 to the width
       this.w - 2,
       this.h,
-      this.style.radius,
+      radius,
       0,
       0,
       true,
@@ -75,7 +78,7 @@ export default class ProgressBar extends Base {
     this._Progress.texture = lng.Tools.getRoundRect(
       w + 1,
       this.h,
-      this.style.radius,
+      radius,
       0,
       0,
       true,

--- a/packages/@lightningjs/ui-components/src/components/Provider/Provider.js
+++ b/packages/@lightningjs/ui-components/src/components/Provider/Provider.js
@@ -71,7 +71,14 @@ export default class Provider extends Base {
 
       let patch = {
         centerInParent: true,
-        radius: this.disableRadius ? 0 : getMaxRoundRadius(this.style.radius, this.style.itemSize, this.style.itemSize, 0),
+        radius: this.disableRadius
+          ? 0
+          : getMaxRoundRadius(
+              this.style.radius,
+              this.style.itemSize,
+              this.style.itemSize,
+              0
+            ),
         alpha: this.style.alpha,
         style: provider.style || {}
       };
@@ -133,7 +140,12 @@ export default class Provider extends Base {
           texture: lng.Tools.getRoundRect(
             this.style.itemSize,
             this.style.itemSize,
-            getMaxRoundRadius(this.style.radius, this.style.itemSize, this.style.itemSize, 0),
+            getMaxRoundRadius(
+              this.style.radius,
+              this.style.itemSize,
+              this.style.itemSize,
+              0
+            ),
             0,
             null,
             true,

--- a/packages/@lightningjs/ui-components/src/components/Provider/Provider.js
+++ b/packages/@lightningjs/ui-components/src/components/Provider/Provider.js
@@ -22,6 +22,7 @@ import Row from '../Row';
 import Icon from '../Icon';
 import TextBox from '../TextBox';
 import * as styles from './Provider.styles';
+import { getMaxRoundRadius } from '../../utils';
 
 export default class Provider extends Base {
   static get __componentName() {
@@ -70,7 +71,7 @@ export default class Provider extends Base {
 
       let patch = {
         centerInParent: true,
-        radius: this.disableRadius ? 0 : this.style.radius,
+        radius: this.disableRadius ? 0 : getMaxRoundRadius(this.style.radius, this.style.itemSize, this.style.itemSize, 0),
         alpha: this.style.alpha,
         style: provider.style || {}
       };
@@ -132,7 +133,7 @@ export default class Provider extends Base {
           texture: lng.Tools.getRoundRect(
             this.style.itemSize,
             this.style.itemSize,
-            this.style.radius,
+            getMaxRoundRadius(this.style.radius, this.style.itemSize, this.style.itemSize, 0),
             0,
             null,
             true,

--- a/packages/@lightningjs/ui-components/src/components/Provider/Provider.js
+++ b/packages/@lightningjs/ui-components/src/components/Provider/Provider.js
@@ -76,8 +76,7 @@ export default class Provider extends Base {
           : getMaxRoundRadius(
               this.style.radius,
               this.style.itemSize,
-              this.style.itemSize,
-              0
+              this.style.itemSize
             ),
         alpha: this.style.alpha,
         style: provider.style || {}
@@ -143,8 +142,7 @@ export default class Provider extends Base {
             getMaxRoundRadius(
               this.style.radius,
               this.style.itemSize,
-              this.style.itemSize,
-              0
+              this.style.itemSize
             ),
             0,
             null,

--- a/packages/@lightningjs/ui-components/src/components/Radio/Radio.js
+++ b/packages/@lightningjs/ui-components/src/components/Radio/Radio.js
@@ -68,18 +68,12 @@ export default class Radio extends Base {
       ? this.style.backgroundColorChecked
       : this.style.backgroundColor;
 
-    // if the inner body should be square, a rounded corner radius can still be applied to the stroke
-    const radius =
-      this.style.radius >= this.w / 2
-        ? (this.w - this.style.strokeWidth - 2) / 2
-        : 0;
-
     this._Body.patch({
       texture: lng.Tools.getRoundRect(
         // Compensating for the extra 2 pixels getRoundRect adds
         this.w - this.style.strokeWidth * 2 - 2,
         this.h - this.style.strokeWidth * 2 - 2,
-        getMaxRoundRadius(radius, this.w, this.h, 0), //Do I need to add an offset here?
+        getMaxRoundRadius(this.style.radius, this.w, this.h, 0),
         null,
         null,
         true,
@@ -94,7 +88,7 @@ export default class Radio extends Base {
       texture: lng.Tools.getRoundRect(
         this.w - 2,
         this.h - 2,
-        getMaxRoundRadius(this.style.radius, this.w, this.h, 0), //Some weird snapping nonsense is happening here and with checkbox
+        getMaxRoundRadius(this.style.radius, this.w, this.h, 0),
         this.style.strokeWidth,
         this.style.strokeColor,
         false

--- a/packages/@lightningjs/ui-components/src/components/Radio/Radio.js
+++ b/packages/@lightningjs/ui-components/src/components/Radio/Radio.js
@@ -68,12 +68,20 @@ export default class Radio extends Base {
       ? this.style.backgroundColorChecked
       : this.style.backgroundColor;
 
+    const width = this.w - this.style.strokeWidth * 2 - 2;
+    const height = this.h - this.style.strokeWidth * 2 - 2;
+
     this._Body.patch({
       texture: lng.Tools.getRoundRect(
         // Compensating for the extra 2 pixels getRoundRect adds
-        this.w - this.style.strokeWidth * 2 - 2,
-        this.h - this.style.strokeWidth * 2 - 2,
-        getMaxRoundRadius(this.style.radius, this.w, this.h, 0),
+        width,
+        height,
+        getMaxRoundRadius(
+          this.style.radius, 
+          width, 
+          height, 
+          this.style.strokeWidth * 2 - 2
+        ),
         null,
         null,
         true,

--- a/packages/@lightningjs/ui-components/src/components/Radio/Radio.js
+++ b/packages/@lightningjs/ui-components/src/components/Radio/Radio.js
@@ -96,7 +96,7 @@ export default class Radio extends Base {
       texture: lng.Tools.getRoundRect(
         this.w - 2,
         this.h - 2,
-        getMaxRoundRadius(this.style.radius, this.w, this.h, 0),
+        getMaxRoundRadius(this.style.radius, this.w, this.h),
         this.style.strokeWidth,
         this.style.strokeColor,
         false

--- a/packages/@lightningjs/ui-components/src/components/Radio/Radio.js
+++ b/packages/@lightningjs/ui-components/src/components/Radio/Radio.js
@@ -19,6 +19,7 @@
 import Base from '../Base';
 import lng from '@lightningjs/core';
 import * as styles from './Radio.styles';
+import { getMaxRoundRadius } from '../../utils';
 
 export default class Radio extends Base {
   static get __componentName() {
@@ -78,7 +79,7 @@ export default class Radio extends Base {
         // Compensating for the extra 2 pixels getRoundRect adds
         this.w - this.style.strokeWidth * 2 - 2,
         this.h - this.style.strokeWidth * 2 - 2,
-        radius,
+        getMaxRoundRadius(radius, this.w, this.h, 0), //Do I need to add an offset here?
         null,
         null,
         true,
@@ -93,7 +94,7 @@ export default class Radio extends Base {
       texture: lng.Tools.getRoundRect(
         this.w - 2,
         this.h - 2,
-        this.style.radius,
+        getMaxRoundRadius(this.style.radius, this.w, this.h, 0), //Some weird snapping nonsense is happening here and with checkbox
         this.style.strokeWidth,
         this.style.strokeColor,
         false

--- a/packages/@lightningjs/ui-components/src/components/Radio/Radio.js
+++ b/packages/@lightningjs/ui-components/src/components/Radio/Radio.js
@@ -77,9 +77,9 @@ export default class Radio extends Base {
         width,
         height,
         getMaxRoundRadius(
-          this.style.radius, 
-          width, 
-          height, 
+          this.style.radius,
+          width,
+          height,
           this.style.strokeWidth * 2 - 2
         ),
         null,

--- a/packages/@lightningjs/ui-components/src/components/Shadow/Shadow.js
+++ b/packages/@lightningjs/ui-components/src/components/Shadow/Shadow.js
@@ -19,6 +19,7 @@
 import lng from '@lightningjs/core';
 import Base from '../Base';
 import * as styles from './Shadow.styles';
+import { getMaxRoundRadius } from '../../utils';
 
 export default class Shadow extends Base {
   static get __componentName() {
@@ -57,6 +58,7 @@ export default class Shadow extends Base {
     // TODO: Need to know which mode style has the largest offset values, could refactor
     const extraBoundsY = this.style.maxOffsetY;
     const extraBoundsX = this.style.maxOffsetX;
+    const radius = getMaxRoundRadius(this.style.radius, this.w, this.h, 0);
 
     this.patch({
       Frame: {
@@ -75,7 +77,7 @@ export default class Shadow extends Base {
               h: this.h - holepunchError,
               x: shadowSize + holepunchError / 2,
               y: shadowSize + holepunchError / 2,
-              radius: this.style.radius
+              radius: radius
             }
           : undefined,
         Shadow: {
@@ -84,7 +86,7 @@ export default class Shadow extends Base {
             // Underlying getShadowRect function adds blur to the canvas size, so we don't need to add it like above
             this.w + this.style.spread * 2,
             this.h + this.style.spread * 2,
-            this.style.radius,
+            radius,
             this.style.blur
           )
         }

--- a/packages/@lightningjs/ui-components/src/components/Shadow/Shadow.js
+++ b/packages/@lightningjs/ui-components/src/components/Shadow/Shadow.js
@@ -58,7 +58,7 @@ export default class Shadow extends Base {
     // TODO: Need to know which mode style has the largest offset values, could refactor
     const extraBoundsY = this.style.maxOffsetY;
     const extraBoundsX = this.style.maxOffsetX;
-    const radius = getMaxRoundRadius(this.style.radius, this.w, this.h, 0);
+    const radius = getMaxRoundRadius(this.style.radius, this.w, this.h);
 
     this.patch({
       Frame: {
@@ -77,7 +77,7 @@ export default class Shadow extends Base {
               h: this.h - holepunchError,
               x: shadowSize + holepunchError / 2,
               y: shadowSize + holepunchError / 2,
-              radius: radius
+              radius
             }
           : undefined,
         Shadow: {

--- a/packages/@lightningjs/ui-components/src/components/Surface/Surface.js
+++ b/packages/@lightningjs/ui-components/src/components/Surface/Surface.js
@@ -62,7 +62,7 @@ export default class Surface extends Base {
       texture: lng.Tools.getRoundRect(
         this.innerW - 2, // Reference the underscored values here in cause the h or w getters need to be overwritten for alignment - see Tile
         this.innerH - 2,
-        getMaxRoundRadius(this.style.radius, this.w, this.h, 0),
+        getMaxRoundRadius(this.style.radius, this.w, this.h),
         0,
         null,
         true,

--- a/packages/@lightningjs/ui-components/src/components/Surface/Surface.js
+++ b/packages/@lightningjs/ui-components/src/components/Surface/Surface.js
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { getMaxRoundRadius } from '../../utils';
 import Base from '../Base';
 import * as styles from './Surface.styles';
 import lng from '@lightningjs/core';
@@ -61,7 +62,7 @@ export default class Surface extends Base {
       texture: lng.Tools.getRoundRect(
         this.innerW - 2, // Reference the underscored values here in cause the h or w getters need to be overwritten for alignment - see Tile
         this.innerH - 2,
-        this.style.radius,
+        getMaxRoundRadius(this.style.radius, this.w, this.h, 0),
         0,
         null,
         true,

--- a/packages/@lightningjs/ui-components/src/components/Toggle/Toggle.js
+++ b/packages/@lightningjs/ui-components/src/components/Toggle/Toggle.js
@@ -143,12 +143,11 @@ export default class Toggle extends Base {
         this.w - 2,
         this.h - 2,
         strokeRadius !== undefined
-          ? getMaxRoundRadius(strokeRadius, this.w, this.h, 0)
+          ? getMaxRoundRadius(strokeRadius, this.w, this.h)
           : getMaxRoundRadius(
               knobRadius,
               this.w - knobPadding * 2 - 2,
-              this.h - knobPadding * 2 - 2,
-              0
+              this.h - knobPadding * 2 - 2
             ) +
               knobPadding +
               strokeWidth,
@@ -170,7 +169,7 @@ export default class Toggle extends Base {
         // Compensating for the extra 2 pixels getRoundRect adds
         knobWidth - 2,
         knobHeight - 2,
-        getMaxRoundRadius(knobRadius, knobWidth, knobHeight, 0),
+        getMaxRoundRadius(knobRadius, knobWidth - 2, knobHeight - 2),
         0,
         0,
         true,

--- a/packages/@lightningjs/ui-components/src/components/Toggle/Toggle.js
+++ b/packages/@lightningjs/ui-components/src/components/Toggle/Toggle.js
@@ -122,7 +122,7 @@ export default class Toggle extends Base {
         // Compensating for the extra 2 pixels getRoundRect adds
         this.w - strokeWidth * 2 - 2,
         this.h - strokeWidth * 2 - 2,
-        getMaxRoundRadius(radius, this.w, this.h, 0),
+        getMaxRoundRadius(radius, this.w, this.h),
         strokeWidth,
         0,
         true,

--- a/packages/@lightningjs/ui-components/src/components/Toggle/Toggle.js
+++ b/packages/@lightningjs/ui-components/src/components/Toggle/Toggle.js
@@ -19,6 +19,7 @@
 import lng from '@lightningjs/core';
 import Base from '../Base';
 import * as styles from './Toggle.styles';
+import { getMaxRoundRadius } from '../../utils';
 
 export default class Toggle extends Base {
   static get __componentName() {
@@ -121,7 +122,7 @@ export default class Toggle extends Base {
         // Compensating for the extra 2 pixels getRoundRect adds
         this.w - strokeWidth * 2 - 2,
         this.h - strokeWidth * 2 - 2,
-        radius,
+        getMaxRoundRadius(radius, this.w, this.h, 0),
         strokeWidth,
         0,
         true,
@@ -142,8 +143,15 @@ export default class Toggle extends Base {
         this.w - 2,
         this.h - 2,
         strokeRadius !== undefined
-          ? strokeRadius
-          : knobRadius + knobPadding + strokeWidth,
+          ? getMaxRoundRadius(strokeRadius, this.w, this.h, 0)
+          : getMaxRoundRadius(
+              knobRadius,
+              this.w - knobPadding * 2 - 2,
+              this.h - knobPadding * 2 - 2,
+              0
+            ) +
+              knobPadding +
+              strokeWidth,
         strokeWidth,
         strokeColor,
         false,
@@ -162,7 +170,7 @@ export default class Toggle extends Base {
         // Compensating for the extra 2 pixels getRoundRect adds
         knobWidth - 2,
         knobHeight - 2,
-        knobRadius,
+        getMaxRoundRadius(knobRadius, knobWidth, knobHeight, 0),
         0,
         0,
         true,

--- a/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.js
+++ b/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.js
@@ -94,7 +94,12 @@ export default class Tooltip extends Base {
           type: Bubble,
           w: this._Background.w,
           h: this._Background.h,
-          radius: getMaxRoundRadius(this.style.radius, this._Background.w, this._Background.h, 0), //not really working here
+          radius: getMaxRoundRadius(
+            this.style.radius,
+            this._Background.w / 2,
+            this._Background.h / 2,
+            0
+          ),
           pointerWidth: this.style.pointerWidth,
           pointerHeight: this.style.pointerHeight,
           color: this.style.backgroundColor

--- a/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.js
+++ b/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.js
@@ -20,6 +20,7 @@ import Bubble from '../../textures/Bubble';
 import TextBox from '../TextBox';
 import Base from '../Base';
 import * as styles from './Tooltip.styles';
+import { getMaxRoundRadius } from '../../utils';
 
 export default class Tooltip extends Base {
   static get __componentName() {
@@ -93,7 +94,7 @@ export default class Tooltip extends Base {
           type: Bubble,
           w: this._Background.w,
           h: this._Background.h,
-          radius: this.style.radius,
+          radius: getMaxRoundRadius(this.style.radius, this._Background.w, this._Background.h, 0), //not really working here
           pointerWidth: this.style.pointerWidth,
           pointerHeight: this.style.pointerHeight,
           color: this.style.backgroundColor

--- a/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.js
+++ b/packages/@lightningjs/ui-components/src/components/Tooltip/Tooltip.js
@@ -88,17 +88,14 @@ export default class Tooltip extends Base {
   _updateBackground() {
     this.patch({
       Background: {
-        w: this._Background.w,
-        h: this._Background.h,
         texture: {
           type: Bubble,
           w: this._Background.w,
           h: this._Background.h,
           radius: getMaxRoundRadius(
             this.style.radius,
-            this._Background.w / 2,
-            this._Background.h / 2,
-            0
+            this._Background.w - this.style.pointerHeight,
+            this._Background.h - this.style.pointerHeight
           ),
           pointerWidth: this.style.pointerWidth,
           pointerHeight: this.style.pointerHeight,

--- a/packages/@lightningjs/ui-components/src/utils/index.js
+++ b/packages/@lightningjs/ui-components/src/utils/index.js
@@ -865,8 +865,7 @@ export function convertTextAlignToFlexJustify(align) {
  * @param {number} offset
  * @return {number} max radius for object before border begins to invert
  */
-export function getMaxRoundRadius(radius, width, height, offset) {
-  //const maxRadius = r => Math.min(r, (Math.min(width, height) / 2) + offset);
+export function getMaxRoundRadius(radius, width, height, offset = 0) {
   const maxRadius = r =>
     Math.max(0, Math.min(r, Math.min(width, height) / 2) + offset);
   return Array.isArray(radius)

--- a/packages/@lightningjs/ui-components/src/utils/index.js
+++ b/packages/@lightningjs/ui-components/src/utils/index.js
@@ -856,6 +856,16 @@ export function convertTextAlignToFlexJustify(align) {
   }
 }
 
+/**
+ * Write params in here soon
+ * function is checking for single num or array
+ */
+export function getMaxRoundRadius(radius, width, height, offset){
+  const maxRadius = r => Math.min(radius, (Math.min(width, height) / 2)) + offset;
+  return Array.isArray(radius) ? radius.map(r => maxRadius(r)) : maxRadius(radius);
+}
+
+
 const utils = {
   isMarkupString,
   capitalizeFirstLetter,
@@ -883,7 +893,8 @@ const utils = {
   getWidthByColumnSpan,
   createConditionalZContext,
   watchForUpdates,
-  convertTextAlignToFlexJustify
+  convertTextAlignToFlexJustify,
+  getMaxRoundRadius
 };
 
 export default utils;

--- a/packages/@lightningjs/ui-components/src/utils/index.js
+++ b/packages/@lightningjs/ui-components/src/utils/index.js
@@ -857,14 +857,22 @@ export function convertTextAlignToFlexJustify(align) {
 }
 
 /**
- * Write params in here soon
- * function is checking for single num or array
+ * Prevents user input radius from inverting.
+ *
+ * @param {number} user input radius
+ * @param {number} width
+ * @param {number} height
+ * @param {number} offset
+ * @return {number} max radius for object before border begins to invert
  */
-export function getMaxRoundRadius(radius, width, height, offset){
-  const maxRadius = r => Math.min(radius, (Math.min(width, height) / 2)) + offset;
-  return Array.isArray(radius) ? radius.map(r => maxRadius(r)) : maxRadius(radius);
+export function getMaxRoundRadius(radius, width, height, offset) {
+  //const maxRadius = r => Math.min(r, (Math.min(width, height) / 2) + offset);
+  const maxRadius = r =>
+    Math.max(0, Math.min(r, Math.min(width, height) / 2) + offset);
+  return Array.isArray(radius)
+    ? radius.map(r => Number(maxRadius(r)) || 0)
+    : Number(maxRadius(radius)) || 0;
 }
-
 
 const utils = {
   isMarkupString,


### PR DESCRIPTION
## Description

Note: The original ticket is a combo of 1410 & 1409 but 1410 was closed as a duplicate with all information migrated to 1409 which is why the branch was originally named 1410. 

Created a getMaxRoundRadius() util to prevent the border-radius from inverting on multiple components. 

To recreate the issue navigate to the Button component in the open-source LUI storybook. In the "Component Style Theme Values" tab edit the radius to 150 and observe border-radius inversion.

## References

[LUI-1409](https://ccp.sys.comcast.net/browse/LUI-1409)

## Testing

<!-- step by step instructions to review this PR's changes -->

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
