### PR TITLE
fix: Components loading with icon set

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Button/Button.js
+++ b/packages/@lightningjs/ui-components/src/components/Button/Button.js
@@ -93,13 +93,13 @@ export default class Button extends Surface {
   }
 
   _updatePositions() {
-    if (this._hasPrefix) {
+    if (this._hasPrefix && this._Prefix !== undefined) {
       this._Prefix.x = this._prefixX;
     }
     if (this._hasTitle) {
       this._TextWrapper.x = this._titleX;
     }
-    if (this._hasSuffix) {
+    if (this._hasSuffix && this._Suffix !== undefined) {
       this._Suffix.x = this._suffixX;
     }
   }
@@ -340,7 +340,7 @@ export default class Button extends Surface {
   }
 
   get _prefixW() {
-    return this._hasPrefix ? this._Prefix.w : 0;
+    return this._hasPrefix && this._Prefix !== undefined ? this._Prefix.w : 0;
   }
 
   get _prefixX() {
@@ -373,7 +373,7 @@ export default class Button extends Surface {
   }
 
   get _suffixW() {
-    return this._hasSuffix ? this._Suffix.w : 0;
+    return this._hasSuffix && this._Suffix !== undefined ? this._Suffix.w : 0;
   }
 
   get _suffixX() {

--- a/packages/@lightningjs/ui-components/src/components/Control/Control.js
+++ b/packages/@lightningjs/ui-components/src/components/Control/Control.js
@@ -113,7 +113,7 @@ export default class Control extends ButtonSmall {
                 2;
               this._patchTitle(middle, 0.5);
             }
-          } else {
+          } else if (this._Prefix !== undefined) {
             const middle =
               (this.w -
                 (this._paddingLeft +

--- a/packages/@lightningjs/ui-components/src/components/TabBar/Tab.js
+++ b/packages/@lightningjs/ui-components/src/components/TabBar/Tab.js
@@ -159,11 +159,11 @@ export default class Tab extends Surface {
   }
 
   get _iconW() {
-    return this.icon ? this._Icon.w : 0;
+    return this.icon && this._Icon !== undefined ? this._Icon.w : 0;
   }
 
   get _iconH() {
-    return this.icon ? this._Icon.h : 0;
+    return this.icon && this._Icon !== undefined ? this._Icon.h : 0;
   }
 
   get _paddingX() {


### PR DESCRIPTION
## Description

A few components were not loading when an icon was set (either true, suffix, or prefix). To recreate the issue navigate to the button component, set the prefix to "icon", and reload the page. Observe the component itself is not generating and the console throwing an error. The issue is occurring because properties are being set on variables that haven't been defined. Checking if the variables equal "undefined" solves the issue.

This can be observed in the following components:

- Button
- ButtonSmall
- Control
- Input
- Keyboard --> KeyboardInput --> With Qwerty
- Keyboard --> KeyboardInput --> With Email
- ListItem
- Tab

## References

[LUI-1398](https://ccp.sys.comcast.net/browse/LUI-1398)

## Testing

<!-- step by step instructions to review this PR's changes -->

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
