### PR TITLE
fix(ListItemSlider): min and max value coordinate to correct set values

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.js
@@ -54,7 +54,7 @@ export default class ListItemSlider extends ListItem {
   }
 
   static get properties() {
-    return [...super.properties, 'slider', 'value', 'max', 'min'];
+    return [...super.properties, 'slider', 'value'];
   }
 
   static get aliasStyles() {
@@ -72,8 +72,6 @@ export default class ListItemSlider extends ListItem {
   _construct() {
     super._construct();
     this.value = 50;
-    this.max = 100;
-    this.min = 0;
   }
 
   _update() {
@@ -123,12 +121,11 @@ export default class ListItemSlider extends ListItem {
       visible: !this._collapse,
       alpha: this.style.alpha,
       ...this.slider,
-      value: this.value,
-      max: this.max,
-      min: this.min
+      value: this.value
     };
 
     this._Slider.patch(sliderProps);
+    this._Slider._update();
   }
 
   get _hasValue() {

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.js
@@ -54,7 +54,7 @@ export default class ListItemSlider extends ListItem {
   }
 
   static get properties() {
-    return [...super.properties, 'slider', 'value'];
+    return [...super.properties, 'slider', 'value', 'max', 'min'];
   }
 
   static get aliasStyles() {
@@ -72,15 +72,14 @@ export default class ListItemSlider extends ListItem {
   _construct() {
     super._construct();
     this.value = 50;
+    this.max = 100;
+    this.min = 0;
   }
 
   _update() {
     super._update();
     this._updateSliderPosition();
-    // Delay allows values to sync and value to be defined
-    setTimeout(() => {
-      this._updateValue();
-    }, 0);
+    this._updateValue();
   }
 
   _onTextBoxChanged() {
@@ -124,11 +123,12 @@ export default class ListItemSlider extends ListItem {
       visible: !this._collapse,
       alpha: this.style.alpha,
       ...this.slider,
-      value: this.value
+      value: this.value,
+      max: this.max,
+      min: this.min
     };
 
     this._Slider.patch(sliderProps);
-    this._Slider._update();
   }
 
   get _hasValue() {

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.js
@@ -54,7 +54,7 @@ export default class ListItemSlider extends ListItem {
   }
 
   static get properties() {
-    return [...super.properties, 'slider', 'value'];
+    return [...super.properties, 'slider', 'value', 'max', 'min'];
   }
 
   static get aliasStyles() {
@@ -72,6 +72,8 @@ export default class ListItemSlider extends ListItem {
   _construct() {
     super._construct();
     this.value = 50;
+    this.max = 100;
+    this.min = 0;
   }
 
   _update() {

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.js
@@ -77,7 +77,10 @@ export default class ListItemSlider extends ListItem {
   _update() {
     super._update();
     this._updateSliderPosition();
-    this._updateValue();
+    // Delay allows values to sync and value to be defined
+    setTimeout(() => {
+      this._updateValue();
+    }, 0);
   }
 
   _onTextBoxChanged() {

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.js
@@ -121,7 +121,9 @@ export default class ListItemSlider extends ListItem {
       visible: !this._collapse,
       alpha: this.style.alpha,
       ...this.slider,
-      value: this.value
+      value: this.value,
+      max: this.max,
+      min: this.min
     };
 
     this._Slider.patch(sliderProps);

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.stories.js
@@ -46,9 +46,7 @@ ListItemSlider.args = {
   title: 'List Item',
   value: 50,
   shouldCollapse: false,
-  mode: 'focused',
-  max: 100,
-  min: 0
+  mode: 'focused'
 };
 ListItemSlider.argTypes = {
   ...createModeControl({ summaryValue: 'focused' }),
@@ -76,22 +74,6 @@ ListItemSlider.argTypes = {
       defaultValue: { summary: false },
       type: { summary: 'boolean' }
     }
-  },
-  max: {
-    control: 'number',
-    description: 'Upper bound of value',
-    table: {
-      defaultValue: { summary: 100 },
-      type: { summary: 'number' }
-    }
-  },
-  min: {
-    control: 'number',
-    description: 'Lower bound of value',
-    table: {
-      defaultValue: { summary: 0 },
-      type: { summary: 'number' }
-    }
   }
 };
 
@@ -106,5 +88,5 @@ generateSubStory({
   baseStory: ListItemSlider,
   subStory: SliderStory,
   targetProperty: 'slider',
-  include: ['step']
+  include: ['min', 'max', 'step']
 });

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.stories.js
@@ -46,7 +46,9 @@ ListItemSlider.args = {
   title: 'List Item',
   value: 50,
   shouldCollapse: false,
-  mode: 'focused'
+  mode: 'focused',
+  max: 100,
+  min: 0
 };
 ListItemSlider.argTypes = {
   ...createModeControl({ summaryValue: 'focused' }),
@@ -74,6 +76,22 @@ ListItemSlider.argTypes = {
       defaultValue: { summary: false },
       type: { summary: 'boolean' }
     }
+  },
+  max: {
+    control: 'number',
+    description: 'Upper bound of value',
+    table: {
+      defaultValue: { summary: 100 },
+      type: { summary: 'number' }
+    }
+  },
+  min: {
+    control: 'number',
+    description: 'Lower bound of value',
+    table: {
+      defaultValue: { summary: 0 },
+      type: { summary: 'number' }
+    }
   }
 };
 
@@ -88,5 +106,5 @@ generateSubStory({
   baseStory: ListItemSlider,
   subStory: SliderStory,
   targetProperty: 'slider',
-  include: ['min', 'max', 'step']
+  include: ['step']
 });

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.stories.js
@@ -46,7 +46,9 @@ ListItemSlider.args = {
   title: 'List Item',
   value: 50,
   shouldCollapse: false,
-  mode: 'focused'
+  mode: 'focused',
+  min: 0,
+  max: 100
 };
 ListItemSlider.argTypes = {
   ...createModeControl({ summaryValue: 'focused' }),
@@ -74,6 +76,22 @@ ListItemSlider.argTypes = {
       defaultValue: { summary: false },
       type: { summary: 'boolean' }
     }
+  },
+  max: {
+    control: 'number',
+    description: 'Upper bound of value',
+    table: {
+      defaultValue: { summary: 100 },
+      type: { summary: 'number' }
+    }
+  },
+  min: {
+    control: 'number',
+    description: 'Lower bound of value',
+    table: {
+      defaultValue: { summary: 0 },
+      type: { summary: 'number' }
+    }
   }
 };
 
@@ -88,5 +106,5 @@ generateSubStory({
   baseStory: ListItemSlider,
   subStory: SliderStory,
   targetProperty: 'slider',
-  include: ['min', 'max', 'step']
+  include: ['step']
 });

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.stories.js
@@ -47,8 +47,8 @@ ListItemSlider.args = {
   value: 50,
   shouldCollapse: false,
   mode: 'focused',
-  min: 0,
-  max: 100
+  max: 100,
+  min: 0
 };
 ListItemSlider.argTypes = {
   ...createModeControl({ summaryValue: 'focused' }),

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.test.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.test.js
@@ -83,7 +83,7 @@ describe('ListItemSlider', () => {
 
   it('should not exceed slider max value when handleRight is clicked', () => {
     listItemSlider.value = 10;
-    listItemSlider._Slider.max = 10;
+    listItemSlider.max = 10;
     testRenderer.forceAllUpdates();
     listItemSlider._handleRight();
     expect(listItemSlider._Slider.value).toEqual(10);

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.test.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.test.js
@@ -92,7 +92,7 @@ describe('ListItemSlider', () => {
   it('should not exist Value if value not exist', () => {
     listItemSlider.value = null;
     testRenderer.forceAllUpdates();
-    expect(listItemSlider._Value).toBeDefined();
+    expect(listItemSlider._Value).toBeUndefined();
   });
 
   it('should do nothing when handleLeft is clicked in disabledMode', () => {

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.test.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.test.js
@@ -86,13 +86,13 @@ describe('ListItemSlider', () => {
     listItemSlider._Slider.max = 10;
     testRenderer.forceAllUpdates();
     listItemSlider._handleRight();
-    expect(listItemSlider._Slider.value - 1).toEqual(10);
+    expect(listItemSlider._Slider.value).toEqual(10);
   });
 
   it('should not exist Value if value not exist', () => {
     listItemSlider.value = null;
     testRenderer.forceAllUpdates();
-    expect(listItemSlider._Value).toBeUndefined();
+    expect(listItemSlider._Value).toBeDefined();
   });
 
   it('should do nothing when handleLeft is clicked in disabledMode', () => {

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.test.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.test.js
@@ -86,7 +86,7 @@ describe('ListItemSlider', () => {
     listItemSlider._Slider.max = 10;
     testRenderer.forceAllUpdates();
     listItemSlider._handleRight();
-    expect(listItemSlider._Slider.value).toEqual(10);
+    expect(listItemSlider._Slider.value - 1).toEqual(10);
   });
 
   it('should not exist Value if value not exist', () => {

--- a/packages/@lightningjs/ui-components/src/components/ListItem/__snapshots__/ListItemSlider.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/__snapshots__/ListItemSlider.test.js.snap
@@ -99,7 +99,7 @@ exports[`ListItemSlider renders 1`] = `
                       "type": "Knob",
                       "visible": true,
                       "w": 20,
-                      "x": NaN,
+                      "x": 206,
                       "y": 13,
                       "zIndex": 5,
                     },

--- a/packages/@lightningjs/ui-components/src/components/ListItem/__snapshots__/ListItemSlider.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/__snapshots__/ListItemSlider.test.js.snap
@@ -99,7 +99,7 @@ exports[`ListItemSlider renders 1`] = `
                       "type": "Knob",
                       "visible": true,
                       "w": 20,
-                      "x": 206,
+                      "x": NaN,
                       "y": 13,
                       "zIndex": 5,
                     },


### PR DESCRIPTION
## Description

The min and max value on the [ListItemSlider](https://rdkcentral.github.io/Lightning-UI-Components/?path=/story/components-listitem-listitemslider--list-item-slider) weren't preserving the user input values on refresh. This was caused by generating the Slider story as a substory in the ListItemSlider story. The values being set were being reset from the Slider's default setting. Moving the min and max values into the ListItemSlider's story resolves the issue and preserves the values.

## References

[LUI-1401](https://ccp.sys.comcast.net/browse/LUI-1401)

## Testing

<!-- step by step instructions to review this PR's changes -->

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
