### PR TITLE
fix(Control): reorders which update methods are called first

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Control/Control.js
+++ b/packages/@lightningjs/ui-components/src/components/Control/Control.js
@@ -40,8 +40,8 @@ export default class Control extends ButtonSmall {
   _update() {
     // ordering this way to make sure that this._Title is defined so the title visibility can be set properly when _updateCollapseStatus is called
     this._updatePrefixStyle();
-    super._update();
     this._updateCollapseStatus();
+    super._update();
   }
 
   _updateCollapseStatus() {

--- a/packages/@lightningjs/ui-components/src/components/Control/Control.js
+++ b/packages/@lightningjs/ui-components/src/components/Control/Control.js
@@ -40,6 +40,7 @@ export default class Control extends ButtonSmall {
   _update() {
     // ordering this way to make sure that this._Title is defined so the title visibility can be set properly when _updateCollapseStatus is called
     this._updatePrefixStyle();
+    super._updateTitle();
     this._updateCollapseStatus();
     super._update();
   }


### PR DESCRIPTION
## Description

- updates visibility of title before the resizing of the control

## References

LUI-1391

## Testing

- make sure there is an icon and text within the control
- set shouldCollapse to true
- change the focus state and notice how the contents of the control don't overlap and the size adjusts correctly

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
