### PR TITLE
fix(Artwork): add imageLoadFailed signal

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.js
+++ b/packages/@lightningjs/ui-components/src/components/Artwork/Artwork.js
@@ -215,6 +215,7 @@ export default class Artwork extends Base {
 
   _rejectLoading(error) {
     this._componentSrc.reject && this._componentSrc.reject(error);
+    this.signal('imageLoadFailed');
   }
 
   async _update() {


### PR DESCRIPTION
## Description

Adds an `imageLoadFailed` signal to let parent element know that a texture did not load properly.

## References

LUI-1404

## Testing

N/A

## Automation

N/A

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
