### PR TITLE
fix(NavigationManager): ensure lazyUpCountBuffer remains non-negative

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.js
@@ -541,6 +541,16 @@ export default class NavigationManager extends FocusManager {
       : this.style.scrollIndex;
   }
 
+  _setLazyUpCountBuffer(buffer) {
+    if (buffer < 0) {
+      console.warn(
+        'lazyUpCountBuffer must be greater than or equal to 0. Setting to 0.'
+      );
+      buffer = 0;
+    }
+    return buffer;
+  }
+
   isFullyOnScreen({ offsetX = 0, offsetY = 0 } = {}) {
     // if the NavigationManager is nested in another Focus Manager
     // (like a Row inside of a Column),

--- a/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.test.js
+++ b/packages/@lightningjs/ui-components/src/components/NavigationManager/NavigationManager.test.js
@@ -426,4 +426,12 @@ describe('NavigationManager', () => {
     expect(navigationManager.alwaysScroll).toBe(true);
     expect(navigationManager.neverScroll).toBe(false);
   });
+
+  it('should set lazyUpCountBuffer to zero if set below', () => {
+    navigationManager.lazyUpCountBuffer = 3;
+    expect(navigationManager.lazyUpCountBuffer).toBe(3);
+
+    navigationManager.lazyUpCountBuffer = -2;
+    expect(navigationManager.lazyUpCountBuffer).toBe(0);
+  });
 });


### PR DESCRIPTION
## Description

Adds a check to make sure that any negative numbers passed in for `lazyUpCountBuffer` throws a warning and sets it to zero.

## References

LUI-1399 and LUI-1403

## Testing

Enter a negative value for `lazyUpCountBuffer` in a Column or Row story. Check the console to ensure that the warning is thrown. The story should operate with `lazyUpCountBuffer` now being zero.

## Automation

Not sure if this affects any current tests, but it fixes what the automation team caught.

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
