### PR TITLE
fix: issue with autoScroll in Slider.js diving into negative values

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.js
+++ b/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.js
@@ -334,25 +334,36 @@ export default class ScrollWrapper extends Base {
   }
 
   _updateSlider() {
-    // height of off screen items that can be scrolled to
-    const scrollHeight = this._ScrollContainer.finalH - this.renderHeight;
-    // number of steps to scroll to bottom of ScrollContainer
-    const contentScrollSteps = Math.ceil(scrollHeight / this.scrollStep);
+    // height of off-screen items that can be scrolled to
+    const scrollHeight = Math.max(
+      this._ScrollContainer.finalH - this.renderHeight,
+      0
+    );
+
+    // number of steps to scroll to the bottom of ScrollContainer
+    const contentScrollSteps =
+      scrollHeight > 0 ? Math.ceil(scrollHeight / this.scrollStep) : 1;
+
     // max value of slider
     const sliderMax = this.renderHeight;
-    // distance slider should move on each key press
-    const sliderStep = sliderMax / contentScrollSteps;
 
-    // This is a vertical slider, so w is actually controlling the height
-    this._Slider.patch({
-      x: this.w - this._sliderWidth,
-      w: sliderMax,
-      min: 0,
-      max: sliderMax,
-      step: sliderStep,
-      onUp: this._scrollUp.bind(this),
-      onDown: this._scrollDown.bind(this)
-    });
+    // distance slider should move on each key press
+    const sliderStep =
+      contentScrollSteps > 0 ? sliderMax / contentScrollSteps : sliderMax;
+
+    // Ensure _Slider and required properties exist
+    if (this._Slider) {
+      // This is a vertical slider, so w is actually controlling the height
+      this._Slider.patch({
+        x: this.w - this._sliderWidth,
+        w: sliderMax,
+        min: 0,
+        max: sliderMax,
+        step: sliderStep,
+        onUp: this._scrollUp.bind(this),
+        onDown: this._scrollDown.bind(this)
+      });
+    }
   }
 
   get _contentWidth() {

--- a/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.stories.js
@@ -121,7 +121,7 @@ export const Basic = args =>
     }
 
     $scrollChanged(type) {
-      args.scrollChanged(type);
+      args.scrollChanged && args.scrollChanged(type);
     }
   };
 


### PR DESCRIPTION
### Title: Fix issue with autoScroll in Slider.js diving into negative values

### Description

This PR addresses a bug in the `Slider.js` component where the autoScroll feature dives into negative values and never stops when the `terms` constant is set to a single word.

### Related Issues

- **Issue Link**: [LUI-1495](https://ccp.sys.comcast.net/browse/LUI-1495)

### Steps to Reproduce Issue

1. Add a `console.log` or breakpoint to line 113 in `Slider.js`.
2. Open the `ScrollWrapper` story.
3. Toggle `autoScroll` to `true`.
4. Observe the scroll values progress and shut off at the appropriate time.
5. Change the value of `const terms` to a single word.
6. Repeat the steps and observe the scroll values diving into negative numbers and never stopping.

### Changes Made

- Adjusted the scroll logic in `Slider.js` to properly handle scenarios where `content` fits on a single line.
