### PR TITLE
fix(ListItemSlider): value updates with min and max

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.js
@@ -92,6 +92,8 @@ export default class ListItemSlider extends ListItem {
 
   _updateValue() {
     if (this._hasValue) {
+      this._Slider.value = this.value =
+        this.value > this.max ? this.max : Math.max(this.min, this.value);
       let valuePatch = {
         content: this.value.toString(),
         style: { textStyle: { ...this.style.valueTextStyle } },


### PR DESCRIPTION
## Description

If the min exceeded the value OR the max was less than the value, the slider value itself was not updating until the arrows were used triggering an update in the value. 

Adding a check in _updateValue() allows the value to update with regard to its minimum and maximum properly. 

_how many times did I say **value** in this pr_

## References

LUI-1491

## Testing

- Run the branch locally
- Change the minimum to be greater than the value
- Observe the value automatically updating to be the minimum
- Repeat by making the value greater than the max and observe the max being set as the value
- Use the arrow keys to confirm the component operates by decreasing/increasing value when expected

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
