### PR TITLE
fix(KeyBoardFull): center keys control removed

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Keyboard/KeyboardFullscreen.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/KeyboardFullscreen.stories.js
@@ -49,19 +49,11 @@ export const KeyboardFullscreen = () =>
   };
 
 KeyboardFullscreen.storyName = 'KeyboardFullscreen';
+
 KeyboardFullscreen.args = {
   centerKeyboard: false,
-  centerKeys: false,
   mode: 'focused'
 };
+
+KeyboardFullscreen.argTypes = Keyboard.sharedArgTypes;
 KeyboardFullscreen.parameters = {};
-KeyboardFullscreen.argTypes = {
-  ...Keyboard.sharedArgTypes,
-  centerKeys: {
-    description: "Center the keys within it's set width of keyboard",
-    control: 'boolean',
-    table: {
-      defaultValue: { summary: false }
-    }
-  }
-};


### PR DESCRIPTION
## Description

The center keys control was removed from the KeyBoard Fullscreen component because that control doesn't relate to this component.

## References

LUI-1499

## Testing

Run locally and observe the control is no longer available. 

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
