### PR TITLE
fix(ListItemSlider): values sync with SB controls and textbox

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.js
@@ -80,6 +80,12 @@ export default class ListItemSlider extends ListItem {
     super._update();
     this._updateSliderPosition();
     this._updateValue();
+    // Added this below
+    if (this._valueChanged) {
+      this.signal('onChange', this.value, this);
+      this.fireAncestors('$announce', this.announce);
+      this._valueChanged = false;
+    }
   }
 
   _onTextBoxChanged() {

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.js
@@ -80,12 +80,6 @@ export default class ListItemSlider extends ListItem {
     super._update();
     this._updateSliderPosition();
     this._updateValue();
-    // Added this below
-    if (this._valueChanged) {
-      this.signal('onChange', this.value, this);
-      this.fireAncestors('$announce', this.announce);
-      this._valueChanged = false;
-    }
   }
 
   _onTextBoxChanged() {
@@ -147,14 +141,10 @@ export default class ListItemSlider extends ListItem {
     return titleWrapWidth;
   }
 
-  _onSliderChanged(value, Slider) {
-    if (value >= Slider.max) {
-      this.value = Slider.max;
-    } else if (value <= Slider.min) {
-      this.value = Slider.min;
-    } else {
-      this.value = Slider.value;
-    }
+  _onSliderChanged(value) {
+    this.value = value;
+    this._updateValue();
+    this.signal('onSliderChange', value, this);
   }
 
   _handleLeft() {

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.stories.js
@@ -18,8 +18,10 @@
 
 import lng from '@lightningjs/core';
 import { default as ListItemSliderComponent } from './ListItemSlider';
-import { createModeControl, generateSubStory } from '../../docs/utils';
-import { Basic as SliderStory } from '../Slider/Slider.stories';
+// import { createModeControl } from '../../docs/utils';
+// import { Basic as SliderStory } from '../Slider/Slider.stories';
+//Added this import below
+import { useArgs } from '@storybook/client-api';
 
 /**
  * A ListItem component with slider functionality
@@ -29,37 +31,50 @@ export default {
   title: 'Components/ListItem/ListItemSlider'
 };
 
-export const ListItemSlider = () =>
-  class ListItemSlider extends lng.Component {
+//Added a bunch of stuff in this block below to match
+// the slider.stories
+export const ListItemSlider = () => {
+  const [{ value }, updateArgs] = useArgs();
+  return class ListItemSlider extends lng.Component {
     static _template() {
       return {
         ListItemSlider: {
-          type: ListItemSliderComponent
+          type: ListItemSliderComponent,
+          value: value,
+          signals: {
+            onChange: true
+          }
         }
       };
     }
+    // update arg control when value changes
+    onChange(value) {
+      updateArgs({ value });
+    }
   };
+};
 
-ListItemSlider.storyName = 'ListItemSlider';
-
+//Commented out args below that get don't need testing
+// but feel free to add them back in.
 ListItemSlider.args = {
-  title: 'List Item',
+  // title: 'List Item',
   value: 50,
-  shouldCollapse: false,
-  mode: 'focused',
+  // shouldCollapse: false,
+  // mode: 'focused',
   max: 100,
   min: 0
 };
+
 ListItemSlider.argTypes = {
-  ...createModeControl({ summaryValue: 'focused' }),
-  title: {
-    control: 'text',
-    description: 'Title text',
-    table: {
-      defaultValue: { summary: 'undefined' },
-      type: { summary: 'string' }
-    }
-  },
+  // ...createModeControl({ summaryValue: 'focused' }),
+  // title: {
+  //   control: 'text',
+  //   description: 'Title text',
+  //   table: {
+  //     defaultValue: { summary: 'undefined' },
+  //     type: { summary: 'string' }
+  //   }
+  // },
   value: {
     control: 'number',
     description: 'Current slider value',
@@ -68,15 +83,15 @@ ListItemSlider.argTypes = {
       type: { summary: 'number' }
     }
   },
-  shouldCollapse: {
-    control: 'boolean',
-    description:
-      'When in unfocused or disabled mode, if shouldCollapse property is true it will collapse the slider (when focused, it will always be expanded)',
-    table: {
-      defaultValue: { summary: false },
-      type: { summary: 'boolean' }
-    }
-  },
+  // shouldCollapse: {
+  //   control: 'boolean',
+  //   description:
+  //     'When in unfocused or disabled mode, if shouldCollapse property is true it will collapse the slider (when focused, it will always be expanded)',
+  //   table: {
+  //     defaultValue: { summary: false },
+  //     type: { summary: 'boolean' }
+  //   }
+  // },
   max: {
     control: 'number',
     description: 'Upper bound of value',
@@ -95,16 +110,48 @@ ListItemSlider.argTypes = {
   }
 };
 
-ListItemSlider.argActions = {
-  shouldCollapse: (shouldCollapse, component) => {
-    component.tag('ListItemSlider').shouldCollapse = shouldCollapse;
-  }
-};
+//Added this block below because slider.stories has it as well
 
-generateSubStory({
-  componentName: 'ListItemSlider',
-  baseStory: ListItemSlider,
-  subStory: SliderStory,
-  targetProperty: 'slider',
-  include: ['step']
-});
+// ListItemSlider.argActions = {
+//   shouldCollapse: (shouldCollapse, component) => {
+//     component.tag('ListItemSlider').shouldCollapse = shouldCollapse;
+//   }
+// };
+
+// export const ListItemSliderSignal = () =>
+//   class SignalHandling extends lng.Component {
+//     static _template() {
+//       return {
+//         flex: { direction: 'column' },
+//         ListItemSlider: {
+//           type: ListItemSlider,
+//           y: 20,
+//           step: 1,
+//           value: 30,
+//           w: 328,
+//           signals: {
+//             onChange: true
+//           }
+//         },
+//         Text: {
+//           y: 60,
+//           type: TextBox
+//         }
+//       };
+//     }
+
+//     onChange(value) {
+//       this.tag('Text').content = `Value: ${value}`;
+//     }
+//   };
+
+// ListItemSliderSignal.args = {
+//   mode: 'focused'
+// };
+
+// ListItemSliderSignal.argTypes = createModeControl({ summaryValue: 'focused' });
+
+// ListItemSliderSignal.parameters = {
+//   storyDetails:
+//     'When the onChange signal is emitted from the Slider the number in the TextBox is updated with the Slider value.'
+// };

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.stories.js
@@ -42,13 +42,13 @@ export const ListItemSlider = () => {
           type: ListItemSliderComponent,
           value: value,
           signals: {
-            onChange: true
+            onSliderChange: true
           }
         }
       };
     }
     // update arg control when value changes
-    onChange(value) {
+    onSliderChange(value) {
       updateArgs({ value });
     }
   };

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.stories.js
@@ -18,9 +18,8 @@
 
 import lng from '@lightningjs/core';
 import { default as ListItemSliderComponent } from './ListItemSlider';
-// import { createModeControl } from '../../docs/utils';
-// import { Basic as SliderStory } from '../Slider/Slider.stories';
-//Added this import below
+import { createModeControl, generateSubStory } from '../../docs/utils';
+import { Basic as SliderStory } from '../Slider/Slider.stories';
 import { useArgs } from '@storybook/client-api';
 
 /**
@@ -31,8 +30,6 @@ export default {
   title: 'Components/ListItem/ListItemSlider'
 };
 
-//Added a bunch of stuff in this block below to match
-// the slider.stories
 export const ListItemSlider = () => {
   const [{ value }, updateArgs] = useArgs();
   return class ListItemSlider extends lng.Component {
@@ -54,27 +51,25 @@ export const ListItemSlider = () => {
   };
 };
 
-//Commented out args below that get don't need testing
-// but feel free to add them back in.
 ListItemSlider.args = {
-  // title: 'List Item',
+  title: 'List Item',
   value: 50,
-  // shouldCollapse: false,
-  // mode: 'focused',
+  shouldCollapse: false,
+  mode: 'focused',
   max: 100,
   min: 0
 };
 
 ListItemSlider.argTypes = {
-  // ...createModeControl({ summaryValue: 'focused' }),
-  // title: {
-  //   control: 'text',
-  //   description: 'Title text',
-  //   table: {
-  //     defaultValue: { summary: 'undefined' },
-  //     type: { summary: 'string' }
-  //   }
-  // },
+  ...createModeControl({ summaryValue: 'focused' }),
+  title: {
+    control: 'text',
+    description: 'Title text',
+    table: {
+      defaultValue: { summary: 'undefined' },
+      type: { summary: 'string' }
+    }
+  },
   value: {
     control: 'number',
     description: 'Current slider value',
@@ -83,15 +78,15 @@ ListItemSlider.argTypes = {
       type: { summary: 'number' }
     }
   },
-  // shouldCollapse: {
-  //   control: 'boolean',
-  //   description:
-  //     'When in unfocused or disabled mode, if shouldCollapse property is true it will collapse the slider (when focused, it will always be expanded)',
-  //   table: {
-  //     defaultValue: { summary: false },
-  //     type: { summary: 'boolean' }
-  //   }
-  // },
+  shouldCollapse: {
+    control: 'boolean',
+    description:
+      'When in unfocused or disabled mode, if shouldCollapse property is true it will collapse the slider (when focused, it will always be expanded)',
+    table: {
+      defaultValue: { summary: false },
+      type: { summary: 'boolean' }
+    }
+  },
   max: {
     control: 'number',
     description: 'Upper bound of value',
@@ -110,48 +105,10 @@ ListItemSlider.argTypes = {
   }
 };
 
-//Added this block below because slider.stories has it as well
-
-// ListItemSlider.argActions = {
-//   shouldCollapse: (shouldCollapse, component) => {
-//     component.tag('ListItemSlider').shouldCollapse = shouldCollapse;
-//   }
-// };
-
-// export const ListItemSliderSignal = () =>
-//   class SignalHandling extends lng.Component {
-//     static _template() {
-//       return {
-//         flex: { direction: 'column' },
-//         ListItemSlider: {
-//           type: ListItemSlider,
-//           y: 20,
-//           step: 1,
-//           value: 30,
-//           w: 328,
-//           signals: {
-//             onChange: true
-//           }
-//         },
-//         Text: {
-//           y: 60,
-//           type: TextBox
-//         }
-//       };
-//     }
-
-//     onChange(value) {
-//       this.tag('Text').content = `Value: ${value}`;
-//     }
-//   };
-
-// ListItemSliderSignal.args = {
-//   mode: 'focused'
-// };
-
-// ListItemSliderSignal.argTypes = createModeControl({ summaryValue: 'focused' });
-
-// ListItemSliderSignal.parameters = {
-//   storyDetails:
-//     'When the onChange signal is emitted from the Slider the number in the TextBox is updated with the Slider value.'
-// };
+generateSubStory({
+  componentName: 'ListItemSlider',
+  baseStory: ListItemSlider,
+  subStory: SliderStory,
+  targetProperty: 'slider',
+  include: ['step']
+});

--- a/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ListItem/ListItemSlider.stories.js
@@ -51,6 +51,8 @@ export const ListItemSlider = () => {
   };
 };
 
+ListItemSlider.storyName = 'ListItemSlider';
+
 ListItemSlider.args = {
   title: 'List Item',
   value: 50,
@@ -102,6 +104,12 @@ ListItemSlider.argTypes = {
       defaultValue: { summary: 0 },
       type: { summary: 'number' }
     }
+  }
+};
+
+ListItemSlider.argActions = {
+  shouldCollapse: (shouldCollapse, component) => {
+    component.tag('ListItemSlider').shouldCollapse = shouldCollapse;
   }
 };
 

--- a/packages/@lightningjs/ui-components/src/components/Slider/Slider.js
+++ b/packages/@lightningjs/ui-components/src/components/Slider/Slider.js
@@ -335,6 +335,20 @@ export default class Slider extends Base {
     return value;
   }
 
+  _setMin(min) {
+    const value = this.value;
+    this.value = min > value ? min : value;
+    this._valueChanged = value !== this.value;
+    return min;
+  }
+
+  _setMax(max) {
+    const value = this.value;
+    this.value = max < value ? max : value;
+    this._valueChanged = value !== this.value;
+    return max;
+  }
+
   set announce(announce) {
     super.announce = announce;
   }


### PR DESCRIPTION
## Description

The ListItemSlider's component value was not syncing between the component's actual textbox value (when you adjust the value with L/R arrows) and the input storybook control value. By using the storybook client API and signals the storybook value is now responsive (staying in sync) with the value of the slider itself. Similar logic is already used within the Slider component to keep its values synced. 

This fix solves the issue of the min and max values not being updated until the arrows were used.

## References

LUI-1491

## Testing

<!-- step by step instructions to review this PR's changes -->

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
