### PR TITLE
fix(InlineContent): marginBottom default style

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.stories.js
@@ -20,13 +20,15 @@ import lng from '@lightningjs/core';
 import { default as InlineContentComponent } from '.';
 import lightningbolt from '../../assets/images/ic_lightning_white_32.png';
 import { getHexColor } from '../../utils';
+import TextBox from '../TextBox';
 
 export default {
   title: 'Components/InlineContent',
   args: {
     contentWrap: false,
     justify: 'center',
-    contentProperties: { marginBottom: -4 },
+    // Commented out for testing purposes. READD BEFORE MERGE
+    // contentProperties: { marginBottom: -4 } Commented out for testing purposes. READD BEFORE MERGE
     maxLines: 0,
     maxLinesSuffix: '..'
   },
@@ -230,4 +232,40 @@ WithTruncation.args = {
   contentWrap: true,
   maxLines: 2,
   maxLinesSuffix: '...'
+};
+
+const lorum =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est eu eleifend interdum. Vivamus egestas maximus elementum. Sed condimentum ligula justo, non sollicitudin lectus rutrum vel. Integer iaculis vitae nisl quis tincidunt. Sed quis dui vehicula, vehicula felis a, tempor leo. Fusce tincidunt, ante eget pretium efficitur, libero elit volutpat quam, sit amet porta tortor odio non ligula. Ut sed dolor eleifend massa auctor porttitor eget ut lectus. Vivamus elementum lorem mauris, eu luctus tortor posuere sit amet. Nunc a interdum metus.';
+
+// ADDED FOR TESTING PURPOSES, REMOVE BEFORE MERGE
+export const TextBoxVSInlineContent = args =>
+  class TextBoxVSInlineContent extends lng.Component {
+    static _template() {
+      return {
+        InlineContent: {
+          type: InlineContentComponent,
+          ...args,
+          w: 600,
+          content: lorum,
+          marquee: false,
+          hideOnLoad: false,
+          fixed: true
+        },
+        Textbox: {
+          type: TextBox,
+          fixed: true,
+          x: 601,
+          w: 600,
+          style: { textStyle: { maxLines: 3 }, offsetY: 0 },
+          marquee: false,
+          content: lorum,
+          hideOnLoad: false,
+          contentWrap: true
+        }
+      };
+    }
+  };
+TextBoxVSInlineContent.args = {
+  contentWrap: true,
+  maxLines: 3
 };

--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.stories.js
@@ -22,6 +22,9 @@ import lightningbolt from '../../assets/images/ic_lightning_white_32.png';
 import { getHexColor } from '../../utils';
 import TextBox from '../TextBox';
 
+const lorum =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est eu eleifend interdum. Vivamus egestas maximus elementum. Sed condimentum ligula justo, non sollicitudin lectus rutrum vel. Integer iaculis vitae nisl quis tincidunt. Sed quis dui vehicula, vehicula felis a, tempor leo. Fusce tincidunt, ante eget pretium efficitur, libero elit volutpat quam, sit amet porta tortor odio non ligula. Ut sed dolor eleifend massa auctor porttitor eget ut lectus. Vivamus elementum lorem mauris, eu luctus tortor posuere sit amet. Nunc a interdum metus.';
+
 export default {
   title: 'Components/InlineContent',
   args: {
@@ -233,9 +236,6 @@ WithTruncation.args = {
   maxLines: 2,
   maxLinesSuffix: '...'
 };
-
-const lorum =
-  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est eu eleifend interdum. Vivamus egestas maximus elementum. Sed condimentum ligula justo, non sollicitudin lectus rutrum vel. Integer iaculis vitae nisl quis tincidunt. Sed quis dui vehicula, vehicula felis a, tempor leo. Fusce tincidunt, ante eget pretium efficitur, libero elit volutpat quam, sit amet porta tortor odio non ligula. Ut sed dolor eleifend massa auctor porttitor eget ut lectus. Vivamus elementum lorem mauris, eu luctus tortor posuere sit amet. Nunc a interdum metus.';
 
 // ADDED FOR TESTING PURPOSES, REMOVE BEFORE MERGE
 export const TextBoxVSInlineContent = args =>

--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.styles.js
@@ -21,10 +21,9 @@ export const base = theme => ({
   iconWidth: theme.spacer.xxl + theme.spacer.xs,
   iconHeight: theme.spacer.xxl + theme.spacer.xs,
   contentSpacing: theme.spacer.md,
-  marginBottom: theme.typography.body1.lineHeight / -10,
+  marginBottom: 0,
   textStyle: {
-    ...theme.typography.body1,
-    verticalAlign: 'bottom'
+    ...theme.typography.body1
   },
   maxLines: 1,
   justify: 'flex-start'

--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.test.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.test.js
@@ -113,8 +113,7 @@ describe('InlineContent', () => {
     await inlineContent.__updateSpyPromise;
     expect(context.theme.name).toBe('Test');
     expect(inlineContent.style.textStyle).toEqual({
-      ...context.theme.typography.body1,
-      verticalAlign: 'bottom'
+      ...context.theme.typography.body1
     });
   });
 


### PR DESCRIPTION
## Description

Sets marginBottom of InlineContent to 0 by default and adds a story comparing the InlineContent and TextBox for testing purposes.

## References

LUI-1493

## Testing

- Check added story `TextBoxVSInlineContent` and notice how the spacing between each line is consistent across the `textBox `and `InlineContent`
- Note the InlineContent is on the left and the textBox is on the right
- This story will be removed before merge and is only for testing purposes

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
