### PR TITLE
fix(InlineContent): uncomments accidental merged properties

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.stories.js
@@ -20,7 +20,6 @@ import lng from '@lightningjs/core';
 import { default as InlineContentComponent } from '.';
 import lightningbolt from '../../assets/images/ic_lightning_white_32.png';
 import { getHexColor } from '../../utils';
-import TextBox from '../TextBox';
 
 export default {
   title: 'Components/InlineContent',

--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.stories.js
@@ -22,16 +22,12 @@ import lightningbolt from '../../assets/images/ic_lightning_white_32.png';
 import { getHexColor } from '../../utils';
 import TextBox from '../TextBox';
 
-const lorum =
-  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est eu eleifend interdum. Vivamus egestas maximus elementum. Sed condimentum ligula justo, non sollicitudin lectus rutrum vel. Integer iaculis vitae nisl quis tincidunt. Sed quis dui vehicula, vehicula felis a, tempor leo. Fusce tincidunt, ante eget pretium efficitur, libero elit volutpat quam, sit amet porta tortor odio non ligula. Ut sed dolor eleifend massa auctor porttitor eget ut lectus. Vivamus elementum lorem mauris, eu luctus tortor posuere sit amet. Nunc a interdum metus.';
-
 export default {
   title: 'Components/InlineContent',
   args: {
     contentWrap: false,
     justify: 'center',
-    // Commented out for testing purposes. READD BEFORE MERGE
-    // contentProperties: { marginBottom: -4 } Commented out for testing purposes. READD BEFORE MERGE
+    contentProperties: { marginBottom: -4 },
     maxLines: 0,
     maxLinesSuffix: '..'
   },
@@ -235,37 +231,4 @@ WithTruncation.args = {
   contentWrap: true,
   maxLines: 2,
   maxLinesSuffix: '...'
-};
-
-// ADDED FOR TESTING PURPOSES, REMOVE BEFORE MERGE
-export const TextBoxVSInlineContent = args =>
-  class TextBoxVSInlineContent extends lng.Component {
-    static _template() {
-      return {
-        InlineContent: {
-          type: InlineContentComponent,
-          ...args,
-          w: 600,
-          content: lorum,
-          marquee: false,
-          hideOnLoad: false,
-          fixed: true
-        },
-        Textbox: {
-          type: TextBox,
-          fixed: true,
-          x: 601,
-          w: 600,
-          style: { textStyle: { maxLines: 3 }, offsetY: 0 },
-          marquee: false,
-          content: lorum,
-          hideOnLoad: false,
-          contentWrap: true
-        }
-      };
-    }
-  };
-TextBoxVSInlineContent.args = {
-  contentWrap: true,
-  maxLines: 3
 };


### PR DESCRIPTION
removes stories and uncomments properties that were accidentally merged

## Description

removes stories and uncomments properties that were accidentally merged in https://github.com/rdkcentral/Lightning-UI-Components/pull/516

## References

## Testing

Check that` InlineContentVsTextBox` story was removed and contentProperties is back in the InlineContent stories args

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
