### PR TITLE
fix(Textbox): stops flash on inlineContent change

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
@@ -147,30 +147,34 @@ export default class InlineContent extends Base {
     // perhaps have to wait until Lightning Flexboxes can emit a signal (like textures) when they've finished loading
     if (this.children.length) {
       setTimeout(() => {
+        debugger
+        this.stage.update()
         this.multiLineHeight = this.finalH;
+
         if (
           this.flex &&
           this.flex._layout &&
           this.flex._layout._lineLayouter &&
           this.flex._layout._lineLayouter._lines
         ) {
+
+
+          // only using this.flex._layout._lineLayouter._lines.length if maxLines is larger than the number of lines so we don't have a height too large
+          let multiplierLines = this.maxLines > this.flex._layout._lineLayouter._lines.length ? this.flex._layout._lineLayouter._lines.length : this.maxLines;
+
           this.multiLineHeight =
-            this.style.textStyle.lineHeight *
-            this.flex._layout._lineLayouter._lines.length;
-          this.h = this.multiLineHeight;
+            this.style.textStyle.lineHeight * multiplierLines;
 
           if (this._shouldTruncate) {
             this._renderMaxLines();
           }
 
-          this._notifyAncestors();
         } else {
           this._contentLoaded();
         }
       }, 10);
-    } else {
-      this._notifyAncestors();
-    }
+    } 
+    this._notifyAncestors();
   }
 
   _renderMaxLines() {

--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
@@ -147,8 +147,6 @@ export default class InlineContent extends Base {
     // perhaps have to wait until Lightning Flexboxes can emit a signal (like textures) when they've finished loading
     if (this.children.length) {
       setTimeout(() => {
-        debugger
-        this.stage.update()
         this.multiLineHeight = this.finalH;
 
         if (
@@ -168,13 +166,15 @@ export default class InlineContent extends Base {
           if (this._shouldTruncate) {
             this._renderMaxLines();
           }
+          this._notifyAncestors();
 
         } else {
           this._contentLoaded();
         }
-      }, 10);
+      }, 10); 
+    } else {
+        this._notifyAncestors();
     } 
-    this._notifyAncestors();
   }
 
   _renderMaxLines() {

--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
@@ -157,7 +157,8 @@ export default class InlineContent extends Base {
         ) {
           // only using this.flex._layout._lineLayouter._lines.length if maxLines is larger than the number of lines so we don't have a height too large
           const multiplierLines =
-            this.maxLines === undefined || this.maxLines > this.flex._layout._lineLayouter._lines.length
+            this.maxLines === undefined ||
+            this.maxLines > this.flex._layout._lineLayouter._lines.length
               ? this.flex._layout._lineLayouter._lines.length
               : this.maxLines;
 

--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
@@ -155,10 +155,11 @@ export default class InlineContent extends Base {
           this.flex._layout._lineLayouter &&
           this.flex._layout._lineLayouter._lines
         ) {
-
-
           // only using this.flex._layout._lineLayouter._lines.length if maxLines is larger than the number of lines so we don't have a height too large
-          let multiplierLines = this.maxLines > this.flex._layout._lineLayouter._lines.length ? this.flex._layout._lineLayouter._lines.length : this.maxLines;
+          let multiplierLines =
+            this.maxLines > this.flex._layout._lineLayouter._lines.length
+              ? this.flex._layout._lineLayouter._lines.length
+              : this.maxLines;
 
           this.multiLineHeight =
             this.style.textStyle.lineHeight * multiplierLines;
@@ -167,14 +168,13 @@ export default class InlineContent extends Base {
             this._renderMaxLines();
           }
           this._notifyAncestors();
-
         } else {
           this._contentLoaded();
         }
-      }, 10); 
+      }, 10);
     } else {
-        this._notifyAncestors();
-    } 
+      this._notifyAncestors();
+    }
   }
 
   _renderMaxLines() {

--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
@@ -157,7 +157,7 @@ export default class InlineContent extends Base {
         ) {
           // only using this.flex._layout._lineLayouter._lines.length if maxLines is larger than the number of lines so we don't have a height too large
           const multiplierLines =
-            this.maxLines > this.flex._layout._lineLayouter._lines.length
+            this.maxLines === undefined || this.maxLines > this.flex._layout._lineLayouter._lines.length
               ? this.flex._layout._lineLayouter._lines.length
               : this.maxLines;
 

--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
@@ -156,7 +156,7 @@ export default class InlineContent extends Base {
           this.flex._layout._lineLayouter._lines
         ) {
           // only using this.flex._layout._lineLayouter._lines.length if maxLines is larger than the number of lines so we don't have a height too large
-          let multiplierLines =
+          const multiplierLines =
             this.maxLines > this.flex._layout._lineLayouter._lines.length
               ? this.flex._layout._lineLayouter._lines.length
               : this.maxLines;

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
@@ -41,10 +41,10 @@ const lightningTextDefaults = Object.entries(
   };
 }, {});
 
-export default class TextBox extends Base {
+export default class TextBox extends InlineContent {
   static _template() {
     return {
-      alpha: 0.001
+      alpha: 0.001,
     };
   }
 
@@ -72,6 +72,7 @@ export default class TextBox extends Base {
   }
 
   _setDimensions(w, h) {
+    debugger
     let width = w;
     let height = h;
     if (!this._isInlineContent) {
@@ -144,7 +145,9 @@ export default class TextBox extends Base {
   }
 
   _updateInlineContent() {
-    this.patch({ Text: undefined });
+    this.patch({ Text: undefined});
+
+    const contentStyle = this._textStyleSet;
 
     const inlineContentPatch = InlineContent.properties.reduce(
       (acc, prop) => {
@@ -157,27 +160,28 @@ export default class TextBox extends Base {
       {
         style: {
           ...this.style,
-          textStyle: this._textStyleSet
+          textStyle: contentStyle
         }
       }
     );
 
-    if (this._textStyleSet.wordWrapWidth) {
-      inlineContentPatch.w = this._textStyleSet.wordWrapWidth;
+    inlineContentPatch.w = this.w;
+
+    if (contentStyle.wordWrapWidth) {
+      inlineContentPatch.w = contentStyle.wordWrapWidth;
       inlineContentPatch.rtt = true;
     }
-    if (this._textStyleSet.maxLines) {
-      inlineContentPatch.maxLines = this._textStyleSet.maxLines;
+    if (contentStyle.maxLines) {
+      inlineContentPatch.maxLines = contentStyle.maxLines;
     }
-    if (this._textStyleSet.maxLinesSuffix) {
-      inlineContentPatch.maxLinesSuffix = this._textStyleSet.maxLinesSuffix;
+    if (contentStyle.maxLinesSuffix) {
+      inlineContentPatch.maxLinesSuffix = contentStyle.maxLinesSuffix;
     }
 
     this.patch({
       alpha: 1,
       InlineContent: {
         type: InlineContent,
-        w: this.w,
         ...inlineContentPatch,
         signals: {
           loadedInlineContent: '_setDimensions'

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
@@ -41,7 +41,7 @@ const lightningTextDefaults = Object.entries(
   };
 }, {});
 
-export default class TextBox extends InlineContent {
+export default class TextBox extends Base {
   static _template() {
     return {
       alpha: 0.001,
@@ -72,7 +72,6 @@ export default class TextBox extends InlineContent {
   }
 
   _setDimensions(w, h) {
-    debugger
     let width = w;
     let height = h;
     if (!this._isInlineContent) {
@@ -145,7 +144,7 @@ export default class TextBox extends InlineContent {
   }
 
   _updateInlineContent() {
-    this.patch({ Text: undefined});
+    this.patch({ Text: undefined });
 
     const contentStyle = this._textStyleSet;
 
@@ -165,8 +164,6 @@ export default class TextBox extends InlineContent {
       }
     );
 
-    inlineContentPatch.w = this.w;
-
     if (contentStyle.wordWrapWidth) {
       inlineContentPatch.w = contentStyle.wordWrapWidth;
       inlineContentPatch.rtt = true;
@@ -182,6 +179,7 @@ export default class TextBox extends InlineContent {
       alpha: 1,
       InlineContent: {
         type: InlineContent,
+        w: this.w,
         ...inlineContentPatch,
         signals: {
           loadedInlineContent: '_setDimensions'

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.js
@@ -44,7 +44,7 @@ const lightningTextDefaults = Object.entries(
 export default class TextBox extends Base {
   static _template() {
     return {
-      alpha: 0.001,
+      alpha: 0.001
     };
   }
 

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.stories.js
@@ -32,7 +32,7 @@ const { args: inlineContentArgs, argTypes: inlineContentArgTypes } =
 const lorum =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est eu eleifend interdum. Vivamus egestas maximus elementum. Sed condimentum ligula justo, non sollicitudin lectus rutrum vel. Integer iaculis vitae nisl quis tincidunt. Sed quis dui vehicula, vehicula felis a, tempor leo. Fusce tincidunt, ante eget pretium efficitur, libero elit volutpat quam, sit amet porta tortor odio non ligula. Ut sed dolor eleifend massa auctor porttitor eget ut lectus. Vivamus elementum lorem mauris, eu luctus tortor posuere sit amet. Nunc a interdum metus.';
 
-export const Basic = (args ) =>
+export const Basic = args =>
   class Basic extends lng.Component {
     static _template() {
       return {
@@ -40,7 +40,12 @@ export const Basic = (args ) =>
           type: TextBox,
           fixed: true,
           w: 600,
-          style: { textStyle: { maxLines: args.maxLines, contentWrap: args.contentWrap} }
+          style: {
+            textStyle: {
+              maxLines: args.maxLines,
+              contentWrap: args.contentWrap
+            }
+          }
         }
       };
     }
@@ -53,7 +58,7 @@ Basic.args = {
   hideOnLoad: false,
   w: 600,
   maxLines: 3,
-  contentWrap: false 
+  contentWrap: false
 };
 
 Basic.argTypes = {
@@ -113,10 +118,10 @@ Basic.argTypes = {
     table: {
       defaultValue: { summary: false }
     }
-  },
+  }
 };
 
-export const WithInlineContentArray = (args) =>
+export const WithInlineContentArray = args =>
   class WithInlineContentArray extends lng.Component {
     static _template() {
       return {
@@ -149,9 +154,9 @@ export const WithInlineContentArray = (args) =>
             textStyle: {
               maxLines: args.maxLines,
               maxLinesSuffix: args.maxLinesSuffix,
-              contentWrap: args.contentWrap,
+              contentWrap: args.contentWrap
             }
-          },
+          }
         }
       };
     }
@@ -160,7 +165,7 @@ export const WithInlineContentArray = (args) =>
 WithInlineContentArray.args = inlineContentArgs;
 WithInlineContentArray.argTypes = inlineContentArgTypes;
 
-export const WithInlineContentString = (args) =>
+export const WithInlineContentString = args =>
   class WithInlineContentArray extends lng.Component {
     static _template() {
       return {
@@ -180,9 +185,9 @@ export const WithInlineContentString = (args) =>
             textStyle: {
               maxLines: args.maxLines,
               maxLinesSuffix: args.maxLinesSuffix,
-              contentWrap: args.contentWrap,
+              contentWrap: args.contentWrap
             }
-          },
+          }
         }
       };
     }
@@ -191,7 +196,7 @@ export const WithInlineContentString = (args) =>
 WithInlineContentString.args = inlineContentArgs;
 WithInlineContentString.argTypes = inlineContentArgTypes;
 
-export const WithInlineContentTruncation = (args) =>
+export const WithInlineContentTruncation = args =>
   class Basic extends lng.Component {
     static _template() {
       return {
@@ -226,11 +231,11 @@ export const WithInlineContentTruncation = (args) =>
             { badge: 'HD', title: 'HD' },
             { badge: 'SD', title: 'SD' },
             ', and this should truncate before going on to a third line.'
-          ],
+          ]
         }
       };
     }
   };
 
-  WithInlineContentTruncation.args = inlineContentArgs;
-  WithInlineContentTruncation.argTypes = inlineContentArgTypes;
+WithInlineContentTruncation.args = inlineContentArgs;
+WithInlineContentTruncation.argTypes = inlineContentArgTypes;

--- a/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/TextBox/TextBox.stories.js
@@ -32,7 +32,7 @@ const { args: inlineContentArgs, argTypes: inlineContentArgTypes } =
 const lorum =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est eu eleifend interdum. Vivamus egestas maximus elementum. Sed condimentum ligula justo, non sollicitudin lectus rutrum vel. Integer iaculis vitae nisl quis tincidunt. Sed quis dui vehicula, vehicula felis a, tempor leo. Fusce tincidunt, ante eget pretium efficitur, libero elit volutpat quam, sit amet porta tortor odio non ligula. Ut sed dolor eleifend massa auctor porttitor eget ut lectus. Vivamus elementum lorem mauris, eu luctus tortor posuere sit amet. Nunc a interdum metus.';
 
-export const Basic = () =>
+export const Basic = (args ) =>
   class Basic extends lng.Component {
     static _template() {
       return {
@@ -40,7 +40,7 @@ export const Basic = () =>
           type: TextBox,
           fixed: true,
           w: 600,
-          style: { textStyle: { maxLines: 3 } }
+          style: { textStyle: { maxLines: args.maxLines, contentWrap: args.contentWrap} }
         }
       };
     }
@@ -51,7 +51,9 @@ Basic.args = {
   marquee: false,
   fixed: true,
   hideOnLoad: false,
-  w: 600
+  w: 600,
+  maxLines: 3,
+  contentWrap: false 
 };
 
 Basic.argTypes = {
@@ -94,10 +96,27 @@ Basic.argTypes = {
     table: {
       defaultValue: { summary: 0 }
     }
-  }
+  },
+  maxLines: {
+    control: 'number',
+    description: 'maximum number of lines to render before truncation',
+    type: 'number',
+    table: {
+      defaultValue: { summary: 'undefined' }
+    }
+  },
+  contentWrap: {
+    control: 'boolean',
+    description:
+      'Determines whether the containing flexbox should wrap the content onto the next line',
+    type: 'boolean',
+    table: {
+      defaultValue: { summary: false }
+    }
+  },
 };
 
-export const WithInlineContentArray = () =>
+export const WithInlineContentArray = (args) =>
   class WithInlineContentArray extends lng.Component {
     static _template() {
       return {
@@ -125,7 +144,14 @@ export const WithInlineContentArray = () =>
             'for fun',
             { badge: 'HD', title: 'HD' },
             { badge: 'SD', title: 'SD' }
-          ]
+          ],
+          style: {
+            textStyle: {
+              maxLines: args.maxLines,
+              maxLinesSuffix: args.maxLinesSuffix,
+              contentWrap: args.contentWrap,
+            }
+          },
         }
       };
     }
@@ -134,7 +160,7 @@ export const WithInlineContentArray = () =>
 WithInlineContentArray.args = inlineContentArgs;
 WithInlineContentArray.argTypes = inlineContentArgTypes;
 
-export const WithInlineContentString = () =>
+export const WithInlineContentString = (args) =>
   class WithInlineContentArray extends lng.Component {
     static _template() {
       return {
@@ -149,7 +175,14 @@ export const WithInlineContentString = () =>
               fontStyle: 'italic',
               textColor: getHexColor('FF6194')
             }
-          }
+          },
+          style: {
+            textStyle: {
+              maxLines: args.maxLines,
+              maxLinesSuffix: args.maxLinesSuffix,
+              contentWrap: args.contentWrap,
+            }
+          },
         }
       };
     }
@@ -158,7 +191,7 @@ export const WithInlineContentString = () =>
 WithInlineContentString.args = inlineContentArgs;
 WithInlineContentString.argTypes = inlineContentArgTypes;
 
-export const WithInlineContentTruncation = () =>
+export const WithInlineContentTruncation = (args) =>
   class Basic extends lng.Component {
     static _template() {
       return {
@@ -167,8 +200,9 @@ export const WithInlineContentTruncation = () =>
           w: 500,
           style: {
             textStyle: {
-              maxLines: 2,
-              maxLinesSuffix: '...'
+              maxLines: args.maxLines,
+              maxLinesSuffix: args.maxLinesSuffix,
+              contentWrap: args.contentWrap
             }
           },
           content: [
@@ -193,8 +227,10 @@ export const WithInlineContentTruncation = () =>
             { badge: 'SD', title: 'SD' },
             ', and this should truncate before going on to a third line.'
           ],
-          contentWrap: true
         }
       };
     }
   };
+
+  WithInlineContentTruncation.args = inlineContentArgs;
+  WithInlineContentTruncation.argTypes = inlineContentArgTypes;


### PR DESCRIPTION
## Description

It was noticed that the TextBox would flash when loading. This would occur when the TextBox contained content that were of type `InlineContent` and any property changed. This was due to the number of lines in the flex container potentially being more than the maxLines within the `InlineContent`. It would then calculate the height based on this wrong number and send it back to the TextBox and flash the wrong number of lines. 

## References

LUI-1435

## Testing

- Check to make sure everything within both the `InlineContent` stories and `TextBox` stories renders as expected.
- Specifically, make sure that when changing the `maxLines` control, it works as expected and that there is no flashing of the component.

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [ ] all commented code has been removed
- [ ] any new console issues have been resolved
- [ ] code linter and formatter has been run
- [ ] test coverage meets repo requirements
- [ ] PR name matches the expected semantic-commit syntax
