### PR TITLE
fix(InlineContent): use custom styles for text element height

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
@@ -154,10 +154,13 @@ export default class InlineContent extends Base {
           this.flex._layout._lineLayouter &&
           this.flex._layout._lineLayouter._lines
         ) {
-          this.multiLineHeight =
-            this.style.textStyle.lineHeight *
-            this.flex._layout._lineLayouter._lines.length;
-          this.h = this.multiLineHeight;
+          let totalHeight = 0;
+          this.flex._layout._lineLayouter._lines.forEach(line => {
+            totalHeight += Object.entries(line.items).sort((a, b) => {
+              return b[1].h - a[1].h;
+            })[0][1].h;
+          });
+          this.multiLineHeight = totalHeight;
 
           if (this._shouldTruncate) {
             this._renderMaxLines();
@@ -288,9 +291,22 @@ export default class InlineContent extends Base {
     const negatedRightMargin = component.flexItem.marginRight * -1;
     let suffix;
     if (type === 'text') {
+      // We need to grab the current styling of the text to ensure that any
+      // custom styling is applied to the suffix
+      const { fontFace, fontSize, fontStyle, lineHeight, verticalAlign } =
+        component.text;
       suffix = this._createText(
         { flexItem: this.contentProperties },
-        `${content.trim()}${this.maxLinesSuffix}`
+        {
+          text: `${content.trim()}${this.maxLinesSuffix}`,
+          style: {
+            fontFace,
+            fontSize,
+            fontStyle,
+            lineHeight,
+            verticalAlign
+          }
+        }
       );
     } else {
       this.childList.add(component);

--- a/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
+++ b/packages/@lightningjs/ui-components/src/components/InlineContent/InlineContent.js
@@ -334,7 +334,10 @@ export default class InlineContent extends Base {
     return {
       ...base,
       y: this.textY !== undefined ? this.textY : this.style.textY,
-      h: this.textHeight,
+      h:
+        textOverrideStyles?.lineHeight ||
+        textOverrideStyles?.fontSize ||
+        this.textHeight,
       text: {
         ...this.style.textStyle,
         ...textOverrideStyles,


### PR DESCRIPTION
## Description

This PR ensures that any custom styles that are being added to specific pieces of text in InlineContent get properly applied to the height of the texture. Previously, the texture would be clipped because it was using the height that was applied to the entirety of the component and not the specific piece of text.

This also ensures that the height of each line in multiline scenarios has the height of the tallest text in that line, as well as that the suffix created when a line is truncated matches the intended styles.

## References

LUI-1520

## Testing

Replace the template of the InlineContent Basic story with the below:

```js
static _template() {
  return {
    Label: {
      w: 740,
      flex: { direction: 'row', justifyContent: 'center' },
      type: InlineContentComponent,
      content: [
        {
          text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Dictum fusce ut placerat orci nulla dignissim enim.',
          style: {
            fontSize: 60,
            fontStyle: 'Regular',
            lineHeight: 75
          }
        },
        {
          text: 'Sign Up',
          style: {
            fontSize: 80,
            fontStyle: 'Bold',
            lineHeight: 90
          }
        }
      ]
    }
  };
}
```

- [ ] Ensure that the overall InlineContent component has a height matching the greatest height of the individual textures in it (in this case: 90).
- [ ] Set `contentWrap` to true and verify the above for each line, as well as each line being properly positioned vertically based on that height.
- [ ] Set `maxLines` to 2. Verify that the final text and the ellipsis that is added when truncating the final line matches the style match each other and the styling from the text in its original setup. 

## Automation

This _shouldn't_ have any affect on any tests, unless there are any that were using custom styles.

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
