### PR TITLE
chore(Hyperlinks): links navigate to correct paths

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Button/Button.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Button/Button.mdx
@@ -32,7 +32,7 @@ https://github.com/rdkcentral/Lightning-UI-Components/blob/develop/packages/@lig
 
 ## Usage
 
-Used to convey an interactable portion of the interface, a button can present text, an icon, a checkbox, or both text and an icon or checkbox.It has support in all the modes.
+Used to convey an interactable portion of the interface, a button can present text, an icon, a checkbox, or both text and an icon or checkbox. It has support in all the modes.
 
 ```js
 import { Button } from '@lightningjs/ui-components';

--- a/packages/@lightningjs/ui-components/src/components/Card/CardRadio.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Card/CardRadio.mdx
@@ -28,12 +28,12 @@ This component is a variant of the `Card` component that includes multiple lines
 
 ## Source
 
-https://github.com/rdkcentral/Lightning-UI-Components/packages/@lightningjs/ui-components/src/components/CardRadio/CardRadio.js
+https://github.com/rdkcentral/Lightning-UI-Components/blob/develop/packages/%40lightningjs/ui-components/src/components/Card/CardRadio.js
 
 ## Usage
 
 `CardRadio` can display a title, subtitle, description and details
-`CardRadio` extends [CardTitle](?path=/docs/components-cardtitle--card-title)
+`CardRadio` extends [CardTitle](?path=/docs/components-card-cardtitle--docs)
 
 ```js
 import { CardRadio } from '@lightningjs/ui-components';
@@ -59,7 +59,7 @@ class Basic extends lng.Component {
 
 | name     | type             | required | default   | description                                                                                              |
 | -------- | ---------------- | -------- | --------- | -------------------------------------------------------------------------------------------------------- |
-| radio    | object           | false    | undefined | Object containing all properties supported in the [Radio component](?path=/docs/components-radio--radio) |
+| radio    | object           | false    | undefined | Object containing all properties supported in the [Radio component](?path=/docs/components-radio--docs) |
 | subtitle | string \| object | false    | undefined | The text to be displayed in the subtitle section of the card.                                            |
 
 ### Style Properties

--- a/packages/@lightningjs/ui-components/src/components/Column/Column.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Column/Column.mdx
@@ -29,7 +29,7 @@ Focus management and smooth scrolling for a list of vertically-oriented items.
 
 ## Source
 
-https://github.com/rdkcentral/Lightning-UI-Components/blob/develop/packages/@lightningjs/ui-components/src/components/Column/Column.js
+https://github.com/rdkcentral/Lightning-UI-Components/blob/develop/packages/%40lightningjs/ui-components/src/components/Column/Column.js
 
 ## Usage
 
@@ -56,7 +56,7 @@ class BasicExample extends lng.Component {
 }
 ```
 
-The `Column` component extends [FocusManager](?path=/docs/components-focusmanager--column-with-rows), so you need to make sure that `_getFocused` returns the `Column` component.
+The `Column` component extends [FocusManager](?path=/docs/components-focusmanager--docs), so you need to make sure that `_getFocused` returns the `Column` component.
 
 ### Column items with changing height
 
@@ -121,7 +121,7 @@ If both of those properties are enabled, `alwaysScroll` will take precedence ove
 
 ### Style Properties
 
-The Column component shares a few of the same style properties as the ones listed in NavigationManager. For a detailed description, please refer to style properties section in the [NavigationManager component](?path=/docs/components-navigationmanager--row)
+The Column component shares a few of the same style properties as the ones listed in NavigationManager. For a detailed description, please refer to style properties section in the [NavigationManager component](?path=/docs/components-navigationmanager--docs)
 
 scrollIndex: number
 itemSpacing: number
@@ -139,7 +139,7 @@ The `Column` component will utilize the following properties on each individual 
 
 ### Methods
 
-The Column component is a subclass of NavigationManager and FocusManager, so inherits all methods from those parent components. These shared methods are already documented in the NavigationManager and FocusManager documentation. For detailed descriptions of these methods, please refer to the methods section in the [NavigationManager](/?path=/docs/components-navigationmanager--row) and [FocusManager](/docs/components-focusmanager--column-with-rows) documentation.
+The Column component is a subclass of NavigationManager and FocusManager, so inherits all methods from those parent components. These shared methods are already documented in the NavigationManager and FocusManager documentation. For detailed descriptions of these methods, please refer to the methods section in the [NavigationManager](?path=/docs/components-navigationmanager--docs) and [FocusManager](?path=/docs/components-focusmanager--docs) documentation.
 
 #### onScreenEffect(): void
 

--- a/packages/@lightningjs/ui-components/src/components/Control/Control.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Control/Control.mdx
@@ -69,7 +69,7 @@ Optional flag for the `Control` element to collapse (hide the title) when `Contr
 
 ### Properties
 
-`Control` has the same properties as the ones listed in [Button](?path=/docs/lightning/ui-core-button--button) in addition to a couple listed below:
+`Control` has the same properties as the ones listed in [Button](?path=/docs/components-button--docs) in addition to a couple listed below:
 
 | name           | type    | required | default   | description                                                                          |
 | -------------- | ------- | -------- | --------- | ------------------------------------------------------------------------------------ |
@@ -79,7 +79,7 @@ Optional flag for the `Control` element to collapse (hide the title) when `Contr
 
 ### Style Properties
 
-`Control` contains the same style properties as [Button](?path=/docs/components-button--button) in additional to a couple other style properties listed below:
+`Control` contains the same style properties as [Button](?path=/docs/components-button--docs) in additional to a couple other style properties listed below:
 
 | name      | type   | description                         |
 | --------- | ------ | ----------------------------------- |

--- a/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.mdx
+++ b/packages/@lightningjs/ui-components/src/mixins/withLayout/withLayout.mdx
@@ -32,7 +32,7 @@ https://github.com/rdkcentral/Lightning-UI-Components/blob/develop/packages/@lig
 
 ## Usage
 
-Let's use an example to see how we can use `withLayout`. Let's say I have an a `Tile` component on screen that should be sized according the screen size:
+Let's use an example to see how we can use `withLayout`. Let's say I have a `Tile` component on screen that should be sized according the screen size:
 
 ```js
 import lng from '@lightningjs/core';

--- a/packages/@lightningjs/ui-components/src/mixins/withTags/withTags.mdx
+++ b/packages/@lightningjs/ui-components/src/mixins/withTags/withTags.mdx
@@ -51,4 +51,4 @@ class Example extends withTags(lng.Component) {
 ```
 
 This example will create two helpers `this._Item` and `this._Image` which will
-return `this.tag('Item')` and `this.tag('Item.Image')` repectively.
+return `this.tag('Item')` and `this.tag('Item.Image')` respectively.


### PR DESCRIPTION
## Description

Fixed broken links for a few docs in storybook and typos.

## References

See 
[LUI-1525](https://ccp.sys.comcast.net/browse/LUI-1525)
[LUI-1526](https://ccp.sys.comcast.net/browse/LUI-1526)
[LUI-1527](https://ccp.sys.comcast.net/browse/LUI-1527)
[LUI-1528](https://ccp.sys.comcast.net/browse/LUI-1528)
[LUI-1529](https://ccp.sys.comcast.net/browse/LUI-1529)

Inner source pr:
https://github.com/comcast-suite/lightning-ui/pull/2167


## Testing

- Navigate to changed links, click and observe they lead to their expected pages. 

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
