### PR TITLE
fix(KeyboardNumbers): move delete key up one row

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Keyboard/KeyboardNumbers.js
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/KeyboardNumbers.js
@@ -41,11 +41,11 @@ export default class KeyboardNumbers extends Keyboard {
         ['1', '2', '3'],
         ['4', '5', '6'],
         ['7', '8', '9'],
-        ['0'],
         [
+          '0',
           {
             title: 'Delete',
-            size: 'lg',
+            size: 'md',
             keyId: 'delete',
             announce: 'delete, button'
           }


### PR DESCRIPTION
## Description

Moves the Delete key up to be in the same row as the 0 key.

## References

N/A

## Testing

Ensure that the Delete key spans the width of two standard keys and is in the same row as the 0 key when the KeyboardNumbers story is set to use the dialpadExtended `defaultFormat`.

## Automation

N/A

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
