### PR TITLE
L UI 1270/content items throws error

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.js
+++ b/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.js
@@ -119,24 +119,22 @@ export default class ControlRow extends TitleRow {
     this._getMoreItems();
   }
 
-  _appendItemsAt(items, appendIndex) {
+  _appendItemsAt(items, appendIndex, removeSpacingIndex) {
     const itemsCopy = [...items];
 
-    console.log(itemsCopy)
-
-
-
-    // if (removeSpacingIndex != undefined || removeSpacingIndex >= 0) {
-    //   this.items[removeSpacingIndex].extraItemSpacing = undefined;
-    //   itemsCopy[itemsCopy.length - 1].extraItemSpacing =
-    //     this.extraItemSpacing == undefined
-    //       ? this.style.extraItemSpacing
-    //       : this.extraItemSpacing;
-    // }
+    if (removeSpacingIndex != undefined && removeSpacingIndex > 0) {
+      this.items[removeSpacingIndex].extraItemSpacing = undefined;
+      itemsCopy[itemsCopy.length - 1].extraItemSpacing =
+        this.extraItemSpacing == undefined
+          ? this.style.extraItemSpacing
+          : this.extraItemSpacing;
+    }
     this.appendItemsAt(itemsCopy, appendIndex);
   }
 
   addContentItems(items) {
+    const lastSelected = this.selectedIndex;
+
     const itemsToAdd = this._createContentItems(items);
     const addIndex = this._lastItemIndex + 1;
     this._appendItemsAt(itemsToAdd, addIndex, this._lastItemIndex);
@@ -145,6 +143,8 @@ export default class ControlRow extends TitleRow {
     if (this._contentItems) {
       this._contentItems = [...this.contentItems, ...itemsToAdd];
     }
+    this._updateContent();
+    this.selectedIndex = lastSelected;
 
     this.patch({
       stopLazyScrollIndex: this.leftControls.length + this.items.length - 1

--- a/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.js
+++ b/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.js
@@ -119,16 +119,20 @@ export default class ControlRow extends TitleRow {
     this._getMoreItems();
   }
 
-  _appendItemsAt(items, appendIndex, removeSpacingIndex) {
+  _appendItemsAt(items, appendIndex) {
     const itemsCopy = [...items];
 
-    if (removeSpacingIndex != undefined) {
-      this.items[removeSpacingIndex].extraItemSpacing = undefined;
-      itemsCopy[itemsCopy.length - 1].extraItemSpacing =
-        this.extraItemSpacing == undefined
-          ? this.style.extraItemSpacing
-          : this.extraItemSpacing;
-    }
+    console.log(itemsCopy)
+
+
+
+    // if (removeSpacingIndex != undefined || removeSpacingIndex >= 0) {
+    //   this.items[removeSpacingIndex].extraItemSpacing = undefined;
+    //   itemsCopy[itemsCopy.length - 1].extraItemSpacing =
+    //     this.extraItemSpacing == undefined
+    //       ? this.style.extraItemSpacing
+    //       : this.extraItemSpacing;
+    // }
     this.appendItemsAt(itemsCopy, appendIndex);
   }
 

--- a/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.js
+++ b/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.js
@@ -122,7 +122,7 @@ export default class ControlRow extends TitleRow {
   _appendItemsAt(items, appendIndex, removeSpacingIndex) {
     const itemsCopy = [...items];
 
-    if (removeSpacingIndex != undefined && removeSpacingIndex > 0) {
+    if (removeSpacingIndex != undefined && removeSpacingIndex >= 0) {
       this.items[removeSpacingIndex].extraItemSpacing = undefined;
       itemsCopy[itemsCopy.length - 1].extraItemSpacing =
         this.extraItemSpacing == undefined

--- a/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.stories.js
@@ -39,6 +39,7 @@ export default {
 };
 
 const createItems = (length, src, props = {}) => {
+  console.log(length, src, props = {})
   return Array.from({ length }).map((_, index) => ({
     type: Tile,
     artwork: {
@@ -82,6 +83,75 @@ export const Basic = () =>
       return this.tag('ControlRow');
     }
   };
+
+// export const Bug = () =>
+//   class Bug extends lng.Component {
+//     static _template() {
+//       return {
+//         ControlRow: {
+//           type: ControlRowComponent,
+//           leftControls: [],
+//           contentItems: [],
+//           rightControls: [],
+//           lazyLoadBuffer: 1
+//         }
+//       };
+//     }
+
+//     _construct() {
+//       setTimeout(() => {
+//         if (this._ControlRow) {
+//           this._ControlRow.addContentItems(
+//             createItems(
+//               3,
+//               'https://image.tmdb.org/t/p/w500/frwl2zBNAl5ZbFDJGoJv0mYo0rF.jpg'
+//             )
+//           );
+//         }
+//       }, 1500);
+//     }
+//     _getFocused() {
+//       return this.tag('ControlRow');
+//     }
+
+//     get _ControlRow() {
+//       return this.tag('ControlRow');
+//     }
+//   };
+
+export const Bug = () =>
+  class Bug extends lng.Component {
+    static _template() {
+      return {
+        ControlRow: {
+          type: ControlRowComponent,
+          leftControls: [],
+          contentItems: [],
+          rightControls: []
+        }
+      };
+    }
+
+    async _construct() {
+      // Ensure the component is fully initialized before adding items
+      await new Promise(resolve => setTimeout(resolve, 100));
+      this._ControlRow.addContentItems(
+        await createItems(
+          3,
+          'https://image.tmdb.org/t/p/w500/frwl2zBNAl5ZbFDJGoJv0mYo0rF.jpg'
+        )
+      );
+    }
+
+    _getFocused() {
+      return this.tag('ControlRow');
+    }
+
+    get _ControlRow() {
+      return this.tag('ControlRow');
+    }
+  };
+
 
 export const LazyLoading = () =>
   class LazyLoading extends lng.Component {

--- a/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.stories.js
@@ -84,41 +84,6 @@ export const Basic = () =>
     }
   };
 
-// export const Bug = () =>
-//   class Bug extends lng.Component {
-//     static _template() {
-//       return {
-//         ControlRow: {
-//           type: ControlRowComponent,
-//           leftControls: [],
-//           contentItems: [],
-//           rightControls: [],
-//           lazyLoadBuffer: 1
-//         }
-//       };
-//     }
-
-//     _construct() {
-//       setTimeout(() => {
-//         if (this._ControlRow) {
-//           this._ControlRow.addContentItems(
-//             createItems(
-//               3,
-//               'https://image.tmdb.org/t/p/w500/frwl2zBNAl5ZbFDJGoJv0mYo0rF.jpg'
-//             )
-//           );
-//         }
-//       }, 1500);
-//     }
-//     _getFocused() {
-//       return this.tag('ControlRow');
-//     }
-
-//     get _ControlRow() {
-//       return this.tag('ControlRow');
-//     }
-//   };
-
 export const Bug = () =>
   class Bug extends lng.Component {
     static _template() {
@@ -127,22 +92,24 @@ export const Bug = () =>
           type: ControlRowComponent,
           leftControls: [],
           contentItems: [],
-          rightControls: []
+          rightControls: [],
+          lazyLoadBuffer: 1
         }
       };
     }
 
-    async _construct() {
-      // Ensure the component is fully initialized before adding items
-      await new Promise(resolve => setTimeout(resolve, 100));
-      this._ControlRow.addContentItems(
-        await createItems(
-          3,
-          'https://image.tmdb.org/t/p/w500/frwl2zBNAl5ZbFDJGoJv0mYo0rF.jpg'
-        )
-      );
+    _construct() {
+      setTimeout(() => {
+        if (this._ControlRow) {
+          this._ControlRow.addContentItems(
+            createItems(
+              3,
+              'https://image.tmdb.org/t/p/w500/frwl2zBNAl5ZbFDJGoJv0mYo0rF.jpg'
+            )
+          );
+        }
+      }, 1500);
     }
-
     _getFocused() {
       return this.tag('ControlRow');
     }
@@ -151,7 +118,6 @@ export const Bug = () =>
       return this.tag('ControlRow');
     }
   };
-
 
 export const LazyLoading = () =>
   class LazyLoading extends lng.Component {

--- a/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.stories.js
@@ -39,7 +39,6 @@ export default {
 };
 
 const createItems = (length, src, props = {}) => {
-  console.log(length, src, props = {})
   return Array.from({ length }).map((_, index) => ({
     type: Tile,
     artwork: {


### PR DESCRIPTION
## Description

Adding contentItems to an empty ControlRow throws an error

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

- Go to Content Row - Bug 
- Open the console to see that error no longer exists 
- Items should be showing in the contentRow as well


## Checklist

- [X] all commented code has been removed
- [X] any new console issues have been resolved
- [X] code linter and formatter has been run
- [X] test coverage meets repo requirements
- [X] PR name matches the expected semantic-commit syntax
