### PR TITLE
fix(ControlRow): allow items to be added if contentItems is empty

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.js
+++ b/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.js
@@ -122,7 +122,7 @@ export default class ControlRow extends TitleRow {
   _appendItemsAt(items, appendIndex, removeSpacingIndex) {
     const itemsCopy = [...items];
 
-    if (removeSpacingIndex != undefined) {
+    if (removeSpacingIndex != undefined && removeSpacingIndex >= 0) {
       this.items[removeSpacingIndex].extraItemSpacing = undefined;
       itemsCopy[itemsCopy.length - 1].extraItemSpacing =
         this.extraItemSpacing == undefined
@@ -133,6 +133,7 @@ export default class ControlRow extends TitleRow {
   }
 
   addContentItems(items) {
+    const lastSelected = this.selectedIndex;
     const itemsToAdd = this._createContentItems(items);
     const addIndex = this._lastItemIndex + 1;
     this._appendItemsAt(itemsToAdd, addIndex, this._lastItemIndex);
@@ -141,6 +142,9 @@ export default class ControlRow extends TitleRow {
     if (this._contentItems) {
       this._contentItems = [...this.contentItems, ...itemsToAdd];
     }
+
+    this._updateContent();
+    this.selectedIndex = lastSelected;
 
     this.patch({
       stopLazyScrollIndex: this.leftControls.length + this.items.length - 1

--- a/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.stories.js
@@ -83,6 +83,42 @@ export const Basic = () =>
     }
   };
 
+export const Bug = () =>
+  class Bug extends lng.Component {
+    static _template() {
+      return {
+        ControlRow: {
+          type: ControlRowComponent,
+          leftControls: [],
+          contentItems: [],
+          rightControls: [],
+          lazyLoadBuffer: 1
+        }
+      };
+    }
+
+    _construct() {
+      setTimeout(() => {
+        if (this._ControlRow) {
+          this._ControlRow.addContentItems(
+            createItems(
+              3,
+              'https://image.tmdb.org/t/p/w500/frwl2zBNAl5ZbFDJGoJv0mYo0rF.jpg'
+            )
+          );
+        }
+      }, 1500);
+    }
+    _getFocused() {
+      return this.tag('ControlRow');
+    }
+
+    get _ControlRow() {
+      return this.tag('ControlRow');
+    }
+  };
+
+
 export const LazyLoading = () =>
   class LazyLoading extends lng.Component {
     static _template() {

--- a/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.stories.js
@@ -118,7 +118,6 @@ export const Bug = () =>
     }
   };
 
-
 export const LazyLoading = () =>
   class LazyLoading extends lng.Component {
     static _template() {

--- a/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ControlRow/ControlRow.stories.js
@@ -83,41 +83,6 @@ export const Basic = () =>
     }
   };
 
-export const Bug = () =>
-  class Bug extends lng.Component {
-    static _template() {
-      return {
-        ControlRow: {
-          type: ControlRowComponent,
-          leftControls: [],
-          contentItems: [],
-          rightControls: [],
-          lazyLoadBuffer: 1
-        }
-      };
-    }
-
-    _construct() {
-      setTimeout(() => {
-        if (this._ControlRow) {
-          this._ControlRow.addContentItems(
-            createItems(
-              3,
-              'https://image.tmdb.org/t/p/w500/frwl2zBNAl5ZbFDJGoJv0mYo0rF.jpg'
-            )
-          );
-        }
-      }, 1500);
-    }
-    _getFocused() {
-      return this.tag('ControlRow');
-    }
-
-    get _ControlRow() {
-      return this.tag('ControlRow');
-    }
-  };
-
 export const LazyLoading = () =>
   class LazyLoading extends lng.Component {
     static _template() {


### PR DESCRIPTION
## Description

Adding contentItems to an empty ControlRow throws an error

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

- Paste Below code inside of `ControlRow.stories` to test: 
```
export const Bug = () =>
  class Bug extends lng.Component {
    static _template() {
      return {
        ControlRow: {
          type: ControlRowComponent,
          leftControls: [],
          contentItems: [],
          rightControls: [],
          lazyLoadBuffer: 1
        }
      };
    }

    _construct() {
      setTimeout(() => {
        if (this._ControlRow) {
          this._ControlRow.addContentItems(
            createItems(
              3,
              'https://image.tmdb.org/t/p/w500/frwl2zBNAl5ZbFDJGoJv0mYo0rF.jpg'
            )
          );
        }
      }, 1500);
    }
    _getFocused() {
      return this.tag('ControlRow');
    }

    get _ControlRow() {
      return this.tag('ControlRow');
    }
  };
```
- Open the console to see that error no longer exists 
- Items should be showing in the contentRow as expected


## Checklist

- [X] all commented code has been removed
- [X] any new console issues have been resolved
- [X] code linter and formatter has been run
- [X] test coverage meets repo requirements
- [X] PR name matches the expected semantic-commit syntax
