### PR TITLE
fix(metadataCardContent): Provider covers text after decrementing value

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.js
@@ -21,7 +21,6 @@ import TextBox from '../TextBox';
 import Provider from '../Provider';
 import FadeShader from '../../shaders/FadeShader';
 import * as styles from './MetadataCardContent.styles';
-import debounce from 'debounce';
 
 export default class MetadataCardContent extends MetadataBase {
   static get __componentName() {

--- a/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.js
@@ -108,11 +108,6 @@ export default class MetadataCardContent extends MetadataBase {
     ];
   }
 
-  _init() {
-    this._debouncedUpdateDetails = debounce(() => this._updateDetails(), 100);
-    super._init();
-  }
-
   _setDetails(details) {
     if (details) {
       this._detailsPromise = new Promise(resolve => {
@@ -239,7 +234,7 @@ export default class MetadataCardContent extends MetadataBase {
 
     this._Provider.x = this._DetailsWrapper.w - this._providerW;
     this._Provider.y = this._DetailsWrapper.h - this._providerH;
-    this._debouncedUpdateDetails();
+    this._updateDetails();
   }
 
   get _textW() {

--- a/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.js
@@ -219,6 +219,7 @@ export default class MetadataCardContent extends MetadataBase {
   _resolveProvider() {
     this._providerPromiseResolver && this._providerPromiseResolver();
     this._updatePositions();
+    this._updateDetails();
   }
 
   _updatePositions() {
@@ -233,7 +234,6 @@ export default class MetadataCardContent extends MetadataBase {
 
     this._Provider.x = this._DetailsWrapper.w - this._providerW;
     this._Provider.y = this._DetailsWrapper.h - this._providerH;
-    this._updateDetails();
   }
 
   get _textW() {

--- a/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.js
@@ -21,7 +21,7 @@ import TextBox from '../TextBox';
 import Provider from '../Provider';
 import FadeShader from '../../shaders/FadeShader';
 import * as styles from './MetadataCardContent.styles';
-import { debounce } from 'lodash';
+import debounce from 'debounce';
 
 export default class MetadataCardContent extends MetadataBase {
   static get __componentName() {
@@ -149,6 +149,7 @@ export default class MetadataCardContent extends MetadataBase {
     this._updateTitle();
     this._updateDescription();
     this._updateDescriptionDetails();
+    this._updateDetails();
   }
 
   _updateDescription() {

--- a/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.js
@@ -21,6 +21,7 @@ import TextBox from '../TextBox';
 import Provider from '../Provider';
 import FadeShader from '../../shaders/FadeShader';
 import * as styles from './MetadataCardContent.styles';
+import { debounce } from 'lodash';
 
 export default class MetadataCardContent extends MetadataBase {
   static get __componentName() {
@@ -107,6 +108,11 @@ export default class MetadataCardContent extends MetadataBase {
     ];
   }
 
+  _init() {
+    this._debouncedUpdateDetails = debounce(() => this._updateDetails(), 100);
+    super._init();
+  }
+
   _setDetails(details) {
     if (details) {
       this._detailsPromise = new Promise(resolve => {
@@ -143,7 +149,6 @@ export default class MetadataCardContent extends MetadataBase {
     this._updateTitle();
     this._updateDescription();
     this._updateDescriptionDetails();
-    this._updateDetails();
   }
 
   _updateDescription() {
@@ -233,6 +238,7 @@ export default class MetadataCardContent extends MetadataBase {
 
     this._Provider.x = this._DetailsWrapper.w - this._providerW;
     this._Provider.y = this._DetailsWrapper.h - this._providerH;
+    this._debouncedUpdateDetails();
   }
 
   get _textW() {


### PR DESCRIPTION
## Description

It has been observed in Storybook on the metadataCardContent Component, that when a provider count is increased to max 9 value and then decreased to a single provider, the effects are still masked over the text. 

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

## Testing

1. Go to metadataCardContent 
2. Change number of visible providers to 9 
3. When number of visible providers is 9 Detail text should be masked
4. Change number of visible providers to 1
5. When number of visible providers is 1 Detail text should not be masked. 

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [X] all commented code has been removed
- [X] any new console issues have been resolved
- [X] code linter and formatter has been run
- [X] test coverage meets repo requirements
- [X] PR name matches the expected semantic-commit syntax
