### PR TITLE
feat(ScrollWrapper): add signals for button press at top and bottom of content

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.d.ts
+++ b/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.d.ts
@@ -75,6 +75,22 @@ declare namespace ScrollWrapper {
      */
     showScrollBar?: boolean;
   }
+
+  export interface TypeConfig extends lng.Component.TypeConfig {
+    SignalMapType: SignalMap;
+  }
+
+  export type SignalMap = {
+    /**
+     * emitted when user is at the top of the content and presses up again
+     */
+    onUpAtTop(): void;
+
+    /**
+     * emitted when user is at the bottom of the content and presses bottom again
+     */
+    onDownAtBottom(): void;
+  };
 }
 
 declare class ScrollWrapper<

--- a/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.js
+++ b/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.js
@@ -247,6 +247,8 @@ export default class ScrollWrapper extends Base {
         this.fireAncestors('$scrollChanged', 'endDown', this);
         this._updateFadeContainer();
       }
+    } else {
+      this.signal('onDownAtBottom');
     }
   }
 
@@ -278,6 +280,8 @@ export default class ScrollWrapper extends Base {
         this._isEndContentVisible = false;
         this._updateFadeContainer();
       }
+    } else {
+      this.signal('onUpAtTop');
     }
   }
 

--- a/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.mdx
+++ b/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.mdx
@@ -136,3 +136,13 @@ Resets the `y` value of both the content and the scroll bar.
 #### $scrollChanged('endUp'|'endDown', this)
 
 Event fired via `fireAncestors`, is triggered when scroll reaches the top or bottom of the scroll boundaries.
+
+### Signals
+
+#### onUpAtTop
+
+Fired when user is at the top of the content within the ScrollWrapper and presses up again.
+
+#### onDownAtBottom
+
+Fired when user is at the bottom of the content within the ScrollWrapper and presses down again.

--- a/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.stories.js
@@ -114,7 +114,9 @@ export const Basic = args =>
           w: 796,
           content: terms,
           signals: {
-            scrollChanged: true
+            scrollChanged: true,
+            onUpAtTop: '_handleUpAtTop',
+            onDownAtBottom: '_handleDownAtBottom'
           }
         }
       };
@@ -122,6 +124,14 @@ export const Basic = args =>
 
     $scrollChanged(type) {
       args.scrollChanged && args.scrollChanged(type);
+    }
+
+    _handleUpAtTop() {
+      console.log('TOP');
+    }
+
+    _handleDownAtBottom() {
+      console.log('BOTTOM');
     }
   };
 

--- a/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.stories.js
@@ -114,9 +114,7 @@ export const Basic = args =>
           w: 796,
           content: terms,
           signals: {
-            scrollChanged: true,
-            onUpAtTop: '_handleUpAtTop',
-            onDownAtBottom: '_handleDownAtBottom'
+            scrollChanged: true
           }
         }
       };
@@ -124,14 +122,6 @@ export const Basic = args =>
 
     $scrollChanged(type) {
       args.scrollChanged && args.scrollChanged(type);
-    }
-
-    _handleUpAtTop() {
-      console.log('TOP');
-    }
-
-    _handleDownAtBottom() {
-      console.log('BOTTOM');
     }
   };
 

--- a/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.test.js
+++ b/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.test.js
@@ -252,6 +252,27 @@ describe('ScrollWrapper', () => {
     );
   });
 
+  it('should fire a signal when pressing Up when already at the top of the scroll container', () => {
+    jest.spyOn(scrollWrapper, 'signal');
+    expect(scrollWrapper.signal).not.toHaveBeenCalled();
+
+    testRenderer.keyPress('Up');
+    testRenderer.update();
+    expect(scrollWrapper.signal).toHaveBeenCalledWith('onUpAtTop');
+  });
+
+  it('should fire a signal when pressing Down when already at the bottom of the scroll container', () => {
+    jest.spyOn(scrollWrapper, 'signal');
+    expect(scrollWrapper.signal).not.toHaveBeenCalled();
+
+    // Simulate scrolling to the bottom and then some
+    for (let i = 0; i < 50; i++) {
+      testRenderer.keyPress('Down');
+      testRenderer.update();
+    }
+    expect(scrollWrapper.signal).toHaveBeenCalledWith('onDownAtBottom');
+  });
+
   it('should scroll up by the scroll step', () => {
     scrollWrapper.scrollStep = 100;
     testRenderer.keyPress('Down');


### PR DESCRIPTION
## Description

Adds signal for Up/Down press when user is at top/bottom of ScrollWrapper container to allow for navigation if component is nested.

## References

LUI-1563

## Testing

Add the following code to the ScrollWrapper Basic story:

```js
// In the template's signals:
            onUpAtTop: '_handleUpAtTop',
            onDownAtBottom: '_handleDownAtBottom'

// As functions within the Basic class:
    _handleUpAtTop() {
      console.log('TOP');
    }

    _handleDownAtBottom() {
      console.log('BOTTOM');
    }
```

Open up the console and ensure that "TOP" and "BOTTOM" print when you are at the top and press Up or bottom and press Down.

## Automation

N/A

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
