### PR TITLE
fix(MetadataCardContent): expose subtitle property

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.test.js
+++ b/packages/@lightningjs/ui-components/src/components/CardContent/CardContent.test.js
@@ -46,6 +46,7 @@ describe('CardContent', () => {
 
   it('sets the announce string to the metadata text from both the metadata component on the right and the tile on the left', () => {
     const title = 'Title';
+    const subtitle = 'Subtitle';
     const description = 'Description';
     const descriptionDetails = 'Description Details';
     const details = 'Details';
@@ -60,6 +61,7 @@ describe('CardContent', () => {
     cardContent.patch({
       metadata: {
         title,
+        subtitle,
         description,
         descriptionDetails,
         details,
@@ -75,6 +77,7 @@ describe('CardContent', () => {
     expect(cardContent.announce).toEqual([
       [
         title,
+        subtitle,
         description,
         descriptionDetails,
         details,

--- a/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.js
@@ -212,7 +212,7 @@ class MetadataBase extends Base {
       marquee: this.marquee,
       style: {
         textStyle: {
-          ...this.style.descriptionTextStyle,
+          ...this.style.subtitleTextStyle,
           maxLines: 1,
           wordWrap: true,
           wordWrapWidth: this._Text.w

--- a/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.mdx
+++ b/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.mdx
@@ -77,7 +77,6 @@ class Example extends lng.Component {
 
 | name         | type           | required             | default   | description                                  |
 | ------------ | -------------- | -------------------- | --------- | -------------------------------------------- |
-| subtitle     | string         | false                | undefined | subtitle text                                |
 | description  | string         | false                | undefined | third line or description of the content     |
 | details      | inline content | false                | undefined | relevant content data in the middle          |
 | logo         | string         | false                | undefined | logo to display at bottom of component       |
@@ -85,6 +84,7 @@ class Example extends lng.Component {
 | logoPosition | string         | false                | 'right'   | which side to place logo (`right` or `left`) |
 | logoTitle    | string         | true (if using logo) | undefined | title of logo to use for announcer           |
 | logoWidth    | number         | true (if using logo) | undefined | width of logo                                |
+| subtitle     | string         | false                | undefined | subtitle text                                |
 | title        | string         | false                | undefined | first line or headline of the content        |
 
 ### Style Properties
@@ -97,6 +97,7 @@ class Example extends lng.Component {
 | logoHeight           | number           | height for logo                                                 |
 | logoPadding          | number           | spacing between logo and secondLine                             |
 | logoWidth            | number           | width for logo                                                  |
+| subtitleTextStyle    | string \| object | text style for subtitle                                         |
 | titleTextStyle       | string \| object | text style for title                                            |
 
 ### Methods

--- a/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.styles.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataBase/MetadataBase.styles.js
@@ -23,6 +23,7 @@ export const base = theme => ({
   logoHeight: theme.typography.body3.lineHeight,
   logoPadding: theme.spacer.lg,
   detailsTextStyle: theme.typography.body3,
+  subtitleTextStyle: theme.typography.body3,
   titleTextStyle: { ...theme.typography.headline1, maxLines: 1 },
   marqueeSync: true,
   alpha: theme.alpha.primary
@@ -38,6 +39,7 @@ export const mode = theme => ({
 export const tone = theme => ({
   neutral: {
     titleTextStyle: { textColor: theme.color.textNeutral },
+    subtitleTextStyle: { textColor: theme.color.textNeutralSecondary },
     detailsTextStyle: { textColor: theme.color.textNeutral },
     descriptionTextStyle: { textColor: theme.color.textNeutralSecondary },
     mode: {
@@ -52,11 +54,13 @@ export const tone = theme => ({
   },
   inverse: {
     titleTextStyle: { textColor: theme.color.textInverse },
+    subtitleTextStyle: { textColor: theme.color.textInverseSecondary },
     detailsTextStyle: { textColor: theme.color.textInverse },
     descriptionTextStyle: { textColor: theme.color.textInverseSecondary },
     mode: {
       disabled: {
         titleTextStyle: { textColor: theme.color.textNeutralDisabled },
+        subtitleTextStyle: { textColor: theme.color.textNeutralDisabled },
         detailsTextStyle: { textColor: theme.color.textNeutralDisabled },
         descriptionTextStyle: {
           textColor: theme.color.textNeutralDisabled
@@ -66,6 +70,7 @@ export const tone = theme => ({
   },
   brand: {
     titleTextStyle: { textColor: theme.color.textNeutral },
+    subtitleTextStyle: { textColor: theme.color.textNeutralSecondary },
     detailsTextStyle: { textColor: theme.color.textNeutral },
     descriptionTextStyle: { textColor: theme.color.textNeutralSecondary },
     mode: {

--- a/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.js
@@ -38,6 +38,9 @@ export default class MetadataCardContent extends MetadataBase {
         Title: {
           type: TextBox
         },
+        Subtitle: {
+          type: TextBox
+        },
         Description: {
           type: TextBox
         },
@@ -72,6 +75,7 @@ export default class MetadataCardContent extends MetadataBase {
       'descriptionDetails',
       'details',
       'provider',
+      'subtitle',
       'title'
     ];
   }
@@ -82,6 +86,10 @@ export default class MetadataCardContent extends MetadataBase {
       {
         name: 'Title',
         path: 'Text.Title'
+      },
+      {
+        name: 'Subtitle',
+        path: 'Text.Subtitle'
       },
       {
         name: 'Description',
@@ -141,9 +149,35 @@ export default class MetadataCardContent extends MetadataBase {
   _updateLines() {
     this._Text.w = this.w;
     this._updateTitle();
+    this._updateSubtitle();
     this._updateDescription();
     this._updateDescriptionDetails();
     this._updateDetails();
+  }
+
+  _updateSubtitle() {
+    if (!this.subtitle && !this._Subtitle) {
+      return;
+    }
+
+    if (!this._Subtitle) {
+      this._Text.childList.addAt({
+        ref: 'Subtitle',
+        type: TextBox
+      });
+    }
+
+    this._Subtitle.patch({
+      content: this.subtitle,
+      style: {
+        textStyle: {
+          ...this.style.subtitleTextStyle,
+          maxLines: 1,
+          wordWrap: true,
+          wordWrapWidth: this._Text.w
+        }
+      }
+    });
   }
 
   _updateDescription() {
@@ -264,6 +298,7 @@ export default class MetadataCardContent extends MetadataBase {
     return (
       this._announce || [
         this._Title && this._Title.announce,
+        this._Subtitle && this._Subtitle.announce,
         this._Description && this._Description.announce,
         this._DescriptionDetails && this._DescriptionDetails.announce,
         this._Details && this._Details.announce,

--- a/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.mdx
+++ b/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.mdx
@@ -43,6 +43,7 @@ class Basic extends lng.Component {
         w: 600,
         h: 250,
         title: 'Title',
+        subtitle: 'Subtitle',
         description: 'Description',
         details: 'Details',
         provider: {
@@ -66,6 +67,7 @@ class Basic extends lng.Component {
 | descriptionDetails | string                                            | false    | undefined | details text directly below description                                               |
 | details            | string                                            | false    | undefined | details text at bottom left of component                                              |
 | provider           | [Provider](?path=/docs/components-provider--docs) | false    | undefined | an object of [Provider](?path=/docs/components-provider--docs) properties to patch in |
+| subtitle           | string                                            | false    | undefined | subtitle text                                                                         |
 
 ### Style Properties
 
@@ -74,5 +76,6 @@ class Basic extends lng.Component {
 | detailsTextStyle        | string \| object | text style for details                                                                  |
 | descriptionDetailsStyle | object           | style for description details                                                           |
 | providerStyle           | object           | style properties to pass along to the [Provider](?path=/docs/components-provider--docs) |
+| subtitleTextStyle       | string \| object | text style for subtitle                                                                 |
 
 ### Methods

--- a/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.stories.js
@@ -46,8 +46,9 @@ const descriptionSample =
 
 MetadataCardContent.args = {
   w: 600,
-  h: 250,
+  h: 300,
   title: 'Title',
+  subtitle: 'Subtitle',
   description: descriptionSample,
   descriptionDetails: [
     '94%',
@@ -93,9 +94,17 @@ MetadataCardContent.argTypes = {
       type: { summary: 'string' }
     }
   },
+  subtitle: {
+    control: 'text',
+    description: 'Subtitle text below title',
+    table: {
+      defaultValue: { summary: 'undefined' },
+      type: { summary: 'string' }
+    }
+  },
   description: {
     control: 'text',
-    description: 'Description text directly below title',
+    description: 'Description text below subtitle',
     table: {
       defaultValue: { summary: 'undefined' },
       type: { summary: 'string' }

--- a/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.test.js
+++ b/packages/@lightningjs/ui-components/src/components/MetadataCardContent/MetadataCardContent.test.js
@@ -50,12 +50,14 @@ describe('MetadataCardContent', () => {
 
   it('sets the announce string to the appropriate text content status', () => {
     const title = 'Title';
+    const subtitle = 'Subtitle';
     const description = 'Description';
     const descriptionDetails = 'Description Details';
     const details = 'Details';
     const provider = { providers: [{ icon: 'test.png', announce: 'test' }] };
     metadataCardContent.patch({
       title,
+      subtitle,
       description,
       descriptionDetails,
       details,
@@ -64,6 +66,7 @@ describe('MetadataCardContent', () => {
     testRenderer.forceAllUpdates();
     expect(metadataCardContent.announce).toEqual([
       title,
+      subtitle,
       description,
       descriptionDetails,
       details,
@@ -84,6 +87,14 @@ describe('MetadataCardContent', () => {
     metadataCardContent.title = title;
     await metadataCardContent.__updateSpyPromise;
     expect(metadataCardContent._Title.content).toBe(title);
+  });
+
+  it('updates the subtitle', async () => {
+    const subtitle = 'subtitle text';
+    expect(metadataCardContent.subtitle).toBe(undefined);
+    metadataCardContent.subtitle = subtitle;
+    await metadataCardContent.__updateSpyPromise;
+    expect(metadataCardContent._Subtitle.content).toBe(subtitle);
   });
 
   it('updates the description', async () => {

--- a/packages/@lightningjs/ui-components/src/components/MetadataCardContent/__snapshots__/MetadataCardContent.test.js.snap
+++ b/packages/@lightningjs/ui-components/src/components/MetadataCardContent/__snapshots__/MetadataCardContent.test.js.snap
@@ -102,7 +102,7 @@ exports[`MetadataCardContent renders 1`] = `
                   "attached": true,
                   "boundsMargin": null,
                   "children": {
-                    "Element-13": {
+                    "Element-14": {
                       "active": false,
                       "alpha": 1,
                       "attached": true,
@@ -137,7 +137,7 @@ exports[`MetadataCardContent renders 1`] = `
                       "y": 0,
                       "zIndex": 0,
                     },
-                    "Element-14": {
+                    "Element-15": {
                       "active": false,
                       "alpha": 1,
                       "attached": true,
@@ -172,7 +172,7 @@ exports[`MetadataCardContent renders 1`] = `
                       "y": 0,
                       "zIndex": 0,
                     },
-                    "Element-15": {
+                    "Element-16": {
                       "active": false,
                       "alpha": 1,
                       "attached": true,
@@ -207,7 +207,7 @@ exports[`MetadataCardContent renders 1`] = `
                       "y": 0,
                       "zIndex": 0,
                     },
-                    "Element-16": {
+                    "Element-17": {
                       "active": false,
                       "alpha": 1,
                       "attached": true,
@@ -576,6 +576,44 @@ exports[`MetadataCardContent renders 1`] = `
           "w": 0,
           "x": 0,
           "y": 5,
+          "zIndex": 0,
+        },
+        "Subtitle": {
+          "active": false,
+          "alpha": 0.001,
+          "attached": true,
+          "boundsMargin": null,
+          "clipping": false,
+          "color": 4294967295,
+          "enabled": true,
+          "flex": false,
+          "flexItem": true,
+          "h": 0,
+          "hasFinalFocus": false,
+          "hasFocus": false,
+          "isComponent": true,
+          "mount": 0,
+          "mountX": 0,
+          "mountY": 0,
+          "pivot": 0.5,
+          "pivotX": 0.5,
+          "pivotY": 0.5,
+          "ref": "Subtitle",
+          "renderOfScreen": undefined,
+          "renderToTexture": false,
+          "scale": 1,
+          "scaleX": 1,
+          "scaleY": 1,
+          "state": "",
+          "tag": [Function],
+          "tags": [
+            "Subtitle",
+          ],
+          "type": "TextBox",
+          "visible": true,
+          "w": 0,
+          "x": 0,
+          "y": 0,
           "zIndex": 0,
         },
         "Title": {


### PR DESCRIPTION
## Description

Exposes the `subtitle` property that exists in MetadataBase in MetadataCardContent.

## References
LUI-1574

## Testing

Ensure that adding a subtitle in the MetadataCardContent story adds the text to the component and shifts the description and descriptionDetails accordingly.

## Automation

N/A

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
