### PR TITLE
feat(Keyboard): pre-load keyboards

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.js
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.js
@@ -75,7 +75,7 @@ export default class Keyboard extends Base {
     if (this.centerKeyboard) {
       this.x = (this.style.screenW - this.w) / 2 - this.style.marginX;
     } else {
-      this.x = 0;
+      this.x == null && (this.x = 0); // if x is undefined or null set to 0, otherwise do not overwrite x pos
     }
     !this._keyboardsCreated && this._createKeyboardsFromFormats();
   }

--- a/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.js
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.js
@@ -219,8 +219,8 @@ export default class Keyboard extends Base {
       const nextKeyboardTag = this.tag(nextKeyboard);
 
       this.selectKeyOn(nextKeyboardTag);
-      this._currentKeyboard.setSmooth('alpha', 0.001, { duration: 0.25 });
-      nextKeyboardTag.setSmooth('alpha', 1, { duration: 0.25 });
+      this._currentKeyboard.alpha = 0.001;
+      nextKeyboardTag.alpha = 1;
       this._currentFormat = next;
     }
   }

--- a/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.js
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.js
@@ -77,7 +77,7 @@ export default class Keyboard extends Base {
     } else {
       this.x = 0;
     }
-    this._createKeyboardsFromFormats();
+    !this._keyboardsCreated && this._createKeyboardsFromFormats();
   }
 
   _createKeyboardsFromFormats() {
@@ -86,9 +86,9 @@ export default class Keyboard extends Base {
       if (format) {
         const keyboardData = this._formatKeyboardData(format);
         this._createKeyboard(key, this._createRows(keyboardData, key));
-        this._formatKeys(key);
       }
     });
+    this._keyboardsCreated = true;
   }
 
   _createKeyboard(key, rows = []) {
@@ -188,28 +188,6 @@ export default class Keyboard extends Base {
         return [data];
       }
       return data;
-    }
-  }
-
-  _formatKeys(key) {
-    const element = this.tag(capitalize(key));
-    if (element) {
-      element.patch({
-        style: {
-          itemSpacing: this.style.keySpacing
-        }
-      });
-      element.items.forEach(row => {
-        row.patch({
-          style: {
-            itemSpacing: this.style.keySpacing
-          },
-          centerInParent: this.centerKeys,
-          wrapSelected: this.rowWrap !== undefined ? this.rowWrap : true
-        });
-      });
-      // force Column to recalculate rows from the centerKeyboard toggle
-      element.queueRequestUpdate();
     }
   }
 

--- a/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.mdx
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.mdx
@@ -93,7 +93,7 @@ All of the following examples will yield the same result.
 | name          | type          | required | default   | description                                                                                                                                   |
 | ------------- | ------------- | -------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | columnCount   | number        | false    | 11        | number of columns across the keyboard if passing a flat array                                                                                 |
-| centeKeyboard | bool          | false    | false     | center the keyboard within it's set width (must set the w property of Keyboard)                                                               |
+| centerKeyboard | bool          | false    | false     | center the keyboard within it's set width (must set the w property of Keyboard)                                                               |
 | centerKeys    | bool          | false    | false     | center the keys within it's set width (must set the w property of Keyboard)                                                                   |
 | defaultFormat | string        | true     | undefined | default format of the keyboard to be shown. should be a key of `formats`.                                                                     |
 | formats       | object        | true     | undefined | object containing arrays that represent different formats that the keyboard can be presented in. These arrays can contain strings or objects. |

--- a/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.test.js
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/Keyboard.test.js
@@ -173,7 +173,7 @@ describe('Keyboard', () => {
 
   it('should toggle to a different format', () => {
     keyboard.$toggleKeyboard('symbols');
-    expect(keyboard.tag('Lowercase').alpha).toEqual(0);
+    expect(keyboard.tag('Lowercase').alpha).toEqual(0.001);
     expect(keyboard.tag('Symbols').alpha).toEqual(1);
   });
 
@@ -187,7 +187,7 @@ describe('Keyboard', () => {
     });
     return keyboard._whenEnabled.then(() => {
       keyboard.$toggleKeyboard('num');
-      expect(keyboard.tag('Abc').alpha).toEqual(0);
+      expect(keyboard.tag('Abc').alpha).toEqual(0.001);
       expect(keyboard.tag('Num').alpha).toEqual(1);
     });
   });

--- a/packages/@lightningjs/ui-components/src/components/Keyboard/KeyboardNumbers.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/Keyboard/KeyboardNumbers.stories.js
@@ -60,7 +60,7 @@ KeyboardNumbers.argTypes = {
   defaultFormat: {
     description: 'Select the format of dialpad',
     control: 'radio',
-    options: ['dialpad', 'dialpadExtended'],
+    options: ['dialpad', 'dialpadExtended', 'numbers'],
     table: {
       defaultValue: { summary: 'undefined' }
     }


### PR DESCRIPTION
## Description

<!-- An explanation of the change made by this PR. The more context provided, the easier to review the PR -->

This PR creates and renders a keyboard associated with all formats and does so 1x in the update lifecycle event. All keyboards but the current are rendered yet hidden with a transparent alpha. This allows for toggling between formats to be more snappy since the requested format isn't being created & rendered on press but rather already exists.

- columns with appropriate rows + keys created and rendered for all formats once on `_update`
- all columns except current format have transparent alpha
- for non-centered keyboards, x position no longer gets overwritten and user can control it
- `_formatKeys` removed because no longer needed - keys are formatted on keyboard creation
- theme of keyboard can't be updated on toggle anymore - consensus was that this basically never happened anyway 
- addressed bug where patching new `formats` didn't update the formats

## References

<!-- any relevant tickets(LUI-123 will autolink to the jira ticket) or design links(figma, etc.) -->

[LUI-855](https://ccp.sys.comcast.net/browse/LUI-855)

## Testing

<!-- step by step instructions to review this PR's changes -->

Created a deployment with these keyboard updates for testing: https://carolyn-lng-ephemeral.glitch.me
Test overall performance, load time, load time on format toggle, feel free to test on STB, etc.

Note, deployment uses:
```json
    "@lightning/ui": "^5.33.2",
    "@lightning/ui-extensions": "^1.16.12",
    "@lightningjs/core": "^2.9.0",
    "@lightningjs/sdk": "^5.3.2",
```

## Automation

<!-- are there any changes to be picked up by the automation team? If so, add screenshots, gifs, and/or explanation -->

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
