### PR TITLE
fix(Knob): rename _updateCircleLayout to _updateLayout

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Knob/Knob.js
+++ b/packages/@lightningjs/ui-components/src/components/Knob/Knob.js
@@ -37,10 +37,10 @@ export default class Knob extends Base {
   }
 
   _update() {
-    this._updateCircleLayout();
+    this._updateLayout();
   }
 
-  _updateCircleLayout() {
+  _updateLayout() {
     this.patch({
       texture: lng.Tools.getRoundRect(
         this.w,


### PR DESCRIPTION
## Description

Updates Knob's `_updateCircleLayout` to `_updateLayout` to line up with check used in internal FocusRing extension.

## References

LUI-1573

## Testing

## Checklist

- [X] all commented code has been removed
- [X] any new console issues have been resolved
- [X] code linter and formatter has been run
- [X] test coverage meets repo requirements
- [X] PR name matches the expected semantic-commit syntax
