### PR TITLE
fix(Colors): enable [token, newAlpha] format

### DIFF
--- a/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
+++ b/packages/@lightningjs/ui-components/src/mixins/withThemeStyles/utils.js
@@ -557,19 +557,30 @@ export const colorParser = (targetObject, styleObj) => {
   // Process style object and remove unnecessary properties
   const processedStyle = JSON.stringify(styleObj, (_, value) => {
     if (-1 < ['tone', 'mode'].indexOf(_)) return value; // Remove any tone/mode or mode/tone properties as they have already been processed
-    if ('string' === typeof value && value.startsWith('theme.')) {
-      // Support theme strings example: theme.radius.md
-      return getValFromObjPath(targetObject, value); // If no theme value exists, the property will be removed from the object
-    } else if (
+
+    // Handle theme strings, e.g., 'theme.radius.md'
+    if (typeof value === 'string' && value.startsWith('theme.')) {
+      // Retrieve the value from the target object using the theme path
+      return getValFromObjPath(targetObject, value); // If no theme value exists, the property will be removed
+    }
+
+    function isValidColor(num) {
+      return num >= 0 && num <= 0xffffffff;
+    }
+
+    // Handle color arrays, e.g., ['#663399', 1] or [255, 0.5]
+    if (
       Array.isArray(value) &&
       value.length === 2 &&
-      typeof value[0] === 'string' &&
-      value[0].substr(0, 1) === '#' &&
+      ((typeof value[0] === 'string' && value[0].startsWith('#')) ||
+        (typeof value[0] === 'number' && isValidColor(value[0]))) &&
       typeof value[1] === 'number'
     ) {
-      // Process value as a color ['#663399', 1]
+      // Return processed hex color or the original value if processing fails
       return getHexColor(value[0], value[1]) || value;
     }
+
+    // Return all other values as-is
     return value;
   });
 


### PR DESCRIPTION
## Description

Enables users to set colors using the format `[colorToken, newAlpha]` so that an existing color token can be utilized and just have its alpha value overridden.

This was doable prior to #499, but was only used in a few fringe cases. This PR enables that again while maintaining the functionality added in the previous PR.

## References

LUI-1592

## Testing

Set the `backgroundColor` in Surface.styles.js to be `[theme.color.interactiveNeutral, theme.alpha.alpha1]`. This should no longer cause the component to render in pure white. Change the second value to `theme.alpha.alpha2` and ensure it adjusts accordingly.

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
