### PR TITLE
fix(ScrollWrapper): bubble focus events and remove signals

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.js
+++ b/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.js
@@ -248,7 +248,7 @@ export default class ScrollWrapper extends Base {
         this._updateFadeContainer();
       }
     } else {
-      this.signal('onDownAtBottom');
+      return false;
     }
   }
 
@@ -281,7 +281,7 @@ export default class ScrollWrapper extends Base {
         this._updateFadeContainer();
       }
     } else {
-      this.signal('onUpAtTop');
+      return false;
     }
   }
 

--- a/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.mdx
+++ b/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.mdx
@@ -136,13 +136,3 @@ Resets the `y` value of both the content and the scroll bar.
 #### $scrollChanged('endUp'|'endDown', this)
 
 Event fired via `fireAncestors`, is triggered when scroll reaches the top or bottom of the scroll boundaries.
-
-### Signals
-
-#### onUpAtTop
-
-Fired when user is at the top of the content within the ScrollWrapper and presses up again.
-
-#### onDownAtBottom
-
-Fired when user is at the bottom of the content within the ScrollWrapper and presses down again.

--- a/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.stories.js
@@ -21,6 +21,9 @@ import { default as ScrollWrapperComponent } from '.';
 import Tile from '../Tile';
 import { createModeControl } from '../../docs/utils';
 import TextBox from '../TextBox/TextBox';
+import Column from '../Column';
+import Row from '../Row';
+import Button from '../Button';
 
 const terms = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Id aliquet risus feugiat in ante metus dictum. Pretium fusce id velit ut tortor pretium viverra suspendisse. Pharetra convallis posuere morbi leo urna. Nunc sed velit dignissim sodales. Feugiat scelerisque varius morbi enim nunc faucibus a pellentesque sit. Facilisis gravida neque convallis a cras semper auctor. Pellentesque pulvinar pellentesque habitant morbi tristique. Non tellus orci ac auctor augue mauris. Semper feugiat nibh sed pulvinar proin gravida hendrerit lectus. Amet risus nullam eget felis eget nunc. Auctor urna nunc id cursus metus aliquam eleifend mi in. Integer malesuada nunc vel risus commodo viverra maecenas accumsan lacus. Hac habitasse platea dictumst vestibulum rhoncus est pellentesque elit ullamcorper. Ac felis donec et odio pellentesque. Semper auctor neque vitae tempus quam pellentesque nec nam aliquam. Sit amet risus nullam eget felis eget.
 
@@ -238,3 +241,44 @@ ObjectArray.parameters = {
   storyDetails:
     'The ScrollWrapper content property is set as an array of Lightning elements.'
 };
+
+export const Focus = () =>
+  class Focus extends lng.Component {
+    static _template() {
+      return {
+        Column: {
+          type: Column,
+          x: 100,
+          y: 100,
+          h: 100,
+          w: 100,
+          neverScroll: true,
+          items: [
+            {
+              type: Row,
+              h: 100,
+              neverScroll: true,
+              items: [
+                {
+                  type: Button,
+                  title: 'Button 1'
+                },
+                {
+                  type: Button,
+                  title: 'Button 2'
+                }
+              ]
+            },
+            {
+              type: ScrollWrapperComponent,
+              h: 200,
+              w: 200,
+              showScrollBar: true,
+              content:
+                'this is a test of the scrollwrapper and focus states, swapping focuse between the Buttons in the Row and this text'
+            }
+          ]
+        }
+      };
+    }
+  };

--- a/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.stories.js
+++ b/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.stories.js
@@ -21,9 +21,6 @@ import { default as ScrollWrapperComponent } from '.';
 import Tile from '../Tile';
 import { createModeControl } from '../../docs/utils';
 import TextBox from '../TextBox/TextBox';
-import Column from '../Column';
-import Row from '../Row';
-import Button from '../Button';
 
 const terms = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Id aliquet risus feugiat in ante metus dictum. Pretium fusce id velit ut tortor pretium viverra suspendisse. Pharetra convallis posuere morbi leo urna. Nunc sed velit dignissim sodales. Feugiat scelerisque varius morbi enim nunc faucibus a pellentesque sit. Facilisis gravida neque convallis a cras semper auctor. Pellentesque pulvinar pellentesque habitant morbi tristique. Non tellus orci ac auctor augue mauris. Semper feugiat nibh sed pulvinar proin gravida hendrerit lectus. Amet risus nullam eget felis eget nunc. Auctor urna nunc id cursus metus aliquam eleifend mi in. Integer malesuada nunc vel risus commodo viverra maecenas accumsan lacus. Hac habitasse platea dictumst vestibulum rhoncus est pellentesque elit ullamcorper. Ac felis donec et odio pellentesque. Semper auctor neque vitae tempus quam pellentesque nec nam aliquam. Sit amet risus nullam eget felis eget.
 
@@ -241,44 +238,3 @@ ObjectArray.parameters = {
   storyDetails:
     'The ScrollWrapper content property is set as an array of Lightning elements.'
 };
-
-export const Focus = () =>
-  class Focus extends lng.Component {
-    static _template() {
-      return {
-        Column: {
-          type: Column,
-          x: 100,
-          y: 100,
-          h: 100,
-          w: 100,
-          neverScroll: true,
-          items: [
-            {
-              type: Row,
-              h: 100,
-              neverScroll: true,
-              items: [
-                {
-                  type: Button,
-                  title: 'Button 1'
-                },
-                {
-                  type: Button,
-                  title: 'Button 2'
-                }
-              ]
-            },
-            {
-              type: ScrollWrapperComponent,
-              h: 200,
-              w: 200,
-              showScrollBar: true,
-              content:
-                'this is a test of the scrollwrapper and focus states, swapping focuse between the Buttons in the Row and this text'
-            }
-          ]
-        }
-      };
-    }
-  };

--- a/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.test.js
+++ b/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.test.js
@@ -22,7 +22,6 @@ import {
   completeAnimation
 } from '@lightningjs/ui-components-test-utils';
 import ScrollWrapper from '.';
-import { jest } from '@jest/globals';
 
 const createScrollWrapper = makeCreateComponent(ScrollWrapper, {
   h: 100,

--- a/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.test.js
+++ b/packages/@lightningjs/ui-components/src/components/ScrollWrapper/ScrollWrapper.test.js
@@ -237,42 +237,6 @@ describe('ScrollWrapper', () => {
     expect(scrollWrapper._ScrollContainer.y).toBe(scrollEndY);
   });
 
-  it('should fire a signal when scrolling has reached the end of the scroll container', () => {
-    scrollWrapper.h = scrollWrapper._ScrollContainer.finalH - 1;
-    jest.spyOn(scrollWrapper, 'fireAncestors');
-    expect(scrollWrapper.fireAncestors).not.toHaveBeenCalled();
-
-    testRenderer.keyPress('Down');
-    testRenderer.update();
-
-    expect(scrollWrapper.fireAncestors).toHaveBeenCalledWith(
-      '$scrollChanged',
-      'endDown',
-      scrollWrapper
-    );
-  });
-
-  it('should fire a signal when pressing Up when already at the top of the scroll container', () => {
-    jest.spyOn(scrollWrapper, 'signal');
-    expect(scrollWrapper.signal).not.toHaveBeenCalled();
-
-    testRenderer.keyPress('Up');
-    testRenderer.update();
-    expect(scrollWrapper.signal).toHaveBeenCalledWith('onUpAtTop');
-  });
-
-  it('should fire a signal when pressing Down when already at the bottom of the scroll container', () => {
-    jest.spyOn(scrollWrapper, 'signal');
-    expect(scrollWrapper.signal).not.toHaveBeenCalled();
-
-    // Simulate scrolling to the bottom and then some
-    for (let i = 0; i < 50; i++) {
-      testRenderer.keyPress('Down');
-      testRenderer.update();
-    }
-    expect(scrollWrapper.signal).toHaveBeenCalledWith('onDownAtBottom');
-  });
-
   it('should scroll up by the scroll step', () => {
     scrollWrapper.scrollStep = 100;
     testRenderer.keyPress('Down');


### PR DESCRIPTION
## Description

The "fix" that was introduced in #533 was actually unnecessary. Instead, what was needed was bubbling the focus event up so that the parent component could handle it. This PR removes the signals and adds that bubbling.

(I'll remove the added story after getting approvals before merging this in.)

## References

LUI-1595

## Testing

Test the ScrollWrapper -> Focus story to make sure that you can navigate back up to the Buttons from the ScrollWrapper, but only once you have navigated back to the top of its content.

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
