### PR TITLE
fix: move type export up

### DIFF
--- a/packages/@lightningjs/ui-components-test-utils/package.json
+++ b/packages/@lightningjs/ui-components-test-utils/package.json
@@ -10,9 +10,9 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./index.js",
-      "require": "./index.js",
-      "types": "./index.d.ts"
+      "require": "./index.js"
     }
   },
   "main": "./index.js",

--- a/packages/@lightningjs/ui-components/package.json
+++ b/packages/@lightningjs/ui-components/package.json
@@ -11,9 +11,9 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/lightning-ui-components.d.ts",
       "import": "./dist/lightning-ui-components.min.mjs",
-      "require": "./dist/lightning-ui-components.min.cjs",
-      "types": "./dist/lightning-ui-components.d.ts"
+      "require": "./dist/lightning-ui-components.min.cjs"
     },
     "./src": "./index.js"
   },


### PR DESCRIPTION
## Description

There is a warning displayed when starting Storybook indicating that the `types` being exported will not be used because TypeScript will resolve to using one of the JavaScript exports before it since they technically match:

```
▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    ../../@lightningjs/ui-components/package.json:16:6:
      16 │       "types": "./dist/lightning-ui-components.d.ts"
         ╵       ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    ../../@lightningjs/ui-components/package.json:14:6:
      14 │       "import": "./dist/lightning-ui-components.min.mjs",
         ╵       ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    ../../@lightningjs/ui-components/package.json:15:6:
      15 │       "require": "./dist/lightning-ui-components.min.cjs",
         ╵       ~~~~~~~~~
```

This PR just moves the `types` to the top of the exports in relevant `package.json` files.

## References

N/A

## Testing

Start Storybook and confirm that they above error does not show in your console.

## Checklist

- [x] all commented code has been removed
- [x] any new console issues have been resolved
- [x] code linter and formatter has been run
- [x] test coverage meets repo requirements
- [x] PR name matches the expected semantic-commit syntax
