### PR TITLE
feat: allow surface class radius to be overwritten by parent

### DIFF
--- a/packages/@lightningjs/ui-components/src/components/Surface/Surface.js
+++ b/packages/@lightningjs/ui-components/src/components/Surface/Surface.js
@@ -52,6 +52,10 @@ export default class Surface extends Base {
     return this.w;
   }
 
+  get _radius() {
+    return getMaxRoundRadius(this.style.radius, this.w, this.h);
+  }
+
   _update() {
     this._updateLayout();
     this._updateScale();
@@ -62,7 +66,7 @@ export default class Surface extends Base {
       texture: lng.Tools.getRoundRect(
         this.innerW - 2, // Reference the underscored values here in cause the h or w getters need to be overwritten for alignment - see Tile
         this.innerH - 2,
-        getMaxRoundRadius(this.style.radius, this.w, this.h),
+        this._radius,
         0,
         null,
         true,


### PR DESCRIPTION
This PR allows components extending Surface to override its radius property by implementing a dynamic radius calculation based on component dimensions.

### Implementation
Adds a _radius getter that computes the radius using the component's style and dimensions.

### Testing
Confirmed all components extending Surface work as expected with the new dynamic radius adjustment.